### PR TITLE
add support for `*` as a hack to enable all profiles

### DIFF
--- a/types/project.go
+++ b/types/project.go
@@ -228,6 +228,11 @@ func (s Services) GetProfiles() []string {
 
 // ApplyProfiles disables service which don't match selected profiles
 func (p *Project) ApplyProfiles(profiles []string) {
+	for _, p := range profiles {
+		if p == "*" {
+			return
+		}
+	}
 	var enabled, disabled Services
 	for _, service := range p.Services {
 		if service.HasProfile(profiles) {


### PR DESCRIPTION
Allows to enable all profiles declared in a compose file using special profile `*`

To be used as `docker compose --profile '*' ... `

#fixes https://github.com/docker/compose-cli/issues/1964