### PR TITLE
[Bug] Reproductive case

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -516,10 +516,14 @@ func loadServiceWithExtends(filename, name string, servicesDict map[string]inter
 			}
 		}
 
+		commandBackup := serviceConfig.Command
 		if err := mergo.Merge(baseService, serviceConfig, mergo.WithAppendSlice, mergo.WithOverride, mergo.WithTransformers(serviceSpecials)); err != nil {
 			return nil, errors.Wrapf(err, "cannot merge service %s", name)
 		}
 		serviceConfig = baseService
+		if len(commandBackup) > 0 {
+			serviceConfig.Command = commandBackup
+		}
 	}
 
 	return serviceConfig, nil

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -290,6 +290,25 @@ services:
 	assert.Check(t, service.Command[0] == "echo")
 }
 
+func TestLoadExtendsOverrideCommand(t *testing.T) {
+	actual, err := loadYAML(`
+services:
+  foo:
+    image: busybox
+    extends:
+      service: bar
+    command: "/bin/ash -c \"rm -rf /tmp/might-not-exist\""
+  bar:
+    image: alpine
+    command: "/bin/ash -c \"echo Oh no...\""`)
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(actual.Services, 2))
+	service, err := actual.GetService("foo")
+	assert.NilError(t, err)
+	assert.Check(t, service.Image == "busybox")
+	assert.DeepEqual(t, service.Command, types.ShellCommand{"/bin/ash", "-c", "rm -rf /tmp/might-not-exist"})
+}
+
 func TestLoadCredentialSpec(t *testing.T) {
 	actual, err := loadYAML(`
 services:


### PR DESCRIPTION
This replicates a bug found by Colleague @MrHuli when using `extends` in a single file; the commands seem to be concatenated, even if this is not the behaviour of docker-compose v1 branch.

Can someone explain to me if this is expected and to the spec, or needs fixing? Test is here. Just figured the reproduction would be more use than an issue (in case it is not an issue).

### Update
I found that merge is not the component responsible (I have a test for loader too locally); I Think given the past issue, it makes sense to me to keep a check in merge too.

I Can contribute the loader case if needed, ~but I think this may actually fix merge.go to not need~ (confirmed merge.go needs its fix too). It simply checks that two commands merge into one if the extending service also defines a command.

This does seem a shame, but I can see a lot of breaking backwards compatibility if people play with `extends`.