### PR TITLE
Fix service.GetDependencies

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -178,7 +178,14 @@ func (s ServiceConfig) GetDependencies() []string {
 	for dependency := range s.DependsOn {
 		dependencies.append(dependency)
 	}
-	dependencies.append(s.Links...)
+	for _, link := range s.Links {
+		parts := strings.Split(link, ":")
+		if len(parts) == 2 {
+			dependencies.append(parts[0])
+		} else {
+			dependencies.append(link)
+		}
+	}
 	if strings.HasPrefix(s.NetworkMode, "service:") {
 		dependencies.append(s.NetworkMode[8:])
 	}


### PR DESCRIPTION
A link can be either [SERVICE or SERVICE:ALIAS](https://github.com/compose-spec/compose-spec/blob/master/spec.md#links), only take the service name in the latter case.

Signed-off-by: Djordje Lukic <djordje.lukic@docker.com>