### PR TITLE
run interpolation on raw yaml before parsing into map[string]interface{}

### DIFF
--- a/compatibility/allowlist_test.go
+++ b/compatibility/allowlist_test.go
@@ -36,19 +36,18 @@ func TestAllowList(t *testing.T) {
 			},
 		},
 	}
-	dict, err := loader.ParseYAML([]byte(`
+	dict := []byte(`
 services:
   foo:
     image: busybox
     network_mode: host
     privileged: true
     mac_address: "a:b:c:d"
-`))
-	assert.NilError(t, err)
+`)
 
 	project, err := loader.Load(types.ConfigDetails{
 		ConfigFiles: []types.ConfigFile{
-			{Filename: "filename.yml", Config: dict},
+			{Filename: "filename.yml", Content: dict},
 		},
 	})
 	assert.NilError(t, err)

--- a/loader/interpolate.go
+++ b/loader/interpolate.go
@@ -82,7 +82,3 @@ func toBoolean(value string) (interface{}, error) {
 		return nil, errors.Errorf("invalid boolean: %s", value)
 	}
 }
-
-func interpolateConfig(configDict map[string]interface{}, opts interp.Options) (map[string]interface{}, error) {
-	return interp.Interpolate(configDict, opts)
-}

--- a/loader/types_test.go
+++ b/loader/types_test.go
@@ -39,9 +39,7 @@ func TestMarshallConfig(t *testing.T) {
 	assert.Check(t, is.Equal(expected, string(actual)))
 
 	// Make sure the expected still
-	dict, err := ParseYAML([]byte(expected))
-	assert.NilError(t, err)
-	_, err = Load(buildConfigDetails(dict, map[string]string{}), func(options *Options) {
+	_, err = Load(buildConfigDetails(expected, map[string]string{}), func(options *Options) {
 		options.SkipNormalization = true
 		options.SkipConsistencyCheck = true
 	})
@@ -61,9 +59,7 @@ func TestJSONMarshallConfig(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(expected, string(actual)))
 
-	dict, err := ParseYAML([]byte(expected))
-	assert.NilError(t, err)
-	_, err = Load(buildConfigDetails(dict, map[string]string{}), func(options *Options) {
+	_, err = Load(buildConfigDetails(expected, map[string]string{}), func(options *Options) {
 		options.SkipNormalization = true
 		options.SkipConsistencyCheck = true
 	})

--- a/types/config.go
+++ b/types/config.go
@@ -38,8 +38,12 @@ func (cd ConfigDetails) LookupEnv(key string) (string, bool) {
 
 // ConfigFile is a filename and the contents of the file as a Dict
 type ConfigFile struct {
+	// Filename is the name of the yaml configuration file
 	Filename string
-	Config   map[string]interface{}
+	// Content is the raw yaml content. Will be loaded from Filename if not set
+	Content []byte
+	// Config if the yaml tree for this config file. Will be parsed from Content if not set
+	Config map[string]interface{}
 }
 
 // Config is a full compose file configuration and model


### PR DESCRIPTION
This move the interpolation process to take place _before_ parsing the yaml tree into a
`map[string]interface{}`, so that a variable which resolves to a numeric value will corectly be parsed as an `int`, not `string`.

tested with https://github.com/docker/compose-cli/pull/1738

see https://github.com/docker/compose-cli/issues/1725 for context