### PR TITLE
introduce WithResolvedPaths to let client code opt for relative or abs

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -240,6 +240,16 @@ func WithInterpolation(interpolation bool) ProjectOptionsFn {
 	}
 }
 
+// WithResolvedPaths set ProjectOptions to enable paths resolution
+func WithResolvedPaths(resolve bool) ProjectOptionsFn {
+	return func(o *ProjectOptions) error {
+		o.loadOptions = append(o.loadOptions, func(options *loader.Options) {
+			options.ResolvePaths = resolve
+		})
+		return nil
+	}
+}
+
 // DefaultFileNames defines the Compose file names for auto-discovery (in order of preference)
 var DefaultFileNames = []string{"compose.yaml", "compose.yml", "docker-compose.yml", "docker-compose.yaml"}
 

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -55,6 +55,7 @@ func loadYAMLWithEnv(yaml string, env map[string]string) (*types.Project, error)
 	return Load(buildConfigDetails(yaml, env), func(options *Options) {
 		options.SkipConsistencyCheck = true
 		options.SkipNormalization = true
+		options.ResolvePaths = true
 	})
 }
 
@@ -1339,7 +1340,7 @@ func TestLoadSecretsWarnOnDeprecatedExternalNameVersion35(t *testing.T) {
 		},
 	}
 	details := types.ConfigDetails{}
-	secrets, err := LoadSecrets(source, details)
+	secrets, err := LoadSecrets(source, details, true)
 	assert.NilError(t, err)
 	expected := map[string]types.SecretConfig{
 		"foo": {

--- a/loader/normalize.go
+++ b/loader/normalize.go
@@ -28,7 +28,7 @@ import (
 )
 
 // normalize compose project by moving deprecated attributes to their canonical position and injecting implicit defaults
-func normalize(project *types.Project) error {
+func normalize(project *types.Project, resolvePaths bool) error {
 	absWorkingDir, err := filepath.Abs(project.WorkingDir)
 	if err != nil {
 		return err
@@ -72,8 +72,10 @@ func normalize(project *types.Project) error {
 			}
 			localContext := absPath(project.WorkingDir, s.Build.Context)
 			if _, err := os.Stat(localContext); err == nil {
-				s.Build.Context = localContext
-				s.Build.Dockerfile = absPath(localContext, s.Build.Dockerfile)
+				if resolvePaths {
+					s.Build.Context = localContext
+					s.Build.Dockerfile = absPath(localContext, s.Build.Dockerfile)
+				}
 			} else {
 				// might be a remote http/git context. Unfortunately supported "remote" syntax is highly ambiguous
 				// in moby/moby and not defined by compose-spec, so let's assume runtime will check

--- a/loader/normalize_test.go
+++ b/loader/normalize_test.go
@@ -19,7 +19,6 @@ package loader
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/compose-spec/compose-go/types"
@@ -59,11 +58,11 @@ func TestNormalizeNetworkNames(t *testing.T) {
 		},
 	}
 
-	expected := strings.ReplaceAll(strings.ReplaceAll(`services:
+	expected := `services:
   foo:
     build:
-      context: /some/path/testdata
-      dockerfile: /some/path/testdata/Dockerfile
+      context: ./testdata
+      dockerfile: Dockerfile
       args:
         FOO: BAR
         ZOT: null
@@ -79,8 +78,8 @@ networks:
     name: CustomName
   mynet:
     name: myProject_mynet
-`, "/some/path", wd), "/", string(filepath.Separator))
-	err := normalize(&project)
+`
+	err := normalize(&project, false)
 	assert.NilError(t, err)
 	marshal, err := yaml.Marshal(project)
 	assert.NilError(t, err)
@@ -104,7 +103,7 @@ func TestNormalizeAbsolutePaths(t *testing.T) {
 		WorkingDir:   absWorkingDir,
 		ComposeFiles: []string{absComposeFile, absOverrideFile},
 	}
-	err := normalize(&project)
+	err := normalize(&project, false)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, expected, project)
 }
@@ -142,7 +141,7 @@ func TestNormalizeVolumes(t *testing.T) {
 		WorkingDir:   absCwd,
 		ComposeFiles: []string{},
 	}
-	err := normalize(&project)
+	err := normalize(&project, false)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, expected, project)
 }


### PR DESCRIPTION
Add a load option to let client code decide if paths should be resolved (absolute) or kept relative.
This addresses https://github.com/docker/compose/issues/8503