### PR TITLE
introduce WithDefaultConfigPath and support for overrides

### DIFF
--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -83,7 +83,11 @@ func TestProjectFromSetOfFiles(t *testing.T) {
 }
 
 func TestProjectComposefilesFromSetOfFiles(t *testing.T) {
-	opts, err := NewProjectOptions([]string{}, WithWorkingDirectory("testdata/simple/"), WithName("my_project"))
+	opts, err := NewProjectOptions([]string{},
+		WithWorkingDirectory("testdata/simple/"),
+		WithName("my_project"),
+		WithDefaultConfigPath,
+	)
 	assert.NilError(t, err)
 	p, err := ProjectFromOptions(opts)
 	assert.NilError(t, err)


### PR DESCRIPTION
compose-go used to search for compose.yaml in parent folders, while this is not defined by the spec. Also miss support for override files : https://github.com/docker/compose-cli/issues/1546

With proposed changes, looking for compose.yaml and the sibling override file is an opt-in feature