### PR TITLE
introduce CustomLabels

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -129,6 +129,7 @@ type ServiceConfig struct {
 	Ipc             string                           `yaml:",omitempty" json:"ipc,omitempty"`
 	Isolation       string                           `mapstructure:"isolation" yaml:"isolation,omitempty" json:"isolation,omitempty"`
 	Labels          Labels                           `yaml:",omitempty" json:"labels,omitempty"`
+	CustomLabels    Labels                           `yaml:"-" json:"-"`
 	Links           []string                         `yaml:",omitempty" json:"links,omitempty"`
 	Logging         *LoggingConfig                   `yaml:",omitempty" json:"logging,omitempty"`
 	LogDriver       string                           `mapstructure:"log_driver" yaml:"log_driver,omitempty" json:"log_driver,omitempty"`


### PR DESCRIPTION
introduce ServiceConfig#CustomLabels to be used by compose implementation to store metadata that are **not** to be serialized as part of the compose canonical configuration.

Compose V2 can then use such labels to set `com.docker.compose.*` labels but get those excluded from the marshaled configuration or service hash. see https://github.com/docker/compose/pull/8960

see https://github.com/docker/compose/issues/8725