### PR TITLE
introduce _merge to merge serviceConfigs

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -32,14 +32,13 @@ import (
 	"github.com/compose-spec/compose-go/schema"
 	"github.com/compose-spec/compose-go/template"
 	"github.com/compose-spec/compose-go/types"
-	units "github.com/docker/go-units"
-	"github.com/imdario/mergo"
-	shellwords "github.com/mattn/go-shellwords"
+	"github.com/docker/go-units"
+	"github.com/mattn/go-shellwords"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/ulyssessouza/godotenv"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // Options supported by Load
@@ -504,10 +503,10 @@ func loadServiceWithExtends(filename, name string, servicesDict map[string]inter
 			}
 		}
 
-		if err := mergo.Merge(baseService, serviceConfig, mergo.WithAppendSlice, mergo.WithOverride, mergo.WithTransformers(serviceSpecials)); err != nil {
-			return nil, errors.Wrapf(err, "cannot merge service %s", name)
+		serviceConfig, err = _merge(baseService, serviceConfig)
+		if err != nil {
+			return nil, err
 		}
-		serviceConfig = baseService
 	}
 
 	return serviceConfig, nil

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -290,6 +290,25 @@ services:
 	assert.Check(t, service.Command[0] == "echo")
 }
 
+func TestLoadExtendsOverrideCommand(t *testing.T) {
+	actual, err := loadYAML(`
+services:
+  foo:
+    image: busybox
+    extends:
+      service: bar
+    command: "/bin/ash -c \"rm -rf /tmp/might-not-exist\""
+  bar:
+    image: alpine
+    command: "/bin/ash -c \"echo Oh no...\""`)
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(actual.Services, 2))
+	service, err := actual.GetService("foo")
+	assert.NilError(t, err)
+	assert.Check(t, service.Image == "busybox")
+	assert.DeepEqual(t, service.Command, types.ShellCommand{"/bin/ash", "-c", "rm -rf /tmp/might-not-exist"})
+}
+
 func TestLoadCredentialSpec(t *testing.T) {
 	actual, err := loadYAML(`
 services:


### PR DESCRIPTION
define a single place to handle service configuration merge, managing corner-cases

see https://github.com/compose-spec/compose-go/pull/163 for context