### PR TITLE
drop all comments from yaml file before applying string substitutions

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -480,6 +480,7 @@ services:
 func TestLoadWithEnvironmentInterpolation(t *testing.T) {
 	home := "/home/foo"
 	config, err := loadYAMLWithEnv(`
+# This is a comment, so using variable syntax here ${SHOULD_NOT_BREAK} parsing
 services:
   test:
     image: busybox

--- a/template/template.go
+++ b/template/template.go
@@ -61,7 +61,7 @@ type Mapping func(string) (string, bool)
 // the substitution and an error.
 type SubstituteFunc func(string, Mapping) (string, bool, error)
 
-// SubstituteWith subsitute variables in the string with their values.
+// SubstituteWith substitute variables in the string with their values.
 // It accepts additional substitute function.
 func SubstituteWith(template string, mapping Mapping, pattern *regexp.Regexp, subsFuncs ...SubstituteFunc) (string, error) {
 	var err error


### PR DESCRIPTION
fix https://github.com/docker/compose-cli/issues/1896