### PR TITLE
unbraced variable must not apply advanced substitutions

### DIFF
--- a/template/template_test.go
+++ b/template/template_test.go
@@ -64,6 +64,13 @@ func TestInvalid(t *testing.T) {
 	}
 }
 
+// see https://github.com/docker/compose/issues/8601
+func TestNonBraced(t *testing.T) {
+	substituted, err := Substitute("$FOO-bar", defaultMapping)
+	assert.NilError(t, err)
+	assert.Equal(t, substituted, "first-bar")
+}
+
 func TestNoValueNoDefault(t *testing.T) {
 	for _, template := range []string{"This ${missing} var", "This ${BAR} var"} {
 		result, err := Substitute(template, defaultMapping)


### PR DESCRIPTION
close https://github.com/docker/compose/issues/8601

aligns with https://github.com/docker/compose/blob/2011bc3cea1c78eccd0fa75d01a6b638d6bfb7c2/compose/config/interpolation.py#L96-L98