### PR TITLE
Support nested variable expansion

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -26,7 +26,7 @@ import (
 
 var delimiter = "\\$"
 var substitutionNamed = "[_a-z][_a-z0-9]*"
-var substitutionBraced = "[_a-z][_a-z0-9]*(?::?[-?][^}]*)?"
+var substitutionBraced = "[_a-z][_a-z0-9]*(?::?[-?](.*}|[^}]*))?"
 
 var patternString = fmt.Sprintf(
 	"%s(?i:(?P<escaped>%s)|(?P<named>%s)|{(?P<braced>%s)}|(?P<invalid>))",
@@ -34,14 +34,6 @@ var patternString = fmt.Sprintf(
 )
 
 var defaultPattern = regexp.MustCompile(patternString)
-
-// DefaultSubstituteFuncs contains the default SubstituteFunc used by the docker cli
-var DefaultSubstituteFuncs = []SubstituteFunc{
-	softDefault,
-	hardDefault,
-	requiredNonEmpty,
-	required,
-}
 
 // InvalidTemplateError is returned when a variable template is not in a valid
 // format
@@ -67,6 +59,14 @@ type SubstituteFunc func(string, Mapping) (string, bool, error)
 // SubstituteWith substitute variables in the string with their values.
 // It accepts additional substitute function.
 func SubstituteWith(template string, mapping Mapping, pattern *regexp.Regexp, subsFuncs ...SubstituteFunc) (string, error) {
+	if len(subsFuncs) == 0 {
+		subsFuncs = []SubstituteFunc{
+			softDefault,
+			hardDefault,
+			requiredNonEmpty,
+			required,
+		}
+	}
 	var err error
 	result := pattern.ReplaceAllStringFunc(template, func(substring string) string {
 		matches := pattern.FindStringSubmatch(substring)
@@ -116,7 +116,7 @@ func SubstituteWith(template string, mapping Mapping, pattern *regexp.Regexp, su
 
 // Substitute variables in the string with their values
 func Substitute(template string, mapping Mapping) (string, error) {
-	return SubstituteWith(template, mapping, defaultPattern, DefaultSubstituteFuncs...)
+	return SubstituteWith(template, mapping, defaultPattern)
 }
 
 // ExtractVariables returns a map of all the variables defined in the specified
@@ -215,6 +215,10 @@ func softDefault(substitution string, mapping Mapping) (string, bool, error) {
 		return "", false, nil
 	}
 	name, defaultValue := partition(substitution, sep)
+	defaultValue, err := Substitute(defaultValue, mapping)
+	if err != nil {
+		return "", false, err
+	}
 	value, ok := mapping(name)
 	if !ok || value == "" {
 		return defaultValue, true, nil
@@ -229,6 +233,10 @@ func hardDefault(substitution string, mapping Mapping) (string, bool, error) {
 		return "", false, nil
 	}
 	name, defaultValue := partition(substitution, sep)
+	defaultValue, err := Substitute(defaultValue, mapping)
+	if err != nil {
+		return "", false, err
+	}
 	value, ok := mapping(name)
 	if !ok {
 		return defaultValue, true, nil
@@ -249,6 +257,10 @@ func withRequired(substitution string, mapping Mapping, sep string, valid func(s
 		return "", false, nil
 	}
 	name, errorMessage := partition(substitution, sep)
+	errorMessage, err := Substitute(errorMessage, mapping)
+	if err != nil {
+		return "", false, err
+	}
 	value, ok := mapping(name)
 	if !ok || !valid(value) {
 		return "", true, &InvalidTemplateError{


### PR DESCRIPTION
Signed-off-by: MarilynFranklin <marilyn.j.franklin@gmail.com>

This is my first pass at implementing nested variable expansion for consistency with [changes proposed here](https://github.com/docker/compose/pull/7795)

I ran into an `initialization loop` error and ended up removing `DefaultSubstituteFuncs` to fix the issue. I suspect there may be a better way to solve that problem, but I'm pretty new to go!

