### PR TITLE
warn on unset variable

### DIFF
--- a/types/config.go
+++ b/types/config.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
 )
 
 // ConfigDetails are the details about a group of ConfigFiles
@@ -33,6 +34,9 @@ type ConfigDetails struct {
 // LookupEnv provides a lookup function for environment variables
 func (cd ConfigDetails) LookupEnv(key string) (string, bool) {
 	v, ok := cd.Environment[key]
+	if !ok {
+		logrus.Warnf("The %s variable is not set. Defaulting to a blank string.", key)
+	}
 	return v, ok
 }
 


### PR DESCRIPTION
Warn user that compose.yaml includes variable which were not resolved, and an empty string will be used.


close https://github.com/docker/compose-cli/issues/1872