### PR TITLE
Change module to compose-spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/docker/compose-go
+module github.com/compose-spec/compose-go
 
 go 1.12
 


### PR DESCRIPTION
Changes the go module path to github.com/compose-spec/compose-go

Signed-off-by: Nick Adcock <nick.adcock@docker.com>