### PR TITLE
Implement convert windows paths functionality

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -28,6 +28,7 @@ import (
 	"github.com/compose-spec/compose-go/errdefs"
 	"github.com/compose-spec/compose-go/loader"
 	"github.com/compose-spec/compose-go/types"
+	"github.com/compose-spec/compose-go/utils"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -332,7 +333,9 @@ func ProjectFromOptions(options *ProjectOptions) (*types.Project, error) {
 		return nil, err
 	}
 
-	options.loadOptions = append(options.loadOptions, withNamePrecedenceLoad(absWorkingDir, options))
+	options.loadOptions = append(options.loadOptions,
+		withNamePrecedenceLoad(absWorkingDir, options),
+		withConvertWindowsPaths(options))
 
 	project, err := loader.Load(types.ConfigDetails{
 		ConfigFiles: configs,
@@ -356,6 +359,12 @@ func withNamePrecedenceLoad(absWorkingDir string, options *ProjectOptions) func(
 		} else {
 			opts.SetProjectName(filepath.Base(absWorkingDir), false)
 		}
+	}
+}
+
+func withConvertWindowsPaths(options *ProjectOptions) func(*loader.Options) {
+	return func(o *loader.Options) {
+		o.ConvertWindowsPaths = utils.StringToBool(options.Environment["COMPOSE_CONVERT_WINDOWS_PATHS"])
 	}
 }
 

--- a/cli/options_windows_test.go
+++ b/cli/options_windows_test.go
@@ -1,0 +1,35 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cli
+
+import (
+	"os"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestConvertWithEnvVar(t *testing.T) {
+	os.Setenv("COMPOSE_CONVERT_WINDOWS_PATHS", "1")
+	defer os.Unsetenv("COMPOSE_CONVERT_WINDOWS_PATHS")
+	opts, _ := NewProjectOptions([]string{"testdata/simple/compose-with-paths.yaml"}, WithOsEnv)
+
+	p, err := ProjectFromOptions(opts)
+
+	assert.NilError(t, err)
+	assert.Equal(t, p.Services[0].Volumes[0].Source, "/c/docker/project")
+}

--- a/cli/testdata/simple/compose-with-paths.yaml
+++ b/cli/testdata/simple/compose-with-paths.yaml
@@ -1,0 +1,7 @@
+services:
+  test:
+    image: hello-world
+    volumes:
+    - type: bind
+      source: C:\docker\project
+      target: /test

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -53,6 +53,8 @@ type Options struct {
 	SkipNormalization bool
 	// Resolve paths
 	ResolvePaths bool
+	// Convert Windows paths
+	ConvertWindowsPaths bool
 	// Skip consistency check
 	SkipConsistencyCheck bool
 	// Skip extends
@@ -489,7 +491,7 @@ func loadServiceWithExtends(filename, name string, servicesDict map[string]inter
 		return nil, fmt.Errorf("cannot extend service %q in %s: service not found", name, filename)
 	}
 
-	serviceConfig, err := LoadService(name, target.(map[string]interface{}), workingDir, lookupEnv, opts.ResolvePaths)
+	serviceConfig, err := LoadService(name, target.(map[string]interface{}), workingDir, lookupEnv, opts.ResolvePaths, opts.ConvertWindowsPaths)
 	if err != nil {
 		return nil, err
 	}
@@ -552,7 +554,7 @@ func loadServiceWithExtends(filename, name string, servicesDict map[string]inter
 
 // LoadService produces a single ServiceConfig from a compose file Dict
 // the serviceDict is not validated if directly used. Use Load() to enable validation
-func LoadService(name string, serviceDict map[string]interface{}, workingDir string, lookupEnv template.Mapping, resolvePaths bool) (*types.ServiceConfig, error) {
+func LoadService(name string, serviceDict map[string]interface{}, workingDir string, lookupEnv template.Mapping, resolvePaths bool, convertPaths bool) (*types.ServiceConfig, error) {
 	serviceConfig := &types.ServiceConfig{
 		Scale: 1,
 	}
@@ -577,9 +579,28 @@ func LoadService(name string, serviceDict map[string]interface{}, workingDir str
 		if resolvePaths {
 			serviceConfig.Volumes[i] = resolveVolumePath(volume, workingDir, lookupEnv)
 		}
+
+		if convertPaths {
+			serviceConfig.Volumes[i] = convertVolumePath(volume)
+		}
 	}
 
 	return serviceConfig, nil
+}
+
+// Windows paths, c:\\my\\path\\shiny, need to be changed to be compatible with
+// the Engine. Volume paths are expected to be linux style /c/my/path/shiny/
+func convertVolumePath(volume types.ServiceVolumeConfig) types.ServiceVolumeConfig {
+	volumeName := strings.ToLower(filepath.VolumeName(volume.Source))
+	if len(volumeName) != 2 {
+		return volume
+	}
+
+	convertedSource := fmt.Sprintf("/%c%s", volumeName[0], volume.Source[len(volumeName):])
+	convertedSource = strings.ReplaceAll(convertedSource, "\\", "/")
+
+	volume.Source = convertedSource
+	return volume
 }
 
 func resolveEnvironment(serviceConfig *types.ServiceConfig, workingDir string, lookupEnv template.Mapping) error {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1833,7 +1833,7 @@ func TestLoadServiceWithEnvFile(t *testing.T) {
 	s, err := LoadService("Test Name", m, ".", func(s string) (string, bool) {
 		assert.Equal(t, "TEST", s)
 		return "YES", true
-	}, true)
+	}, true, false)
 	assert.NilError(t, err)
 	assert.Equal(t, "YES", *s.Environment["HALLO"])
 }
@@ -1857,7 +1857,7 @@ func TestLoadServiceWithVolumes(t *testing.T) {
 			},
 		},
 	}
-	s, err := LoadService("Test Name", m, ".", nil, true)
+	s, err := LoadService("Test Name", m, ".", nil, true, false)
 	assert.NilError(t, err)
 	assert.Equal(t, len(s.Volumes), 2)
 	assert.Equal(t, "/path 1", s.Volumes[0].Target)

--- a/loader/loader_windows_test.go
+++ b/loader/loader_windows_test.go
@@ -1,0 +1,53 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package loader
+
+import (
+	"testing"
+
+	"github.com/compose-spec/compose-go/types"
+	"gotest.tools/v3/assert"
+)
+
+func TestConvertWindowsVolumePath(t *testing.T) {
+	var testcases = []struct {
+		windowsPath           string
+		expectedConvertedPath string
+	}{
+		{
+			windowsPath:           "c:\\hello\\docker",
+			expectedConvertedPath: "/c/hello/docker",
+		},
+		{
+			windowsPath:           "d:\\compose",
+			expectedConvertedPath: "/d/compose",
+		},
+		{
+			windowsPath:           "e:\\path with spaces\\compose",
+			expectedConvertedPath: "/e/path with spaces/compose",
+		},
+	}
+	for _, testcase := range testcases {
+		volume := types.ServiceVolumeConfig{
+			Type:   "bind",
+			Source: testcase.windowsPath,
+			Target: "/test",
+		}
+
+		assert.Equal(t, testcase.expectedConvertedPath, convertVolumePath(volume).Source)
+	}
+}


### PR DESCRIPTION
Implements [option to convert windows paths](https://docs.docker.com/compose/reference/envvars/#compose_convert_windows_paths) (was not present in v2).

Resolves docker/compose#9132