### PR TITLE
weekly release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Weekly Release
+
+on:
+  schedule:
+    - cron:  '12 0 * * WED'
+
+        
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%s')"
+      - name: Get weekly release number
+        id: weekly
+        run: echo "::set-output name=weekly::$(expr ${{ steps.date.outputs.date }} / 86400 / 7 - 2697)"
+      - uses: ncipollo/release-action@v1
+        with:
+          tag: v1.${{ steps.weekly.outputs.weekly }}.0
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automated weekly release workflow every Wednesday as `v1.{{week count}}.0` (jenkins-style)

example run on https://github.com/ndeloof/compose-go/releases/tag/v1.0.0
close https://github.com/compose-spec/compose-go/issues/118

(I would update workflow before merge so we get an initial release)