### PR TITLE
Fix project name regexp

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -314,7 +314,7 @@ func ProjectFromOptions(options *ProjectOptions) (*types.Project, error) {
 		} else if nameFromEnv, ok := options.Environment[ComposeProjectName]; ok && nameFromEnv != "" {
 			opts.Name = nameFromEnv
 		} else {
-			opts.Name = regexp.MustCompile(`(?m)[a-z]+[-_a-z0-9]*[a-z0-9]+`).FindString(strings.ToLower(filepath.Base(absWorkingDir)))
+			opts.Name = regexp.MustCompile(`(?m)[a-z]+[-_a-z0-9]*`).FindString(strings.ToLower(filepath.Base(absWorkingDir)))
 		}
 		opts.Name = strings.ToLower(opts.Name)
 	}


### PR DESCRIPTION
This fixes the regexp on the case of a single character project name. 
Resolves https://github.com/docker/compose-cli/issues/2052