### PR TITLE
shm_size can be set as pain int or unitByte notation

### DIFF
--- a/compatibility/services.go
+++ b/compatibility/services.go
@@ -668,8 +668,8 @@ func (c *AllowList) CheckSecurityOpt(service *types.ServiceConfig) {
 }
 
 func (c *AllowList) CheckShmSize(service *types.ServiceConfig) {
-	if !c.supported("services.shm_size") && service.ShmSize != "" {
-		service.ShmSize = ""
+	if !c.supported("services.shm_size") && service.ShmSize != 0 {
+		service.ShmSize = 0
 		c.Unsupported("services.shm_size")
 	}
 }

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -556,6 +556,7 @@ services:
         soft: $theint
     privileged: $thebool
     read_only: $thebool
+    shm_size: 2gb
     stdin_open: ${thebool}
     tty: $thebool
     volumes:
@@ -647,6 +648,7 @@ networks:
 				},
 				Privileged: true,
 				ReadOnly:   true,
+				ShmSize:    types.UnitBytes(2 * 1024 * 1024 * 1024),
 				StdinOpen:  true,
 				Tty:        true,
 				Volumes: []types.ServiceVolumeConfig{

--- a/types/types.go
+++ b/types/types.go
@@ -155,7 +155,7 @@ type ServiceConfig struct {
 	Scale           int                              `yaml:",omitempty" json:"scale,omitempty"`
 	Secrets         []ServiceSecretConfig            `yaml:",omitempty" json:"secrets,omitempty"`
 	SecurityOpt     []string                         `mapstructure:"security_opt" yaml:"security_opt,omitempty" json:"security_opt,omitempty"`
-	ShmSize         string                           `mapstructure:"shm_size" yaml:"shm_size,omitempty" json:"shm_size,omitempty"`
+	ShmSize         UnitBytes                        `mapstructure:"shm_size" yaml:"shm_size,omitempty" json:"shm_size,omitempty"`
 	StdinOpen       bool                             `mapstructure:"stdin_open" yaml:"stdin_open,omitempty" json:"stdin_open,omitempty"`
 	StopGracePeriod *Duration                        `mapstructure:"stop_grace_period" yaml:"stop_grace_period,omitempty" json:"stop_grace_period,omitempty"`
 	StopSignal      string                           `mapstructure:"stop_signal" yaml:"stop_signal,omitempty" json:"stop_signal,omitempty"`


### PR DESCRIPTION
shm_size can be set both as plain int or a string with byte notation

fix https://github.com/docker/compose-cli/issues/1565