### PR TITLE
fix `ports: []` fail to validate schema

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -391,7 +391,7 @@ func convertToStringKeysRecursive(value interface{}, keyPrefix string) (interfac
 		return dict, nil
 	}
 	if list, ok := value.([]interface{}); ok {
-		var convertedList []interface{}
+		convertedList := []interface{}{}
 		for index, entry := range list {
 			newKeyPrefix := fmt.Sprintf("%s[%d]", keyPrefix, index)
 			convertedEntry, err := convertToStringKeysRecursive(entry, newKeyPrefix)

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1743,3 +1743,13 @@ services:
 	assert.NilError(t, err)
 	assert.Equal(t, "always", svc.PullPolicy)
 }
+
+func TestEmptyList(t *testing.T) {
+	_, err := loadYAML(`
+services:
+  test:
+    image: nginx:latest
+    ports: []
+`)
+	assert.NilError(t, err)
+}


### PR DESCRIPTION
`[]` must be converted into an empty list, not `nil` otherwise schema validation fail