### PR TITLE
Fix inherited env var not found in multi-var .env

### DIFF
--- a/dotenv/fixtures/inherited-not-found-multi-var.env
+++ b/dotenv/fixtures/inherited-not-found-multi-var.env
@@ -1,0 +1,3 @@
+FOO=bar
+VARIABLE_NOT_FOUND
+BAR=baz

--- a/dotenv/godotenv_test.go
+++ b/dotenv/godotenv_test.go
@@ -598,6 +598,65 @@ func TestInheritedEnvVariableNotFoundWithLookup(t *testing.T) {
 	}
 }
 
+func TestInheritedEnvVariableNotFoundMultiVar(t *testing.T) {
+	envMap, err := Read("fixtures/inherited-not-found-multi-var.env")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v, present := envMap["VARIABLE_NOT_FOUND"]; present {
+		t.Errorf("Expected 'VARIABLE_NOT_FOUND' to not exist, but got %q", v)
+	}
+
+	expectedValues := map[string]string{
+		"FOO": "bar",
+		"BAR": "baz",
+	}
+	if len(envMap) != len(expectedValues) {
+		t.Errorf("Expected the size of envMap to be %d, but was %d", len(expectedValues), len(envMap))
+	}
+	for key, value := range expectedValues {
+		if envMap[key] != value {
+			t.Errorf("Read got one of the keys wrong, [%q]->%q", key, envMap[key])
+		}
+	}
+}
+
+func TestInheritedEnvVariableNotFoundMultiVarWithLookup(t *testing.T) {
+	notFoundMap := make(map[string]bool)
+	envMap, err := ReadWithLookup(func(v string) (string, bool) {
+		envVar, ok := os.LookupEnv(v)
+		if !ok {
+			notFoundMap[v] = true
+		}
+		return envVar, ok
+	}, "fixtures/inherited-not-found-multi-var.env")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !notFoundMap["VARIABLE_NOT_FOUND"] {
+		t.Error("Expected 'VARIABLE_NOT_FOUND' to be part of not found variables")
+	}
+	if v, present := envMap["VARIABLE_NOT_FOUND"]; present {
+		t.Errorf("Expected 'VARIABLE_NOT_FOUND' to not exist, but got %q", v)
+	}
+
+	expectedValues := map[string]string{
+		"FOO": "bar",
+		"BAR": "baz",
+	}
+	if len(envMap) != len(expectedValues) {
+		t.Errorf("Expected the size of envMap to be %d, but was %d", len(expectedValues), len(envMap))
+	}
+	for key, value := range expectedValues {
+		if envMap[key] != value {
+			t.Errorf("Read got one of the keys wrong, [%q]->%q", key, envMap[key])
+		}
+	}
+}
+
 func TestExpendingEnvironmentWithLookup(t *testing.T) {
 	rawEnvLine := "TEST=$ME"
 	expectedValue := "YES"

--- a/dotenv/parser.go
+++ b/dotenv/parser.go
@@ -41,9 +41,9 @@ func parseBytes(src []byte, out map[string]string, lookupFn LookupFn) error {
 			value, ok := lookupFn(key)
 			if ok {
 				out[key] = value
-				cutset = left
-				continue
 			}
+			cutset = left
+			continue
 		}
 
 		value, left, err := extractVarValue(left, out, lookupFn)


### PR DESCRIPTION
The package `dotenv` implements inherited environment variables which allows variables to be set on the host and passed to a container using key-only pairs in a `.env` file. Package `compose-go` uses this feature by calling the function `ParseWithLookup` of `dotenv`.

One expectation of this feature is that an environment variable will not be passed to the container if the host does not set it. This scenario is tested in `dotenv`. However, there is an issue if a `.env` file contains multiple key pairs resulting of environment variables not being set properly in the container.

This PR fixes this issue.

## Demonstration

Define a `.env` file with the following:

```
ENV_A
ENV_B=
ENV_C=env_c
```

And a docker-compose.yml file:

```yml
services:
  alpine:
    image: alpine
    env_file: .env
```

### Docker

```bash
$ docker run --rm --env-file=.env alpine env
ENV_B=
ENV_C=env_c
```

Here `ENV_A` has not been set and `ENV_B` is set with an empty value.

### Docker-Compose (V1)

```bash
$ docker-compose run --rm alpine env
ENV_B=
ENV_C=env_c
```

With Docker-Compose (V1), we get the same outcome as Docker

### Compose (v2)

```bash
$ docker compose run --rm alpine env
ENV_C=env_c
ENV_A=ENV_B=
```

Here's where the outcome is quite unexpected: `ENV_A` is set with the value `ENV_B=`.

Compose seems to have a problem with key-only items in `.env` file.