### PR TITLE
transformSize accept UnitBytes created by interpolation

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -1005,10 +1005,13 @@ var transformSize TransformerFunc = func(value interface{}) (interface{}, error)
 	switch value := value.(type) {
 	case int:
 		return int64(value), nil
+	case int64, types.UnitBytes:
+		return value, nil
 	case string:
 		return units.RAMInBytes(value)
+	default:
+		return value, errors.Errorf("invalid type for size %T", value)
 	}
-	panic(errors.Errorf("invalid type for size %T", value))
 }
 
 var transformStringToDuration TransformerFunc = func(value interface{}) (interface{}, error) {


### PR DESCRIPTION
interpolation produces the expected `UnitBytes` type for shm_size and comparable fields
this PR updates `transformSize` so it is a no-op when type is already correct

close https://github.com/docker/compose/issues/8613