### PR TITLE
pid_limit -> pids_limit

### DIFF
--- a/compatibility/checker.go
+++ b/compatibility/checker.go
@@ -89,7 +89,7 @@ type Checker interface {
 	CheckOomKillDisable(service *types.ServiceConfig)
 	CheckOomScoreAdj(service *types.ServiceConfig)
 	CheckPid(service *types.ServiceConfig)
-	CheckPidLimit(service *types.ServiceConfig)
+	CheckPidsLimit(service *types.ServiceConfig)
 	CheckPlatform(service *types.ServiceConfig)
 	CheckPortsMode(p *types.ServicePortConfig)
 	CheckPortsTarget(p *types.ServicePortConfig)
@@ -343,7 +343,7 @@ func CheckServiceConfig(service *types.ServiceConfig, c Checker) {
 	c.CheckOomKillDisable(service)
 	c.CheckOomScoreAdj(service)
 	c.CheckPid(service)
-	c.CheckPidLimit(service)
+	c.CheckPidsLimit(service)
 	c.CheckPlatform(service)
 	if len(service.Ports) > 0 && c.CheckPorts(service) {
 		for i, p := range service.Ports {

--- a/compatibility/services.go
+++ b/compatibility/services.go
@@ -463,10 +463,10 @@ func (c *AllowList) CheckPid(service *types.ServiceConfig) {
 	}
 }
 
-func (c *AllowList) CheckPidLimit(service *types.ServiceConfig) {
-	if !c.supported("services.pid_limit") && service.PidLimit != 0 {
-		service.PidLimit = 0
-		c.Unsupported("services.pid_limit")
+func (c *AllowList) CheckPidsLimit(service *types.ServiceConfig) {
+	if !c.supported("services.pids_limit") && service.PidsLimit != 0 {
+		service.PidsLimit = 0
+		c.Unsupported("services.pids_limit")
 	}
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -144,7 +144,7 @@ type ServiceConfig struct {
 	OomKillDisable  bool                             `mapstructure:"oom_kill_disable" yaml:"oom_kill_disable,omitempty" json:"oom_kill_disable,omitempty"`
 	OomScoreAdj     int64                            `mapstructure:"oom_score_adj" yaml:"oom_score_adj,omitempty" json:"oom_score_adj,omitempty"`
 	Pid             string                           `yaml:",omitempty" json:"pid,omitempty"`
-	PidLimit        int64                            `mapstructure:"pid_limit" yaml:"pid_limit,omitempty" json:"pid_limit,omitempty"`
+	PidsLimit       int64                            `mapstructure:"pids_limit" yaml:"pids_limit,omitempty" json:"pids_limit,omitempty"`
 	Platform        string                           `yaml:",omitempty" json:"platform,omitempty"`
 	Ports           []ServicePortConfig              `yaml:",omitempty" json:"ports,omitempty"`
 	Privileged      bool                             `yaml:",omitempty" json:"privileged,omitempty"`


### PR DESCRIPTION
`pids_limit` is the correct form, added in Docker Compose spec 2.1.

Please see compose-spec/compose-spec#159 https://github.com/compose-spec/compose-spec/pull/160
