### PR TITLE
Adding compose files passed as cmd options in project struct 

### DIFF
--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -62,6 +63,25 @@ func TestProjectFromSetOfFiles(t *testing.T) {
 	service, err := p.GetService("simple")
 	assert.NilError(t, err)
 	assert.Equal(t, service.Image, "haproxy")
+}
+
+func TestProjectComposefilesFromSetOfFiles(t *testing.T) {
+	opts, err := NewProjectOptions([]string{}, WithWorkingDirectory("testdata/simple/"), WithName("my_project"))
+	assert.NilError(t, err)
+	p, err := ProjectFromOptions(opts)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, p.ComposeFiles, []string{filepath.Join("testdata", "simple", "compose.yaml")})
+}
+
+func TestProjectComposefilesFromWorkingDir(t *testing.T) {
+	opts, err := NewProjectOptions([]string{
+		"testdata/simple/compose.yaml",
+		"testdata/simple/compose-with-overrides.yaml",
+	}, WithName("my_project"))
+	assert.NilError(t, err)
+	p, err := ProjectFromOptions(opts)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, p.ComposeFiles, []string{"testdata/simple/compose.yaml", "testdata/simple/compose-with-overrides.yaml"})
 }
 
 func TestProjectWithDotEnv(t *testing.T) {

--- a/types/project.go
+++ b/types/project.go
@@ -25,14 +25,15 @@ import (
 
 // Project is the result of loading a set of compose files
 type Project struct {
-	Name       string
-	WorkingDir string
-	Services   Services               `json:"services"`
-	Networks   Networks               `yaml:",omitempty" json:"networks,omitempty"`
-	Volumes    Volumes                `yaml:",omitempty" json:"volumes,omitempty"`
-	Secrets    Secrets                `yaml:",omitempty" json:"secrets,omitempty"`
-	Configs    Configs                `yaml:",omitempty" json:"configs,omitempty"`
-	Extensions map[string]interface{} `yaml:",inline" json:"-"`
+	Name         string
+	WorkingDir   string
+	Services     Services               `json:"services"`
+	Networks     Networks               `yaml:",omitempty" json:"networks,omitempty"`
+	Volumes      Volumes                `yaml:",omitempty" json:"volumes,omitempty"`
+	Secrets      Secrets                `yaml:",omitempty" json:"secrets,omitempty"`
+	Configs      Configs                `yaml:",omitempty" json:"configs,omitempty"`
+	Extensions   map[string]interface{} `yaml:",inline" json:"-"`
+	ComposeFiles []string               `yaml:",omitempty" json:"composefiles,omitempty"`
 }
 
 // ServiceNames return names for all services in this Compose config


### PR DESCRIPTION
Used to set runtime labels

Note: docker-compose runtime labels include filenames as specified by users in the command line, or default compose names, not absolute filenames.

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>