### PR TITLE
add blkio_config struct to match compose-spec schema

### DIFF
--- a/compatibility/checker.go
+++ b/compatibility/checker.go
@@ -24,6 +24,12 @@ import (
 type Checker interface {
 	Errors() []error
 	CheckBlkioConfig(build *types.ServiceConfig)
+	CheckBlkioWeight(build *types.BlkioConfig)
+	CheckBlkioWeightDevice(build *types.BlkioConfig)
+	CheckBlkioDeviceReadBps(build *types.BlkioConfig)
+	CheckBlkioDeviceReadIOps(build *types.BlkioConfig)
+	CheckBlkioDeviceWriteBps(build *types.BlkioConfig)
+	CheckBlkioDeviceWriteIOps(build *types.BlkioConfig)
 	CheckBuild(build *types.ServiceConfig) bool
 	CheckBuildArgs(build *types.BuildConfig)
 	CheckBuildLabels(build *types.BuildConfig)

--- a/compatibility/services.go
+++ b/compatibility/services.go
@@ -23,9 +23,51 @@ import (
 )
 
 func (c *AllowList) CheckBlkioConfig(service *types.ServiceConfig) {
-	if !c.supported("services.blkio_config") && service.BlkioConfig != "" {
-		service.BlkioConfig = ""
+	if !c.supported("services.blkio_config") && service.BlkioConfig != nil {
+		service.BlkioConfig = nil
 		c.Unsupported("services.blkio_config")
+	}
+}
+
+func (c *AllowList) CheckBlkioWeight(config *types.BlkioConfig) {
+	if !c.supported("services.blkio_config.weight") && config.Weight != 0 {
+		config.Weight = 0
+		c.Unsupported("services.blkio_config.weight")
+	}
+}
+
+func (c *AllowList) CheckBlkioWeightDevice(config *types.BlkioConfig) {
+	if !c.supported("services.blkio_config.weight_device") && len(config.WeightDevice) != 0 {
+		config.WeightDevice = nil
+		c.Unsupported("services.blkio_config.weight_device")
+	}
+}
+
+func (c *AllowList) CheckBlkioDeviceReadBps(config *types.BlkioConfig) {
+	if !c.supported("services.blkio_config.device_read_bps") && len(config.DeviceWriteBps) != 0 {
+		config.DeviceWriteBps = nil
+		c.Unsupported("services.blkio_config.device_read_bps")
+	}
+}
+
+func (c *AllowList) CheckBlkioDeviceReadIOps(config *types.BlkioConfig) {
+	if !c.supported("services.blkio_config.device_read_iops") && len(config.DeviceReadIOps) != 0 {
+		config.DeviceReadIOps = nil
+		c.Unsupported("services.blkio_config.device_read_iops")
+	}
+}
+
+func (c *AllowList) CheckBlkioDeviceWriteBps(config *types.BlkioConfig) {
+	if !c.supported("services.blkio_config.device_write_bps") && len(config.DeviceWriteBps) != 0 {
+		config.DeviceWriteBps = nil
+		c.Unsupported("services.blkio_config.device_write_bps")
+	}
+}
+
+func (c *AllowList) CheckBlkioDeviceWriteIOps(config *types.BlkioConfig) {
+	if !c.supported("services.blkio_config.device_write_iops") && len(config.DeviceWriteIOps) != 0 {
+		config.DeviceWriteIOps = nil
+		c.Unsupported("services.blkio_config.device_write_iops")
 	}
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -89,7 +89,7 @@ type ServiceConfig struct {
 	Profiles []string `mapstructure:"profiles" yaml:"profiles,omitempty" json:"profiles,omitempty"`
 
 	Build           *BuildConfig                     `yaml:",omitempty" json:"build,omitempty"`
-	BlkioConfig     string                           `yaml:",omitempty" json:"blkio_config,omitempty"`
+	BlkioConfig     *BlkioConfig                     `yaml:",omitempty" json:"blkio_config,omitempty"`
 	CapAdd          []string                         `mapstructure:"cap_add" yaml:"cap_add,omitempty" json:"cap_add,omitempty"`
 	CapDrop         []string                         `mapstructure:"cap_drop" yaml:"cap_drop,omitempty" json:"cap_drop,omitempty"`
 	CgroupParent    string                           `mapstructure:"cgroup_parent" yaml:"cgroup_parent,omitempty" json:"cgroup_parent,omitempty"`
@@ -231,7 +231,6 @@ func (s set) toSlice() []string {
 }
 
 // BuildConfig is a type for build
-// using the same format at libcompose: https://github.com/docker/libcompose/blob/master/yaml/build.go#L12
 type BuildConfig struct {
 	Context    string            `yaml:",omitempty" json:"context,omitempty"`
 	Dockerfile string            `yaml:",omitempty" json:"dockerfile,omitempty"`
@@ -242,6 +241,34 @@ type BuildConfig struct {
 	Isolation  string            `yaml:",omitempty" json:"isolation,omitempty"`
 	Network    string            `yaml:",omitempty" json:"network,omitempty"`
 	Target     string            `yaml:",omitempty" json:"target,omitempty"`
+
+	Extensions map[string]interface{} `yaml:",inline" json:"-"`
+}
+
+// BlkioConfig define blkio config
+type BlkioConfig struct {
+	Weight          uint16           `yaml:",omitempty" json:"weight,omitempty"`
+	WeightDevice    []WeightDevice   `yaml:",omitempty" json:"weight_device,omitempty"`
+	DeviceReadBps   []ThrottleDevice `yaml:",omitempty" json:"device_read_bps,omitempty"`
+	DeviceReadIOps  []ThrottleDevice `yaml:",omitempty" json:"device_read_iops,omitempty"`
+	DeviceWriteBps  []ThrottleDevice `yaml:",omitempty" json:"device_write_bps,omitempty"`
+	DeviceWriteIOps []ThrottleDevice `yaml:",omitempty" json:"device_write_iops,omitempty"`
+
+	Extensions map[string]interface{} `yaml:",inline" json:"-"`
+}
+
+// WeightDevice is a structure that holds device:weight pair
+type WeightDevice struct {
+	Path   string
+	Weight uint16
+
+	Extensions map[string]interface{} `yaml:",inline" json:"-"`
+}
+
+// ThrottleDevice is a structure that holds device:rate_per_second pair
+type ThrottleDevice struct {
+	Path string
+	Rate uint64
 
 	Extensions map[string]interface{} `yaml:",inline" json:"-"`
 }


### PR DESCRIPTION
struct is defined in schema but was mapped to a `string` by legacy docker/cli/compose implementation