### PR TITLE
Fix project named derived from working dir : same as docker-compose

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -177,7 +177,7 @@ func ProjectFromOptions(options *ProjectOptions) (*types.Project, error) {
 		} else if nameFromEnv, ok := os.LookupEnv(ComposeProjectName); ok {
 			opts.Name = nameFromEnv
 		} else {
-			opts.Name = regexp.MustCompile(`[^a-z0-9\\-_]+`).
+			opts.Name = regexp.MustCompile(`[^-_a-z0-9]+`).
 				ReplaceAllString(strings.ToLower(filepath.Base(absWorkingDir)), "")
 		}
 	}

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -110,6 +110,16 @@ func TestProjectWithDiscardEnvFile(t *testing.T) {
 	assert.Assert(t, service.EnvFile == nil)
 }
 
+func TestProjectNameFromWorkingDir(t *testing.T) {
+	opts, err := NewProjectOptions([]string{
+		"testdata/env-file/compose-with-env-file.yaml",
+	})
+	assert.NilError(t, err)
+	p, err := ProjectFromOptions(opts)
+	assert.NilError(t, err)
+	assert.Equal(t, p.Name, "env-file")
+}
+
 func TestEnvMap(t *testing.T) {
 	m := map[string]string{}
 	m["foo"] = "bar"


### PR DESCRIPTION
Keep same transformation as in docker-compose: https://github.com/docker/compose/blob/master/compose/cli/command.py#L176

Esp. Allow “-“ in project name

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>