### PR TITLE
Allow types.Project to be marshalled and render the initial compose yaml

### DIFF
--- a/types/project.go
+++ b/types/project.go
@@ -25,18 +25,18 @@ import (
 
 // Project is the result of loading a set of compose files
 type Project struct {
-	Name         string
-	WorkingDir   string
+	Name         string                 `yaml:"-" json:"-"`
+	WorkingDir   string                 `yaml:"-" json:"-"`
 	Services     Services               `json:"services"`
 	Networks     Networks               `yaml:",omitempty" json:"networks,omitempty"`
 	Volumes      Volumes                `yaml:",omitempty" json:"volumes,omitempty"`
 	Secrets      Secrets                `yaml:",omitempty" json:"secrets,omitempty"`
 	Configs      Configs                `yaml:",omitempty" json:"configs,omitempty"`
-	Extensions   map[string]interface{} `yaml:",inline" json:"-"`
-	ComposeFiles []string               `yaml:",omitempty" json:"composefiles,omitempty"`
+	Extensions   map[string]interface{} `yaml:",inline" json:"-"` // https://github.com/golang/go/issues/6213
+	ComposeFiles []string               `yaml:"-" json:"-"`
 
 	// DisabledServices track services which have been disable as profile is not active
-	DisabledServices Services
+	DisabledServices Services `yaml:"-" json:"-"`
 }
 
 // ServiceNames return names for all services in this Compose config


### PR DESCRIPTION
Project has many extra fileds which get marshalled into yaml/json by default
By excluding those, we can marshall back a project into yaml as "canonical compose file" after being loaded from multiple files/overrides/env