### PR TITLE
 Fixing variable substitution when using compose v2.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/compose-spec/compose-go
 go 1.16
 
 require (
-	github.com/compose-spec/godotenv v1.0.0
+	github.com/compose-spec/godotenv v0.0.0-20211026074040-865524795bdc
 	github.com/distribution/distribution/v3 v3.0.0-20210316161203-a01c71e2477e
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0
@@ -20,5 +20,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.0.3
 )
-
-replace github.com/compose-spec/godotenv => github.com/tbocek/godotenv v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -20,3 +20,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.0.3
 )
+
+replace github.com/compose-spec/godotenv => github.com/tbocek/godotenv v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/compose-spec/compose-go
 go 1.16
 
 require (
-	github.com/compose-spec/godotenv v0.0.0-20211026074040-865524795bdc
+	github.com/compose-spec/godotenv v1.1.0
 	github.com/distribution/distribution/v3 v3.0.0-20210316161203-a01c71e2477e
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/tbocek/godotenv v1.0.1 h1:En2OK+IozmQcJHEeAa1szAkOYzyoXg4jeyh1G93v4vA=
+github.com/tbocek/godotenv v1.0.1/go.mod h1:zF/3BOa18Z24tts5qnO/E9YURQanJTBUf7nlcCTNsyc=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bshuster-repo/logrus-logstash-hook v1.0.0/go.mod h1:zsTqEiSzDgAa/8GZR
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/compose-spec/godotenv v0.0.0-20211026074040-865524795bdc h1:YoaQYdCyZoo6c20kMLKR69KGX9P4JY1EMP3xOZhM5cA=
-github.com/compose-spec/godotenv v0.0.0-20211026074040-865524795bdc/go.mod h1:zF/3BOa18Z24tts5qnO/E9YURQanJTBUf7nlcCTNsyc=
+github.com/compose-spec/godotenv v1.1.0 h1:wzShe5P6L/Aw3wsV357eWlZdMcPaOe2V2+3+qGwMEL4=
+github.com/compose-spec/godotenv v1.1.0/go.mod h1:zF/3BOa18Z24tts5qnO/E9YURQanJTBUf7nlcCTNsyc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/bshuster-repo/logrus-logstash-hook v1.0.0/go.mod h1:zsTqEiSzDgAa/8GZR
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/compose-spec/godotenv v1.0.0 h1:TV24JYhh5GCC1G14npQVhCtxeoiwd0NcT0VdwcCQyXU=
-github.com/compose-spec/godotenv v1.0.0/go.mod h1:zF/3BOa18Z24tts5qnO/E9YURQanJTBUf7nlcCTNsyc=
+github.com/compose-spec/godotenv v0.0.0-20211026074040-865524795bdc h1:YoaQYdCyZoo6c20kMLKR69KGX9P4JY1EMP3xOZhM5cA=
+github.com/compose-spec/godotenv v0.0.0-20211026074040-865524795bdc/go.mod h1:zF/3BOa18Z24tts5qnO/E9YURQanJTBUf7nlcCTNsyc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -108,8 +108,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/tbocek/godotenv v1.0.1 h1:En2OK+IozmQcJHEeAa1szAkOYzyoXg4jeyh1G93v4vA=
-github.com/tbocek/godotenv v1.0.1/go.mod h1:zF/3BOa18Z24tts5qnO/E9YURQanJTBUf7nlcCTNsyc=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -559,13 +559,9 @@ func resolveEnvironment(serviceConfig *types.ServiceConfig, workingDir string, l
 				return err
 			}
 			defer file.Close()
-			//TODO:  template.Mapping from this library and LookupFn from the godotenv library
-			//have the same function signature. Is this the proper way to cast it?
-			var cast godotenv.LookupFn
-			cast = func(s string) (string, bool) {
+			fileVars, err := godotenv.ParseWithLookup(file, func(s string) (string, bool) {
 				return lookupEnv(s)
-			}
-			fileVars, err := godotenv.ParseWithLookup(file, cast)
+			})
 			if err != nil {
 				return err
 			}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -559,7 +559,13 @@ func resolveEnvironment(serviceConfig *types.ServiceConfig, workingDir string, l
 				return err
 			}
 			defer file.Close()
-			fileVars, err := godotenv.Parse(file)
+			//TODO:  template.Mapping from this library and LookupFn from the godotenv library
+			//have the same function signature. Is this the proper way to cast it?
+			var cast godotenv.LookupFn
+			cast = func(s string) (string, bool) {
+				return lookupEnv(s)
+			}
+			fileVars, err := godotenv.ParseWithLookup(file, cast)
 			if err != nil {
 				return err
 			}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -559,9 +559,7 @@ func resolveEnvironment(serviceConfig *types.ServiceConfig, workingDir string, l
 				return err
 			}
 			defer file.Close()
-			fileVars, err := godotenv.ParseWithLookup(file, func(s string) (string, bool) {
-				return lookupEnv(s)
-			})
+			fileVars, err := godotenv.ParseWithLookup(file, godotenv.LookupFn(lookupEnv))
 			if err != nil {
 				return err
 			}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1811,3 +1811,24 @@ services:
 `)
 	assert.NilError(t, err)
 }
+
+func TestLoadService(t *testing.T) {
+	file, err := os.CreateTemp(os.TempDir(), "test-compose-go")
+	assert.NilError(t, err)
+	defer os.Remove(file.Name())
+
+	_, err = file.Write([]byte("HALLO=$TEST"))
+	assert.NilError(t, err)
+
+	m := map[string]interface{}{
+		"env_file": file.Name(),
+	}
+	s, err := LoadService("Test Name", m, ".", func(s string) (string, bool) {
+		if s == "TEST" {
+			return "YES", true
+		}
+		return "NO", false
+	}, true)
+	assert.NilError(t, err)
+	assert.Equal(t, "YES", *s.Environment["HALLO"])
+}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1813,7 +1813,7 @@ services:
 }
 
 func TestLoadService(t *testing.T) {
-	file, err := os.CreateTemp(os.TempDir(), "test-compose-go")
+	file, err := os.CreateTemp("", "test-compose-go")
 	assert.NilError(t, err)
 	defer os.Remove(file.Name())
 
@@ -1824,10 +1824,8 @@ func TestLoadService(t *testing.T) {
 		"env_file": file.Name(),
 	}
 	s, err := LoadService("Test Name", m, ".", func(s string) (string, bool) {
-		if s == "TEST" {
-			return "YES", true
-		}
-		return "NO", false
+		assert.Equal(t, "TEST", s)
+		return "YES", true
 	}, true)
 	assert.NilError(t, err)
 	assert.Equal(t, "YES", *s.Environment["HALLO"])


### PR DESCRIPTION
This fixes https://github.com/docker/compose/issues/8798, variable substitution not working. In godotenv, there seems to be an empty envMap, which should be in my opinion the lookup function, then checks the environment variables. Also to trigger this env lookup, compose-go has to call godotenv.ParseWithLookup. See also https://github.com/compose-spec/godotenv/pull/9