### PR TITLE
introduce WithConfigFileEnv to get config file paths from environment

### DIFF
--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -60,7 +60,7 @@ func TestProjectName(t *testing.T) {
 	})
 
 	t.Run("by .env", func(t *testing.T) {
-		opts, err := NewProjectOptions(nil, WithWorkingDirectory("testdata/env-file"), WithDotEnv)
+		opts, err := NewProjectOptions(nil, WithWorkingDirectory("testdata/env-file"), WithDotEnv, WithConfigFileEnv)
 		assert.NilError(t, err)
 		p, err := ProjectFromOptions(opts)
 		assert.NilError(t, err)


### PR DESCRIPTION
`WithConfigFileEnv` passed to `NewProjectOptions` will load config file if `COMPOSE_FILE` is set in user's environment.

see https://github.com/docker/compose-cli/issues/1668