### PR TITLE
Enable `all` as DeviceRequest.Count value and fix typo

### DIFF
--- a/compatibility/deploy.go
+++ b/compatibility/deploy.go
@@ -198,8 +198,8 @@ func (c *AllowList) CheckDeployResourcesDevicesIDs(s string, r types.DeviceReque
 
 func (c *AllowList) CheckDeployResourcesDevicesDriver(s string, r types.DeviceRequest) {
 	k := fmt.Sprintf("services.deploy.resources.%s.devices.driver", s)
-	if !c.supported(k) && r.Diver != "" {
-		r.Diver = ""
+	if !c.supported(k) && r.Driver != "" {
+		r.Driver = ""
 		c.Unsupported(k)
 	}
 }

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1697,3 +1697,35 @@ func TestLoadWithExtends(t *testing.T) {
 	}
 	assert.Check(t, is.DeepEqual(expServices, actual.Services))
 }
+
+func TestServiceDeviceRequestCount(t *testing.T) {
+	_, err := loadYAML(`
+services:
+  hello-world:
+    image: redis:alpine
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+              count: all
+`)
+	assert.NilError(t, err)
+}
+
+func TestServiceDeviceRequestCountType(t *testing.T) {
+	_, err := loadYAML(`
+services:
+  hello-world:
+    image: redis:alpine
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+              count: somestring
+`)
+	assert.ErrorContains(t, err, "invalid string value for 'count' (the only value allowed is 'all')")
+}

--- a/types/types.go
+++ b/types/types.go
@@ -377,8 +377,8 @@ type Resource struct {
 
 type DeviceRequest struct {
 	Capabilities []string `mapstructure:"capabilities" yaml:"capabilities,omitempty" json:"capabilities,omitempty"`
-	Diver        string   `mapstructure:"driver" yaml:"driver,omitempty" json:"driver,omitempty"`
-	Count        int      `mapstructure:"count" yaml:"count,omitempty" json:"count,omitempty"`
+	Driver       string   `mapstructure:"driver" yaml:"driver,omitempty" json:"driver,omitempty"`
+	Count        int64    `mapstructure:"count" yaml:"count,omitempty" json:"count,omitempty"`
 	IDs          []string `mapstructure:"device_ids" yaml:"device_ids,omitempty" json:"device_ids,omitempty"`
 }
 


### PR DESCRIPTION
Enable `all` as `Count` value and change `Diver`-> `Driver` in DeviceRequest struct.

Closes https://github.com/docker/dev-tooling-team/issues/264

Signed-off-by: aiordache <anca.iordache@docker.com>