### PR TITLE
allow override by empty command

### DIFF
--- a/loader/merge.go
+++ b/loader/merge.go
@@ -108,10 +108,10 @@ func _merge(baseService *types.ServiceConfig, overrideService *types.ServiceConf
 	if err := mergo.Merge(baseService, overrideService, mergo.WithAppendSlice, mergo.WithOverride, mergo.WithTransformers(serviceSpecials)); err != nil {
 		return nil, err
 	}
-	if len(overrideService.Command) > 0 {
+	if overrideService.Command != nil {
 		baseService.Command = overrideService.Command
 	}
-	if len(overrideService.Entrypoint) > 0 {
+	if overrideService.Entrypoint != nil {
 		baseService.Entrypoint = overrideService.Entrypoint
 	}
 	return baseService, nil

--- a/loader/merge_test.go
+++ b/loader/merge_test.go
@@ -869,7 +869,9 @@ func TestLoadMultipleConfigs(t *testing.T) {
 	base := map[string]interface{}{
 		"services": map[string]interface{}{
 			"foo": map[string]interface{}{
-				"image": "foo",
+				"image":      "foo",
+				"entrypoint": "echo",
+				"command":    "hellow world",
 				"build": map[string]interface{}{
 					"context":    ".",
 					"dockerfile": "bar.Dockerfile",
@@ -894,7 +896,9 @@ func TestLoadMultipleConfigs(t *testing.T) {
 	override := map[string]interface{}{
 		"services": map[string]interface{}{
 			"foo": map[string]interface{}{
-				"image": "baz",
+				"image":      "baz",
+				"entrypoint": "ping",
+				"command":    "localhost",
 				"build": map[string]interface{}{
 					"dockerfile": "foo.Dockerfile",
 					"args": []interface{}{
@@ -942,8 +946,10 @@ func TestLoadMultipleConfigs(t *testing.T) {
 				Environment: types.MappingWithEquals{},
 			},
 			{
-				Name:  "foo",
-				Image: "baz",
+				Name:       "foo",
+				Image:      "baz",
+				Entrypoint: types.ShellCommand{"ping"},
+				Command:    types.ShellCommand{"localhost"},
 				Build: &types.BuildConfig{
 					Context:    ".",
 					Dockerfile: "foo.Dockerfile",


### PR DESCRIPTION
`command` and `entrypoint` can be defined as blank string, as "unset shell command".
This still should apply as a valid override while merging compose files

close https://github.com/docker/compose/issues/8536