### PR TITLE
allow use of plain booleans as environment values

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -456,6 +456,29 @@ services:
 	}
 }
 
+func TestLoadEnvironmentWithBoolean(t *testing.T) {
+	config, err := loadYAML(`
+services:
+  dict-env:
+    image: busybox
+    environment:
+      FOO: true
+      BAR: false
+`)
+	assert.NilError(t, err)
+
+	expected := types.MappingWithEquals{
+		"FOO": strPtr("true"),
+		"BAR": strPtr("false"),
+	}
+
+	assert.Check(t, is.Equal(1, len(config.Services)))
+
+	for _, service := range config.Services {
+		assert.Check(t, is.DeepEqual(expected, service.Environment))
+	}
+}
+
 func TestInvalidEnvironmentValue(t *testing.T) {
 	_, err := loadYAML(`
 services:
@@ -464,7 +487,7 @@ services:
     environment:
       FOO: ["1"]
 `)
-	assert.ErrorContains(t, err, "services.dict-env.environment.FOO must be a string, number or null")
+	assert.ErrorContains(t, err, "services.dict-env.environment.FOO must be a string, number, boolean or null")
 }
 
 func TestInvalidEnvironmentObject(t *testing.T) {

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -769,7 +769,7 @@
           "type": "object",
           "patternProperties": {
             ".+": {
-              "type": ["string", "number", "null"]
+              "type": ["string", "number", "boolean", "null"]
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
see https://github.com/compose-spec/compose-spec/pull/187

Fixes docker/compose-cli#1975