### PR TITLE
don't truncate project name computed by parent folder name with dots

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -333,7 +333,7 @@ func ProjectFromOptions(options *ProjectOptions) (*types.Project, error) {
 		} else if nameFromEnv, ok := options.Environment[ComposeProjectName]; ok && nameFromEnv != "" {
 			opts.Name = nameFromEnv
 		} else {
-			opts.Name = filepath.Base(absWorkingDir)
+			opts.Name = strings.ToLower(filepath.Base(absWorkingDir))
 		}
 		opts.Name = normalizeName(opts.Name)
 	}

--- a/cli/options.go
+++ b/cli/options.go
@@ -333,7 +333,7 @@ func ProjectFromOptions(options *ProjectOptions) (*types.Project, error) {
 		} else if nameFromEnv, ok := options.Environment[ComposeProjectName]; ok && nameFromEnv != "" {
 			opts.Name = nameFromEnv
 		} else {
-			opts.Name = strings.ToLower(filepath.Base(absWorkingDir))
+			opts.Name = filepath.Base(absWorkingDir)
 		}
 		opts.Name = normalizeName(opts.Name)
 	}
@@ -354,6 +354,7 @@ func ProjectFromOptions(options *ProjectOptions) (*types.Project, error) {
 
 func normalizeName(s string) string {
 	r := regexp.MustCompile("[a-z0-9_-]")
+	s = strings.ToLower(s)
 	s = strings.Join(r.FindAllString(s, -1), "")
 	return strings.TrimLeft(s, "_-")
 }

--- a/cli/options.go
+++ b/cli/options.go
@@ -335,7 +335,7 @@ func ProjectFromOptions(options *ProjectOptions) (*types.Project, error) {
 		} else {
 			opts.Name = filepath.Base(absWorkingDir)
 		}
-		opts.Name = regexp.MustCompile(`(?m)[a-z0-9]+[-_a-z0-9]*`).FindString(strings.ToLower(opts.Name))
+		opts.Name = normalizeName(opts.Name)
 	}
 	options.loadOptions = append(options.loadOptions, nameLoadOpt)
 
@@ -350,6 +350,12 @@ func ProjectFromOptions(options *ProjectOptions) (*types.Project, error) {
 
 	project.ComposeFiles = configPaths
 	return project, nil
+}
+
+func normalizeName(s string) string {
+	r := regexp.MustCompile("[a-z0-9_-]")
+	s = strings.Join(r.FindAllString(s, -1), "")
+	return strings.TrimLeft(s, "_-")
 }
 
 // getConfigPathsFromOptions retrieves the config files for project based on project options

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -82,6 +82,14 @@ func TestProjectName(t *testing.T) {
 		assert.Equal(t, p.Name, "my_project")
 	})
 
+	t.Run("by name contains dots", func(t *testing.T) {
+		opts, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithName("www.my.project"))
+		assert.NilError(t, err)
+		p, err := ProjectFromOptions(opts)
+		assert.NilError(t, err)
+		assert.Equal(t, p.Name, "wwwmyproject")
+	})
+
 	t.Run("by working dir", func(t *testing.T) {
 		opts, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithWorkingDirectory("."))
 		assert.NilError(t, err)

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -90,6 +90,14 @@ func TestProjectName(t *testing.T) {
 		assert.Equal(t, p.Name, "wwwmyproject")
 	})
 
+	t.Run("by name uppercase", func(t *testing.T) {
+		opts, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithName("MY_PROJECT"))
+		assert.NilError(t, err)
+		p, err := ProjectFromOptions(opts)
+		assert.NilError(t, err)
+		assert.Equal(t, p.Name, "my_project")
+	})
+
 	t.Run("by working dir", func(t *testing.T) {
 		opts, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithWorkingDirectory("."))
 		assert.NilError(t, err)


### PR DESCRIPTION
when project name includes some unsupported characters (like `my.project`) we must ignore them, not truncate the computed project name => `myproject`

fix https://github.com/docker/compose/issues/8822

Also introduce a dedicated `normalizeName` func to manage project name computation, vs regexp which tends to become complex to maintain :P 