### PR TITLE
force project name to be lowercase

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -297,6 +297,7 @@ func ProjectFromOptions(options *ProjectOptions) (*types.Project, error) {
 			opts.Name = regexp.MustCompile(`[^-_a-z0-9]+`).
 				ReplaceAllString(strings.ToLower(filepath.Base(absWorkingDir)), "")
 		}
+		opts.Name = strings.ToLower(opts.Name)
 	}
 	options.loadOptions = append(options.loadOptions, nameLoadOpt)
 


### PR DESCRIPTION
This force project name to be lowercase.
Required as service image name is inferred by project name, and must be lowercase
see https://github.com/docker/compose/blob/4a51af09d6cdb9407a6717334333900327bc9302/compose/cli/command.py#L197-L198

close https://github.com/docker/compose-cli/issues/1871