### PR TITLE
whenever backed by a ShellCommand, service.command must NOT merge WithAppendSlice

### DIFF
--- a/loader/merge.go
+++ b/loader/merge.go
@@ -89,6 +89,9 @@ func mergeServices(base, override []types.ServiceConfig) ([]types.ServiceConfig,
 			if err := mergo.Merge(&baseService, &overrideService, mergo.WithAppendSlice, mergo.WithOverride, mergo.WithTransformers(serviceSpecials)); err != nil {
 				return base, errors.Wrapf(err, "cannot merge service %s", name)
 			}
+			if len(overrideService.Command) > 0 {
+				baseService.Command = overrideService.Command
+			}
 			baseServices[name] = baseService
 			continue
 		}

--- a/loader/merge_test.go
+++ b/loader/merge_test.go
@@ -1147,3 +1147,29 @@ func TestMergeTopLevelExtensions(t *testing.T) {
 		},
 	}, config)
 }
+
+func TestMergeCommands(t *testing.T) {
+	configDetails := types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{
+			{Filename: "base.yml", Config: map[string]interface{}{
+				"services": map[string]interface{}{
+					"foo": map[string]interface{}{
+						"image":   "alpine",
+						"command": "/bin/bash -c \"echo 'hello'\"",
+					},
+				},
+			}},
+			{Filename: "override.yml", Config: map[string]interface{}{
+				"services": map[string]interface{}{
+					"foo": map[string]interface{}{
+						"image":   "alpine",
+						"command": "/bin/ash -c \"echo 'world'\"",
+					},
+				},
+			}},
+		},
+	}
+	merged, err := loadTestProject(configDetails)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, merged.Services[0].Command, types.ShellCommand{"/bin/ash", "-c", "echo 'world'"})
+}


### PR DESCRIPTION
service.Command is implemented as a `type ShellCommand []sring` and so mergo applies `WithAppendSlice` policy, which isn't relevant in this case.

close https://github.com/docker/compose-cli/issues/1601