### PR TITLE
Add restart policy constants

### DIFF
--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -123,7 +123,7 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 					},
 				},
 				RestartPolicy: &types.RestartPolicy{
-					Condition:   "on-failure",
+					Condition:   types.RestartPolicyOnFailure,
 					Delay:       durationPtr(5 * time.Second),
 					MaxAttempts: uint64Ptr(3),
 					Window:      durationPtr(2 * time.Minute),
@@ -357,7 +357,7 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 			},
 			Privileged: true,
 			ReadOnly:   true,
-			Restart:    "always",
+			Restart:    types.RestartPolicyAlways,
 			Secrets: []types.ServiceSecretConfig{
 				{
 					Source: "secret1",

--- a/types/types.go
+++ b/types/types.go
@@ -215,6 +215,17 @@ const (
 )
 
 const (
+	//RestartPolicyAlways always restart the container if it stops
+	RestartPolicyAlways = "always"
+	//RestartPolicyOnFailure restart the container if it exits due to an error
+	RestartPolicyOnFailure = "on-failure"
+	//RestartPolicyNo do not automatically restart the container
+	RestartPolicyNo = "no"
+	//RestartPolicyUnlessStopped always restart the container unless the container is stopped (manually or otherwise)
+	RestartPolicyUnlessStopped = "unless-stopped"
+)
+
+const (
 	// NetworkModeServicePrefix is the prefix for network_mode pointing to a service
 	NetworkModeServicePrefix = "service:"
 	// NetworkModeContainerPrefix is the prefix for network_mode pointing to a container


### PR DESCRIPTION
Signed-off-by: Timo Walter <twalter@walter-se.com>

This PR adds restart policy constants that will eliminate the string literals for the `Restart` values.