### PR TITLE
Add light loading on project

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -240,6 +240,16 @@ func WithDotEnv(o *ProjectOptions) error {
 	return nil
 }
 
+// WithFullProjectLoading set ProjectOptions to enable/skip interpolation
+func WithFullProjectLoading(projectLoading bool) ProjectOptionsFn {
+	return func(o *ProjectOptions) error {
+		o.loadOptions = append(o.loadOptions, func(options *loader.Options) {
+			options.SkipFullProjectLoading = !projectLoading
+		})
+		return nil
+	}
+}
+
 // WithInterpolation set ProjectOptions to enable/skip interpolation
 func WithInterpolation(interpolation bool) ProjectOptionsFn {
 	return func(o *ProjectOptions) error {


### PR DESCRIPTION
The idea of this PR is just to have a simple load of the project that just gets the service list including just the names to serve the completions. 
That's quite hacky, but replicating or changing the flow seemed worse than that.
Given that it's inside an `if` block it looks less scary 😄 