### PR TITLE
allow services to use `x-...` as names

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -261,7 +261,7 @@ func loadSections(filename string, config map[string]interface{}, configDetails 
 		return nil, err
 	}
 
-	cfg.Networks, err = LoadNetworks(getSection(config, "networks"), configDetails.Version)
+	cfg.Networks, err = LoadNetworks(getSection(config, "networks"))
 	if err != nil {
 		return nil, err
 	}
@@ -425,6 +425,14 @@ func formatInvalidKeyError(keyPrefix string, key interface{}) error {
 // the servicesDict is not validated if directly used. Use Load() to enable validation
 func LoadServices(filename string, servicesDict map[string]interface{}, workingDir string, lookupEnv template.Mapping, opts *Options) ([]types.ServiceConfig, error) {
 	var services []types.ServiceConfig
+
+	x, ok := servicesDict["extensions"]
+	if ok {
+		// as a top-level attribute, "services" doesn't support extensions, and a service can be named `x-foo`
+		for k, v := range x.(map[string]interface{}) {
+			servicesDict[k] = v
+		}
+	}
 
 	for name := range servicesDict {
 		serviceConfig, err := loadServiceWithExtends(filename, name, servicesDict, workingDir, lookupEnv, opts, &cycleTracker{})
@@ -620,7 +628,7 @@ func transformUlimits(data interface{}) (interface{}, error) {
 
 // LoadNetworks produces a NetworkConfig map from a compose file Dict
 // the source Dict is not validated if directly used. Use Load() to enable validation
-func LoadNetworks(source map[string]interface{}, version string) (map[string]types.NetworkConfig, error) {
+func LoadNetworks(source map[string]interface{}) (map[string]types.NetworkConfig, error) {
 	networks := make(map[string]types.NetworkConfig)
 	err := Transform(source, &networks)
 	if err != nil {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1362,7 +1362,7 @@ func TestLoadNetworksWarnOnDeprecatedExternalNameVersion35(t *testing.T) {
 			},
 		},
 	}
-	networks, err := LoadNetworks(source, "3.5")
+	networks, err := LoadNetworks(source)
 	assert.NilError(t, err)
 	expected := map[string]types.NetworkConfig{
 		"foo": {
@@ -1386,7 +1386,7 @@ func TestLoadNetworksWarnOnDeprecatedExternalName(t *testing.T) {
 			},
 		},
 	}
-	networks, err := LoadNetworks(source, "3.4")
+	networks, err := LoadNetworks(source)
 	assert.NilError(t, err)
 	expected := map[string]types.NetworkConfig{
 		"foo": {


### PR DESCRIPTION
x-* is reserved by the compose specification for model extension, but we don't expect any extension within the top-level `services` element, and should allow users to define services with name `x-foo`

close https://github.com/docker/compose-cli/issues/2050