### PR TITLE
include IPC,PID,Volumes_From in dependencies detection

### DIFF
--- a/loader/validate.go
+++ b/loader/validate.go
@@ -38,15 +38,15 @@ func checkConsistency(project *types.Project) error {
 			}
 		}
 
-		if strings.HasPrefix(s.NetworkMode, types.NetworkModeServicePrefix) {
-			serviceName := s.NetworkMode[len(types.NetworkModeServicePrefix):]
+		if strings.HasPrefix(s.NetworkMode, types.ServicePrefix) {
+			serviceName := s.NetworkMode[len(types.ServicePrefix):]
 			if _, err := project.GetServices(serviceName); err != nil {
 				return fmt.Errorf("service %q not found for network_mode 'service:%s'", serviceName, serviceName)
 			}
 		}
 
-		if strings.HasPrefix(s.NetworkMode, types.NetworkModeContainerPrefix) {
-			containerName := s.NetworkMode[len(types.NetworkModeContainerPrefix):]
+		if strings.HasPrefix(s.NetworkMode, types.ContainerPrefix) {
+			containerName := s.NetworkMode[len(types.ContainerPrefix):]
 			if _, err := project.GetByContainerName(containerName); err != nil {
 				return fmt.Errorf("service with container_name %q not found for network_mode 'container:%s'", containerName, containerName)
 			}

--- a/types/types.go
+++ b/types/types.go
@@ -226,10 +226,17 @@ const (
 )
 
 const (
+	// ServicePrefix is the prefix for references pointing to a service
+	ServicePrefix = "service:"
+	// ContainerPrefix is the prefix for references pointing to a container
+	ContainerPrefix = "container:"
+
 	// NetworkModeServicePrefix is the prefix for network_mode pointing to a service
-	NetworkModeServicePrefix = "service:"
+	// Deprecated prefer ServicePrefix
+	NetworkModeServicePrefix = ServicePrefix
 	// NetworkModeContainerPrefix is the prefix for network_mode pointing to a container
-	NetworkModeContainerPrefix = "container:"
+	// Deprecated prefer ContainerPrefix
+	NetworkModeContainerPrefix = ContainerPrefix
 )
 
 // GetDependencies retrieve all services this service depends on
@@ -246,9 +253,21 @@ func (s ServiceConfig) GetDependencies() []string {
 			dependencies.append(link)
 		}
 	}
-	if strings.HasPrefix(s.NetworkMode, NetworkModeServicePrefix) {
-		dependencies.append(s.NetworkMode[len(NetworkModeServicePrefix):])
+	if strings.HasPrefix(s.NetworkMode, ServicePrefix) {
+		dependencies.append(s.NetworkMode[len(ServicePrefix):])
 	}
+	if strings.HasPrefix(s.Ipc, ServicePrefix) {
+		dependencies.append(s.Ipc[len(ServicePrefix):])
+	}
+	if strings.HasPrefix(s.Pid, ServicePrefix) {
+		dependencies.append(s.Pid[len(ServicePrefix):])
+	}
+	for _, vol := range s.VolumesFrom {
+		if !strings.HasPrefix(s.Pid, ContainerPrefix) {
+			dependencies.append(vol)
+		}
+	}
+
 	return dependencies.toSlice()
 }
 


### PR DESCRIPTION
GetDependencies doesn't consider depencies to services by `ipc: service:xx`, `pid: service:xx`, or `volumes_from: [xx]`, 

required (but also need a fix in compose.v2) for https://github.com/docker/compose-cli/issues/2035