### PR TITLE
Add support for compose version 3.0 as 3.9

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -53,7 +53,7 @@ func normalizeVersion(version string) string {
 	switch version {
 	case "3":
 		return "3.9" // latest
-	case "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8":
+	case "3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8":
 		return "3.9" // pre-existing specification but backward compatible
 	default:
 		return version


### PR DESCRIPTION
Adds support for compose files set to version 3.0, treating them as
version 3.9 the same as other v3.* files.

Signed-off-by: Nick Adcock <nick.adcock@docker.com>