### PR TITLE
introduce WithNormalization to give loader the ability to skip normalization

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -249,6 +249,16 @@ func WithInterpolation(interpolation bool) ProjectOptionsFn {
 	}
 }
 
+// WithNormalization set ProjectOptions to enable/skip normalization
+func WithNormalization(normalization bool) ProjectOptionsFn {
+	return func(o *ProjectOptions) error {
+		o.loadOptions = append(o.loadOptions, func(options *loader.Options) {
+			options.SkipNormalization = !normalization
+		})
+		return nil
+	}
+}
+
 // WithResolvedPaths set ProjectOptions to enable paths resolution
 func WithResolvedPaths(resolve bool) ProjectOptionsFn {
 	return func(o *ProjectOptions) error {


### PR DESCRIPTION
With this option, compose implementation can load compose project and skip normalization, typically to implement a comparable feature as `docker-compose config` to render the parsed compose yaml but apply minimal changes