### PR TITLE
support x-* extension in transformed types

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -746,7 +746,7 @@ var transformServicePort TransformerFunc = func(data interface{}) (interface{}, 
 					ports = append(ports, v)
 				}
 			case map[string]interface{}:
-				ports = append(ports, value)
+				ports = append(ports, groupXFieldsIntoExtensions(value))
 			default:
 				return data, errors.Errorf("invalid type %T for port", value)
 			}
@@ -762,7 +762,7 @@ var transformStringSourceMap TransformerFunc = func(data interface{}) (interface
 	case string:
 		return map[string]interface{}{"source": value}, nil
 	case map[string]interface{}:
-		return data, nil
+		return groupXFieldsIntoExtensions(data.(map[string]interface{})), nil
 	default:
 		return data, errors.Errorf("invalid type %T for secret", value)
 	}
@@ -773,7 +773,7 @@ var transformBuildConfig TransformerFunc = func(data interface{}) (interface{}, 
 	case string:
 		return map[string]interface{}{"context": value}, nil
 	case map[string]interface{}:
-		return data, nil
+		return groupXFieldsIntoExtensions(data.(map[string]interface{})), nil
 	default:
 		return data, errors.Errorf("invalid type %T for service build", value)
 	}
@@ -792,7 +792,7 @@ var transformDependsOnConfig TransformerFunc = func(data interface{}) (interface
 		}
 		return transformed, nil
 	case map[string]interface{}:
-		return data, nil
+		return groupXFieldsIntoExtensions(data.(map[string]interface{})), nil
 	default:
 		return data, errors.Errorf("invalid type %T for service depends_on", value)
 	}
@@ -803,7 +803,7 @@ var transformServiceVolumeConfig TransformerFunc = func(data interface{}) (inter
 	case string:
 		return ParseVolume(value)
 	case map[string]interface{}:
-		return data, nil
+		return groupXFieldsIntoExtensions(data.(map[string]interface{})), nil
 	default:
 		return data, errors.Errorf("invalid type %T for service volume", value)
 	}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -548,6 +548,7 @@ services:
       - "34567"
       - target: $theint
         published: $theint
+        x-foo-bar: true
     ulimits:
       nproc: $theint
       nofile:
@@ -637,7 +638,7 @@ networks:
 				Ports: []types.ServicePortConfig{
 					{Target: 555, Mode: "ingress", Protocol: "tcp"},
 					{Target: 34567, Mode: "ingress", Protocol: "tcp"},
-					{Target: 555, Published: 555},
+					{Target: 555, Published: 555, Extensions: map[string]interface{}{"x-foo-bar": true}},
 				},
 				Ulimits: map[string]*types.UlimitsConfig{
 					"nproc":  {Single: 555},


### PR DESCRIPTION
Some types get special handling during the loading process to manage short vs long syntax
when we process so, we need to invoke `groupXFieldsIntoExtensions` to populate the `Extensions` field from all `x-*` elements.