### PR TITLE
Introduce CheckImage

### DIFF
--- a/compatibility/allowlist_test.go
+++ b/compatibility/allowlist_test.go
@@ -29,6 +29,7 @@ func TestAllowList(t *testing.T) {
 	var checker Checker = customChecker{
 		&AllowList{
 			Supported: []string{
+				"services.image",
 				"services.network_mode",
 				"services.privileged",
 				"services.networks",

--- a/compatibility/checker.go
+++ b/compatibility/checker.go
@@ -68,6 +68,7 @@ type Checker interface {
 	CheckHealthCheckInterval(h *types.HealthCheckConfig)
 	CheckHealthCheckRetries(h *types.HealthCheckConfig)
 	CheckHealthCheckStartPeriod(h *types.HealthCheckConfig)
+	CheckImage(service *types.ServiceConfig)
 	CheckInit(service *types.ServiceConfig)
 	CheckIpc(service *types.ServiceConfig)
 	CheckIsolation(service *types.ServiceConfig)
@@ -302,6 +303,7 @@ func CheckServiceConfig(service *types.ServiceConfig, c Checker) {
 		c.CheckHealthCheckTest(service.HealthCheck)
 		c.CheckHealthCheckTimeout(service.HealthCheck)
 	}
+	c.CheckImage(service)
 	c.CheckInit(service)
 	c.CheckIpc(service)
 	c.CheckIsolation(service)

--- a/compatibility/services.go
+++ b/compatibility/services.go
@@ -298,6 +298,13 @@ func (c *AllowList) CheckHealthCheckStartPeriod(h *types.HealthCheckConfig) {
 	}
 }
 
+func (c *AllowList) CheckImage(service *types.ServiceConfig) {
+	if !c.supported("services.image") && service.Image != "" {
+		service.Image = ""
+		c.Unsupported("services.image")
+	}
+}
+
 func (c *AllowList) CheckInit(service *types.ServiceConfig) {
 	if !c.supported("services.init") && service.Init != nil {
 		service.Init = nil


### PR DESCRIPTION
Introduce Compatibility Check method for service.image
this allows compose implementation to override and check service.image in not empty, or a specific registry is in use 