### PR TITLE
Normalize absolute paths for working dir & compose files

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -285,6 +285,13 @@ func getConfigPathsFromOptions(options *ProjectOptions) ([]string, error) {
 				logrus.Warnf("Found multiple config files with supported names: %s", strings.Join(candidates, ", "))
 				logrus.Warnf("Using %s", winner)
 			}
+			if !filepath.IsAbs(winner) {
+				fAbs, err := filepath.Abs(winner)
+				if err != nil {
+					return nil, err
+				}
+				winner = fAbs
+			}
 			return []string{winner}, nil
 		}
 		parent := filepath.Dir(pwd)

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -77,7 +77,8 @@ func TestProjectComposefilesFromSetOfFiles(t *testing.T) {
 	assert.NilError(t, err)
 	p, err := ProjectFromOptions(opts)
 	assert.NilError(t, err)
-	assert.DeepEqual(t, p.ComposeFiles, []string{filepath.Join("testdata", "simple", "compose.yaml")})
+	absPath, _ := filepath.Abs(filepath.Join("testdata", "simple", "compose.yaml"))
+	assert.DeepEqual(t, p.ComposeFiles, []string{absPath})
 }
 
 func TestProjectComposefilesFromWorkingDir(t *testing.T) {


### PR DESCRIPTION
These paths will be included in container labels, used to resolve compose files if required in further compose commands on running projects

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>