### PR TITLE
Added support for volume bind option SELinux :z :Z

### DIFF
--- a/loader/volume_test.go
+++ b/loader/volume_test.go
@@ -112,6 +112,38 @@ func TestParseVolumeWithBindOptions(t *testing.T) {
 	assert.Check(t, is.DeepEqual(expected, volume))
 }
 
+func TestParseVolumeWithBindOptionsSELinuxShared(t *testing.T) {
+	volume, err := ParseVolume("/source:/target:ro,z")
+	expected := types.ServiceVolumeConfig{
+		Type:     "bind",
+		Source:   "/source",
+		Target:   "/target",
+		ReadOnly: true,
+		Bind: &types.ServiceVolumeBind{
+			CreateHostPath: true,
+			SELinux:        "z",
+		},
+	}
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(expected, volume))
+}
+
+func TestParseVolumeWithBindOptionsSELinuxPrivate(t *testing.T) {
+	volume, err := ParseVolume("/source:/target:ro,Z")
+	expected := types.ServiceVolumeConfig{
+		Type:     "bind",
+		Source:   "/source",
+		Target:   "/target",
+		ReadOnly: true,
+		Bind: &types.ServiceVolumeBind{
+			CreateHostPath: true,
+			SELinux:        "Z",
+		},
+	}
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(expected, volume))
+}
+
 func TestParseVolumeWithBindOptionsWindows(t *testing.T) {
 	volume, err := ParseVolume("C:\\source\\foo:D:\\target:ro,rprivate")
 	expected := types.ServiceVolumeConfig{

--- a/types/types.go
+++ b/types/types.go
@@ -660,11 +660,20 @@ const (
 
 // ServiceVolumeBind are options for a service volume of type bind
 type ServiceVolumeBind struct {
+	SELinux        string `yaml:",omitempty" json:"selinux,omitempty"`
 	Propagation    string `yaml:",omitempty" json:"propagation,omitempty"`
 	CreateHostPath bool   `mapstructure:"create_host_path" yaml:"create_host_path,omitempty" json:"create_host_path,omitempty"`
 
 	Extensions map[string]interface{} `yaml:",inline" json:"-"`
 }
+
+// SELinux represents the SELinux re-labeling options.
+const (
+	// SELinuxShared option indicates that the bind mount content is shared among multiple containers
+	SELinuxShared string = "z"
+	// SELinuxPrivate option indicates that the bind mount content is private and unshared
+	SELinuxPrivate string = "Z"
+)
 
 // Propagation represents the propagation of a mount.
 const (


### PR DESCRIPTION
The docker-compose CLI v2 uses the docker/compose-go package for
parsing Docker Compose YAML specification files and currently it misses
support for the SELinux relabeling with `:z` or `:Z`.

It is a regression compared to docker-compose CLI v1.

This feature allow to use the SELinux field to set the `:z` or `:Z`
bind option for relabeling SELinux label.

It fixes #214

References:
- https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label

Signed-off-by: Tymoteusz Blazejczyk <tymoteusz.blazejczyk@tymonx.com>