### PR TITLE
Do not set undefined inherited variables

### DIFF
--- a/dotenv/godotenv_test.go
+++ b/dotenv/godotenv_test.go
@@ -575,8 +575,8 @@ func TestInheritedEnvVariablSingleVar(t *testing.T) {
 
 func TestInheritedEnvVariableNotFound(t *testing.T) {
 	envMap, err := Read("fixtures/inherited-not-found.env")
-	if envMap["VARIABLE_NOT_FOUND"] != "" || err != nil {
-		t.Errorf("Expected 'VARIABLE_NOT_FOUND' to be '' with no errors")
+	if _, ok := envMap["VARIABLE_NOT_FOUND"]; ok || err != nil {
+		t.Errorf("Expected 'VARIABLE_NOT_FOUND' to be undefined with no errors")
 	}
 }
 
@@ -589,8 +589,8 @@ func TestInheritedEnvVariableNotFoundWithLookup(t *testing.T) {
 		}
 		return envVar, ok
 	}, "fixtures/inherited-not-found.env")
-	if envMap["VARIABLE_NOT_FOUND"] != "" || err != nil {
-		t.Errorf("Expected 'VARIABLE_NOT_FOUND' to be '' with no errors")
+	if _, ok := envMap["VARIABLE_NOT_FOUND"]; ok || err != nil {
+		t.Errorf("Expected 'VARIABLE_NOT_FOUND' to be undefined with no errors")
 	}
 	_, ok := notFoundMap["VARIABLE_NOT_FOUND"]
 	if !ok {

--- a/dotenv/parser.go
+++ b/dotenv/parser.go
@@ -41,9 +41,9 @@ func parseBytes(src []byte, out map[string]string, lookupFn LookupFn) error {
 			value, ok := lookupFn(key)
 			if ok {
 				out[key] = value
-				cutset = left
-				continue
 			}
+			cutset = left
+			continue
 		}
 
 		value, left, err := extractVarValue(left, out, lookupFn)


### PR DESCRIPTION
Prior to Docker-Compose v2, inherited variables that were undefined on the host would not be defined in the container. This returns the original behavior.

This resolves https://github.com/docker/compose/issues/9031