### PR TITLE
Fixed a typo in GroupAdd type mapping

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -121,7 +121,7 @@ type ServiceConfig struct {
 	Extends         ExtendsConfig                    `yaml:"extends,omitempty" json:"extends,omitempty"`
 	ExternalLinks   []string                         `mapstructure:"external_links" yaml:"external_links,omitempty" json:"external_links,omitempty"`
 	ExtraHosts      HostsList                        `mapstructure:"extra_hosts" yaml:"extra_hosts,omitempty" json:"extra_hosts,omitempty"`
-	GroupAdd        []string                         `mapstructure:"group_app" yaml:"group_add,omitempty" json:"group_add,omitempty"`
+	GroupAdd        []string                         `mapstructure:"group_add" yaml:"group_add,omitempty" json:"group_add,omitempty"`
 	Hostname        string                           `yaml:",omitempty" json:"hostname,omitempty"`
 	HealthCheck     *HealthCheckConfig               `yaml:",omitempty" json:"healthcheck,omitempty"`
 	Image           string                           `yaml:",omitempty" json:"image,omitempty"`


### PR DESCRIPTION
Found an issue that GroupAdd was not working with docker compose v2. This typo fix should restore "group_add" parameter to docker compose again.

Fixes https://github.com/docker/compose/issues/8810

Signed-off-by: William Axhav Bratt <william@axhav.se>