### PR TITLE
types: add support for enable_ipv6

### DIFF
--- a/loader/interpolate.go
+++ b/loader/interpolate.go
@@ -71,6 +71,7 @@ var interpolateTypeCastMapping = map[interp.Path]interp.Cast{
 	iPath("networks", interp.PathMatchAll, "external"):               toBoolean,
 	iPath("networks", interp.PathMatchAll, "internal"):               toBoolean,
 	iPath("networks", interp.PathMatchAll, "attachable"):             toBoolean,
+	iPath("networks", interp.PathMatchAll, "enable_ipv6"):            toBoolean,
 	iPath("volumes", interp.PathMatchAll, "external"):                toBoolean,
 	iPath("secrets", interp.PathMatchAll, "external"):                toBoolean,
 	iPath("configs", interp.PathMatchAll, "external"):                toBoolean,

--- a/types/types.go
+++ b/types/types.go
@@ -748,6 +748,7 @@ type NetworkConfig struct {
 	Internal   bool                   `yaml:",omitempty" json:"internal,omitempty"`
 	Attachable bool                   `yaml:",omitempty" json:"attachable,omitempty"`
 	Labels     Labels                 `yaml:",omitempty" json:"labels,omitempty"`
+	EnableIPv6 bool                   `mapstructure:"enable_ipv6" yaml:"enable_ipv6,omitempty" json:"enable_ipv6,omitempty"`
 	Extensions map[string]interface{} `yaml:",inline" json:"-"`
 }
 


### PR DESCRIPTION
The enable_ipv6 property specified in the network spec was missing
from the NetworkConfig struct.  Because of this ommission, users of
this library had no visibility into this setting.  In particular,
this prevented the docker-compose v2 application from creating a
Network object in docker with an appropriate setting for the
EnableIPv6 option.

This change parses the "enable_ipv6" property into the NetworkConfig
struct and makes it available in the EnableIPv6 field for any
downstream library users to use.

Signed-off-by: Stacey Sheldon <stac@es.net>