### PR TITLE
assume remote context if local path doesn't exists

### DIFF
--- a/loader/normalize_test.go
+++ b/loader/normalize_test.go
@@ -17,6 +17,7 @@
 package loader
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -27,9 +28,10 @@ import (
 )
 
 func TestNormalizeNetworkNames(t *testing.T) {
+	wd, _ := os.Getwd()
 	project := types.Project{
 		Name:       "myProject",
-		WorkingDir: "/some/path",
+		WorkingDir: wd,
 		Environment: map[string]string{
 			"FOO": "BAR",
 		},
@@ -47,7 +49,7 @@ func TestNormalizeNetworkNames(t *testing.T) {
 			{
 				Name: "foo",
 				Build: &types.BuildConfig{
-					Context: "foo",
+					Context: "./testdata",
 					Args: map[string]*string{
 						"FOO": nil,
 						"ZOT": nil,
@@ -57,12 +59,11 @@ func TestNormalizeNetworkNames(t *testing.T) {
 		},
 	}
 
-	absFolder, _ := filepath.Abs("/some/path/foo")
 	expected := strings.ReplaceAll(strings.ReplaceAll(`services:
   foo:
     build:
-      context: /some/path/foo
-      dockerfile: /some/path/foo/Dockerfile
+      context: /some/path/testdata
+      dockerfile: /some/path/testdata/Dockerfile
       args:
         FOO: BAR
         ZOT: null
@@ -78,7 +79,7 @@ networks:
     name: CustomName
   mynet:
     name: myProject_mynet
-`, "/some/path/foo", absFolder), "/", string(filepath.Separator))
+`, "/some/path", wd), "/", string(filepath.Separator))
 	err := normalize(&project)
 	assert.NilError(t, err)
 	marshal, err := yaml.Marshal(project)


### PR DESCRIPTION
fix https://github.com/docker/compose-cli/issues/1854

I wish we could introduce some `IsRemoteContext` func based on a well defined set of requirements for remote context URLs, but according to https://github.com/moby/moby/issues/33686#issuecomment-308748173 there's a large set of de facto hack-ish syntax being supported by `docker build` we'd like to embrace.

So better assume the compose implementation/container runtime will be able to validate path/URL and report adequate error when relevant.