### PR TITLE
Inherited dot env variables from a fork

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -204,11 +204,22 @@ func WithDotEnv(o *ProjectOptions) error {
 	}
 	defer file.Close()
 
-	env, err := godotenv.Parse(file)
+	notInEnvSet := make(map[string]interface{})
+	env, err := godotenv.ParseWithLookup(file, func(k string) (string, bool) {
+		v, ok := os.LookupEnv(k)
+		if !ok {
+			notInEnvSet[k] = nil
+			return "", true
+		}
+		return v, true
+	})
 	if err != nil {
 		return err
 	}
 	for k, v := range env {
+		if _, ok := notInEnvSet[k]; ok {
+			continue
+		}
 		o.Environment[k] = v
 	}
 	return nil

--- a/cli/options.go
+++ b/cli/options.go
@@ -27,9 +27,9 @@ import (
 	"github.com/compose-spec/compose-go/errdefs"
 	"github.com/compose-spec/compose-go/loader"
 	"github.com/compose-spec/compose-go/types"
-	"github.com/joho/godotenv"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/ulyssessouza/godotenv"
 )
 
 // ProjectOptions groups the command line options recommended for a Compose implementation

--- a/go.mod
+++ b/go.mod
@@ -20,3 +20,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.0.3
 )
+
+replace github.com/joho/godotenv => github.com/ulyssessouza/godotenv v1.3.1-0.20210720203245-d3051d55ab34

--- a/go.mod
+++ b/go.mod
@@ -8,17 +8,15 @@ require (
 	github.com/docker/go-units v0.4.0
 	github.com/google/go-cmp v0.5.5
 	github.com/imdario/mergo v0.3.12
-	github.com/joho/godotenv v1.3.0
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
+	github.com/ulyssessouza/godotenv v1.3.1-0.20210806120901-e417b721114e
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.0.3
 )
-
-replace github.com/joho/godotenv => github.com/ulyssessouza/godotenv v1.3.1-0.20210720203245-d3051d55ab34

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,6 @@ github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
-github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
-github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
@@ -108,6 +106,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/ulyssessouza/godotenv v1.3.1-0.20210720203245-d3051d55ab34 h1:IkbbgnOv8QHXW+RZ+TPiCvNUh2uY086KUmToRBUmWek=
+github.com/ulyssessouza/godotenv v1.3.1-0.20210720203245-d3051d55ab34/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/ulyssessouza/godotenv v1.3.1-0.20210720203245-d3051d55ab34 h1:IkbbgnOv8QHXW+RZ+TPiCvNUh2uY086KUmToRBUmWek=
-github.com/ulyssessouza/godotenv v1.3.1-0.20210720203245-d3051d55ab34/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/ulyssessouza/godotenv v1.3.1-0.20210806120901-e417b721114e h1:byEYm3QADv5mDUesYKstWwRodf2RoxxC/YuGOxtdqJw=
+github.com/ulyssessouza/godotenv v1.3.1-0.20210806120901-e417b721114e/go.mod h1:9JN/BuU6Agy5aHyEoA5EIPkBsYbk0+2R42zJgYi/SlI=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -33,11 +33,11 @@ import (
 	"github.com/compose-spec/compose-go/types"
 	units "github.com/docker/go-units"
 	"github.com/imdario/mergo"
-	"github.com/joho/godotenv"
 	shellwords "github.com/mattn/go-shellwords"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/ulyssessouza/godotenv"
 	yaml "gopkg.in/yaml.v2"
 )
 


### PR DESCRIPTION
This fork is necessary until the feature of  `godotenv.ParseWithLookup` is merged (with this [PR](https://github.com/joho/godotenv/pull/149) or any similar) so that empty variables can be Looked up from the environment