### PR TITLE
Set test paths to UNIX style on Windows

### DIFF
--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -378,10 +378,10 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 				{Target: "/var/lib/mysql", Type: "volume"},
 				{Source: "/opt/data", Target: "/var/lib/mysql", Type: "bind"},
 				{Source: workingDir, Target: "/code", Type: "bind"},
-				{Source: filepath.Join(workingDir, "static"), Target: "/var/www/html", Type: "bind"},
+				{Source: filepath.ToSlash(filepath.Join(workingDir, "static")), Target: "/var/www/html", Type: "bind"},
 				{Source: homeDir + "/configs", Target: "/etc/configs/", Type: "bind", ReadOnly: true},
 				{Source: "datavolume", Target: "/var/lib/mysql", Type: "volume"},
-				{Source: filepath.Join(workingDir, "opt"), Target: "/opt", Consistency: "cached", Type: "bind"},
+				{Source: filepath.ToSlash(filepath.Join(workingDir, "opt")), Target: "/opt", Consistency: "cached", Type: "bind"},
 				{Target: "/opt", Type: "tmpfs", Tmpfs: &types.ServiceVolumeTmpfs{
 					Size: int64(10000),
 				}},
@@ -472,7 +472,7 @@ func volumes() map[string]types.VolumeConfig {
 func configs(workingDir string) map[string]types.ConfigObjConfig {
 	return map[string]types.ConfigObjConfig{
 		"config1": {
-			File: filepath.Join(workingDir, "config_data"),
+			File: filepath.ToSlash(filepath.Join(workingDir, "config_data")),
 			Labels: map[string]string{
 				"foo": "bar",
 			},
@@ -499,7 +499,7 @@ func configs(workingDir string) map[string]types.ConfigObjConfig {
 func secrets(workingDir string) map[string]types.SecretConfig {
 	return map[string]types.SecretConfig{
 		"secret1": {
-			File: filepath.Join(workingDir, "secret_data"),
+			File: filepath.ToSlash(filepath.Join(workingDir, "secret_data")),
 			Labels: map[string]string{
 				"foo": "bar",
 			},
@@ -1457,6 +1457,6 @@ func fullExampleJSON(workingDir string) string {
 		workingDir,
 		workingDir,
 		workingDir,
-		filepath.Join(workingDir, "static"),
-		filepath.Join(workingDir, "opt"))
+		filepath.ToSlash(filepath.Join(workingDir, "static")),
+		filepath.ToSlash(filepath.Join(workingDir, "opt")))
 }


### PR DESCRIPTION
Sets paths created for tests to using UNIX style forward-slashes even when running on Windows nodes

This is required as the tests do simple string comparisons

Fixes #18 
