### PR TITLE
don't resolve `FOO=`, value is empty string

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -446,26 +446,29 @@ services:
     environment:
       FOO: "1"
       BAR: 2
-      BAZ: 2.5
-      QUX:
-      QUUX:
+      GA: 2.5
+      BU: ""
+      ZO:
+      MEU:
   list-env:
     image: busybox
     environment:
       - FOO=1
       - BAR=2
-      - BAZ=2.5
-      - QUX=
-      - QUUX
-`, map[string]string{"QUX": "qux"})
+      - GA=2.5
+      - BU=
+      - ZO
+      - MEU
+`, map[string]string{"MEU": "Shadoks"})
 	assert.NilError(t, err)
 
 	expected := types.MappingWithEquals{
-		"FOO":  strPtr("1"),
-		"BAR":  strPtr("2"),
-		"BAZ":  strPtr("2.5"),
-		"QUX":  strPtr("qux"),
-		"QUUX": nil,
+		"FOO": strPtr("1"),
+		"BAR": strPtr("2"),
+		"GA":  strPtr("2.5"),
+		"BU":  strPtr(""),
+		"ZO":  nil,
+		"MEU": strPtr("Shadoks"),
 	}
 
 	assert.Check(t, is.Equal(2, len(config.Services)))

--- a/types/types.go
+++ b/types/types.go
@@ -352,7 +352,7 @@ func (e MappingWithEquals) OverrideBy(other MappingWithEquals) MappingWithEquals
 // Resolve update a MappingWithEquals for keys without value (`key`, but not `key=`)
 func (e MappingWithEquals) Resolve(lookupFn func(string) (string, bool)) MappingWithEquals {
 	for k, v := range e {
-		if v == nil || *v == "" {
+		if v == nil {
 			if value, ok := lookupFn(k); ok {
 				e[k] = &value
 			}


### PR DESCRIPTION
variable set as `FOO=` should not be resolved based on project environment, but set to empty string


This is a fix https://github.com/docker/compose-cli/issues/1989