### PR TITLE
use GetWorkingDir instead of WorkingDir

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -105,7 +105,10 @@ func WithDefaultConfigPath(o *ProjectOptions) error {
 	if len(o.ConfigPaths) > 0 {
 		return nil
 	}
-	pwd := o.WorkingDir
+	pwd, err := o.GetWorkingDir()
+	if err != nil {
+		return err
+	}
 	for {
 		candidates := findFiles(DefaultFileNames, pwd)
 		if len(candidates) > 0 {


### PR DESCRIPTION
Execution of `docker compose up` in sub dir throws `can't find a suitable configuration file in this directory or any parent`,
even if `docker-compose.yml` is placed in parent dir properly.


If you do not pass cli the option and `o.WorkingDir` is empty, `filepath.Dir(pwd)` returns "." as parent dir.
Fix this by using `o.GetWorkingDir`