### PR TITLE
always create a "default" network if not set by user

### DIFF
--- a/loader/normalize.go
+++ b/loader/normalize.go
@@ -27,8 +27,8 @@ import (
 
 // normalize compose project by moving deprecated attributes to their canonical position and injecting implicit defaults
 func normalize(project *types.Project) error {
-	// If none defined, Compose model involves an implicit "default" network
-	if len(project.Networks) == 0 {
+	// If not declared explicitly, Compose model involves an implicit "default" network
+	if _, ok := project.Networks["default"]; !ok {
 		project.Networks["default"] = types.NetworkConfig{}
 	}
 

--- a/loader/normalize_test.go
+++ b/loader/normalize_test.go
@@ -41,6 +41,7 @@ func TestNormalizeNetworkNames(t *testing.T) {
 	expected := types.Project{
 		Name: "myProject",
 		Networks: types.Networks{
+			"default": {Name: "myProject_default"},
 			"myExternalnet": {
 				Name:     "myExternalnet",
 				External: types.External{External: true},


### PR DESCRIPTION
docker-compose creates a "default" network in addition to the declared ones
see https://github.com/docker/compose/blob/2a4aca7f54ca6982b8d3f0c236ce22d7f7e90a08/compose/network.py#L256-L257

This will fix https://github.com/docker/compose-cli/issues/1308