### PR TITLE
resolve COMPOSE_PROJECT_NAME from configured environment sources

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -189,7 +189,7 @@ func ProjectFromOptions(options *ProjectOptions) (*types.Project, error) {
 	var nameLoadOpt = func(opts *loader.Options) {
 		if options.Name != "" {
 			opts.Name = options.Name
-		} else if nameFromEnv, ok := os.LookupEnv(ComposeProjectName); ok {
+		} else if nameFromEnv, ok := options.Environment[ComposeProjectName]; ok {
 			opts.Name = nameFromEnv
 		} else {
 			opts.Name = regexp.MustCompile(`[^-_a-z0-9]+`).

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -50,6 +50,13 @@ func TestProjectName(t *testing.T) {
 	p, err = ProjectFromOptions(opts)
 	assert.NilError(t, err)
 	assert.Equal(t, p.Name, "my_project_from_env")
+
+	opts, err = NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithDotEnv)
+	assert.NilError(t, err)
+	p, err = ProjectFromOptions(opts)
+	assert.NilError(t, err)
+	assert.Equal(t, p.Name, "my_project_from_dot_env")
+
 }
 
 func TestProjectFromSetOfFiles(t *testing.T) {

--- a/cli/testdata/simple/.env
+++ b/cli/testdata/simple/.env
@@ -1,1 +1,2 @@
 PUBLIC_PORT=8000
+COMPOSE_PROJECT_NAME=my_project_from_dot_env


### PR DESCRIPTION
see https://github.com/docker/compose-cli/issues/1430

as sources for environment variable can be set with options (WithDotEnv, WithEnvFile, WithOsEnv) this also must be used to lookup COMPOSE_PROJECT_NAME assigning project name

includes updated test case