### PR TITLE
Ignore double quotes on parsing types.Duration from JSON

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -52,6 +52,16 @@ func (d Duration) MarshalYAML() (interface{}, error) {
 	return d.String(), nil
 }
 
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), "\"")
+	timeDuration, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	*d = Duration(timeDuration)
+	return nil
+}
+
 // Services is a list of ServiceConfig
 type Services []ServiceConfig
 


### PR DESCRIPTION
This is a fix to be integrated in https://github.com/docker/compose-cli/pull/845 for the `Healthcheck Interval`