### PR TITLE
Fix project name generated after working dir:  take absolute path

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -127,6 +127,10 @@ func ProjectFromOptions(options *ProjectOptions) (*types.Project, error) {
 	if err != nil {
 		return nil, err
 	}
+	absWorkingDir, err := filepath.Abs(workingDir)
+	if err != nil {
+		return nil, err
+	}
 
 	return loader.Load(types.ConfigDetails{
 		ConfigFiles: configs,
@@ -139,7 +143,7 @@ func ProjectFromOptions(options *ProjectOptions) (*types.Project, error) {
 			opts.Name = nameFromEnv
 		} else {
 			opts.Name = regexp.MustCompile(`[^a-z0-9\\-_]+`).
-				ReplaceAllString(strings.ToLower(filepath.Base(workingDir)), "")
+				ReplaceAllString(strings.ToLower(filepath.Base(absWorkingDir)), "")
 		}
 	})
 }

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -32,6 +32,13 @@ func TestProjectName(t *testing.T) {
 	assert.Equal(t, p.Name, "my_project")
 
 	p, err = ProjectFromOptions(&ProjectOptions{
+		WorkingDir:  ".",
+		ConfigPaths: []string{"testdata/simple/compose.yaml"},
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, p.Name, "cli")
+
+	p, err = ProjectFromOptions(&ProjectOptions{
 		ConfigPaths: []string{"testdata/simple/compose.yaml"},
 	})
 	assert.NilError(t, err)


### PR DESCRIPTION
Otherwise we end up with an empty name in case of “.” Working dir