### PR TITLE
fix merging ports

### DIFF
--- a/loader/merge.go
+++ b/loader/merge.go
@@ -147,12 +147,21 @@ func toServicePortConfigsMap(s interface{}) (map[interface{}]interface{}, error)
 		return nil, errors.Errorf("not a servicePortConfig slice: %v", s)
 	}
 	m := map[interface{}]interface{}{}
+	type port struct {
+		target    uint32
+		published uint32
+		ip        string
+		protocol  string
+	}
+
 	for _, p := range ports {
-		k := p.Published
-		if k == 0 {
-			k = p.Target
+		mergeKey := port{
+			target:    p.Target,
+			published: p.Published,
+			ip:        p.HostIP,
+			protocol:  p.Protocol,
 		}
-		m[k] = p
+		m[mergeKey] = p
 	}
 	return m, nil
 }

--- a/loader/merge_test.go
+++ b/loader/merge_test.go
@@ -286,23 +286,29 @@ func TestLoadMultipleServicePorts(t *testing.T) {
 			},
 		},
 		{
-			name: "override_same_published",
+			name: "override_distinct_protocols",
 			portBase: map[string]interface{}{
 				"ports": []interface{}{
-					"8080:80",
+					"8080:80/tcp",
 				},
 			},
 			portOverride: map[string]interface{}{
 				"ports": []interface{}{
-					"8080:81",
+					"8080:80/udp",
 				},
 			},
 			expected: []types.ServicePortConfig{
 				{
 					Mode:      "ingress",
 					Published: 8080,
-					Target:    81,
+					Target:    80,
 					Protocol:  "tcp",
+				},
+				{
+					Mode:      "ingress",
+					Published: 8080,
+					Target:    80,
+					Protocol:  "udp",
 				},
 			},
 		},
@@ -947,6 +953,12 @@ func TestLoadMultipleConfigs(t *testing.T) {
 					},
 				},
 				Ports: []types.ServicePortConfig{
+					{
+						Mode:      "ingress",
+						Target:    80,
+						Published: 8080,
+						Protocol:  "tcp",
+					},
 					{
 						Target:    81,
 						Published: 8080,


### PR DESCRIPTION
fix port merge logic: align with docker-compose to use composite key `(target,publish,ip,protocol)` 
see https://github.com/docker/compose/blob/c81046aac0ce1360f1bab64368f9a318c593d82a/compose/config/types.py#L419

close https://github.com/docker/compose/issues/8557
close https://github.com/docker/compose/issues/8586