### PR TITLE
Introduce a back-reference from top-level elements to Config

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -121,7 +121,33 @@ func Load(configDetails types.ConfigDetails, options ...func(*Options)) (*types.
 		configs = append(configs, cfg)
 	}
 
-	return merge(configs)
+	project, err := merge(configs)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, s := range project.Services {
+		s.Project = project
+		project.Services[i] = s
+	}
+	for i, v := range project.Volumes {
+		v.Project = project
+		project.Volumes[i] = v
+	}
+	for i, s := range project.Secrets {
+		s.Project = project
+		project.Secrets[i] = s
+	}
+	for i, c := range project.Configs {
+		c.Project = project
+		project.Configs[i] = c
+	}
+	for i, n := range project.Networks {
+		n.Project = project
+		project.Networks[i] = n
+	}
+
+	return project, nil
 }
 
 func validateForbidden(configDict map[string]interface{}) error {

--- a/types/types.go
+++ b/types/types.go
@@ -107,7 +107,8 @@ func (s Services) MarshalJSON() ([]byte, error) {
 
 // ServiceConfig is the configuration of one service
 type ServiceConfig struct {
-	Name string `yaml:"-" json:"-"`
+	Name    string  `yaml:"-" json:"-"`
+	Project *Config `yaml:"-" json:"-"`
 
 	Build           *BuildConfig                     `yaml:",omitempty" json:"build,omitempty"`
 	CapAdd          []string                         `mapstructure:"cap_add" yaml:"cap_add,omitempty" json:"cap_add,omitempty"`
@@ -535,6 +536,7 @@ func (u *UlimitsConfig) MarshalJSON() ([]byte, error) {
 
 // NetworkConfig for a network
 type NetworkConfig struct {
+	Project    *Config                `yaml:"-" json:"-"`
 	Name       string                 `yaml:",omitempty" json:"name,omitempty"`
 	Driver     string                 `yaml:",omitempty" json:"driver,omitempty"`
 	DriverOpts map[string]string      `mapstructure:"driver_opts" yaml:"driver_opts,omitempty" json:"driver_opts,omitempty"`
@@ -559,6 +561,7 @@ type IPAMPool struct {
 
 // VolumeConfig for a volume
 type VolumeConfig struct {
+	Project    *Config                `yaml:"-" json:"-"`
 	Name       string                 `yaml:",omitempty" json:"name,omitempty"`
 	Driver     string                 `yaml:",omitempty" json:"driver,omitempty"`
 	DriverOpts map[string]string      `mapstructure:"driver_opts" yaml:"driver_opts,omitempty" json:"driver_opts,omitempty"`
@@ -600,6 +603,7 @@ type CredentialSpecConfig struct {
 
 // FileObjectConfig is a config type for a file used by a service
 type FileObjectConfig struct {
+	Project        *Config                `yaml:"-" json:"-"`
 	Name           string                 `yaml:",omitempty" json:"name,omitempty"`
 	File           string                 `yaml:",omitempty" json:"file,omitempty"`
 	External       External               `yaml:",omitempty" json:"external,omitempty"`


### PR DESCRIPTION
a Compose implementation using compose-go will need (at least) to retrieve secrets/configs/network by name when it handle service configuration. For this purpose, a reference to the global config is required even when managing a single service, and we end-up passing the config as parameter.

This introduces a back reference to global config "Project" from top-level element to make such processing simpler