### PR TITLE
Introduce ValidatorFn and BlackList implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,5 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	gopkg.in/yaml.v2 v2.2.8
 	gotest.tools/v3 v3.0.2
+	k8s.io/client-go v11.0.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -51,7 +51,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gotest.tools/v3 v3.0.0 h1:d+tVGRu6X0ZBQ+kyAR8JKi6AXhTP2gmQaoIYaGFz634=
-gotest.tools/v3 v3.0.0/go.mod h1:TUP+/YtXl/dp++T+SZ5v2zUmLVBHmptSb/ajDLCJ+3c=
 gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
+k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
+k8s.io/client-go v11.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=

--- a/types/types.go
+++ b/types/types.go
@@ -10,48 +10,6 @@ import (
 	"github.com/docker/go-connections/nat"
 )
 
-// UnsupportedProperties not yet supported by this implementation of the compose file
-var UnsupportedProperties = []string{
-	"build",
-	"cap_add",
-	"cap_drop",
-	"cgroup_parent",
-	"devices",
-	"domainname",
-	"external_links",
-	"ipc",
-	"links",
-	"mac_address",
-	"network_mode",
-	"pid",
-	"privileged",
-	"restart",
-	"security_opt",
-	"shm_size",
-	"ulimits",
-	"userns_mode",
-}
-
-// DeprecatedProperties that were removed from the v3 format, but their
-// use should not impact the behaviour of the application.
-var DeprecatedProperties = map[string]string{
-	"container_name": "Setting the container name is not supported.",
-	"expose":         "Exposing ports is unnecessary - services on the same network can access each other's containers on any port.",
-}
-
-// ForbiddenProperties that are not supported in this implementation of the
-// compose file.
-var ForbiddenProperties = map[string]string{
-	"extends":       "Support for `extends` is not implemented yet.",
-	"volume_driver": "Instead of setting the volume driver on the service, define a volume using the top-level `volumes` option and specify the driver there.",
-	"volumes_from":  "To share a volume between services, define it using the top-level `volumes` option and reference it from each service that shares it using the service-level `volumes` option.",
-	"cpu_quota":     "Set resource limits using deploy.resources",
-	"cpu_shares":    "Set resource limits using deploy.resources",
-	"cpuset":        "Set resource limits using deploy.resources",
-	"mem_limit":     "Set resource limits using deploy.resources",
-	"memswap_limit": "Set resource limits using deploy.resources",
-}
-
 // Duration is a thin wrapper around time.Duration with improved JSON marshalling
 type Duration time.Duration
 


### PR DESCRIPTION
- Remove `UnsupportedProperties` which is swarm-specific
- Introduce a flexible `ValidatorFn` option for implementation to check supported features
- Offer a `Blacklist` helper factory to set ValidatorFn based on a JSONPath blacklist 

