### PR TITLE
Introduce ability to reject/override relative bind mount paths

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -41,7 +41,17 @@ func loadYAMLWithEnv(yaml string, env map[string]string) (*types.Config, error) 
 		return nil, err
 	}
 
-	return Load(buildConfigDetails(dict, env))
+	if home, ok := env["HOME"]; ok {
+		// test overrides $HOME
+		os.Setenv("HOME", home)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	return Load(buildConfigDetails(dict, env), func(options *Options) {
+		options.CheckVolumes = ResolveRelativeBindPath(wd)
+	})
 }
 
 var sampleYAML = `


### PR DESCRIPTION
compose-go is not compliant with https://github.com/docker/compose-spec/blob/master/spec.md#short-syntax-3 as it accept relative paths for bind-mounts.

Proposed changes still make this possible (as demonstrated by test cases) but disabled by default and flexible for extensibility by Compose implementations

