### PR TITLE
Fix required env vars ignored except the last one

### DIFF
--- a/interpolation/interpolation_test.go
+++ b/interpolation/interpolation_test.go
@@ -114,6 +114,7 @@ func TestValidUnexistentInterpolation(t *testing.T) {
 		{test: "{{{ ${FOO:?foo_} }}}", errMsg: "foo_"},
 		{test: "{{{ ${FOO:?foo-bar-value} }}}", errMsg: "foo-bar-value"},
 		{test: "{{{ ${FOO:?foo} ${BAR:-DEFAULT_VALUE} }}}", errMsg: "foo"},
+		{test: "${FOO:?foo} ${BAR:?bar}", errMsg: "foo"},
 		{test: "{{{ ${BAR} }}}", expected: "{{{  }}}"},
 		{test: "${FOO:?baz} }}}", errMsg: "baz"},
 		{test: "${FOO?baz} }}}", errMsg: "baz"},

--- a/template/template.go
+++ b/template/template.go
@@ -62,6 +62,7 @@ type SubstituteFunc func(string, Mapping) (string, bool, error)
 // It accepts additional substitute function.
 func SubstituteWith(template string, mapping Mapping, pattern *regexp.Regexp, subsFuncs ...SubstituteFunc) (string, error) {
 	var outerErr error
+	var returnErr error
 
 	result := pattern.ReplaceAllStringFunc(template, func(substring string) string {
 		_, subsFunc := getSubstitutionFunctionForTemplate(substring)
@@ -91,6 +92,9 @@ func SubstituteWith(template string, mapping Mapping, pattern *regexp.Regexp, su
 
 		if substitution == "" {
 			outerErr = &InvalidTemplateError{Template: template}
+			if returnErr == nil {
+				returnErr = outerErr
+			}
 			return ""
 		}
 
@@ -101,6 +105,9 @@ func SubstituteWith(template string, mapping Mapping, pattern *regexp.Regexp, su
 			)
 			value, applied, outerErr = subsFunc(substitution, mapping)
 			if outerErr != nil {
+				if returnErr == nil {
+					returnErr = outerErr
+				}
 				return ""
 			}
 			if applied {
@@ -119,7 +126,7 @@ func SubstituteWith(template string, mapping Mapping, pattern *regexp.Regexp, su
 		return value
 	})
 
-	return result, outerErr
+	return result, returnErr
 }
 
 func getSubstitutionFunctionForTemplate(template string) (string, SubstituteFunc) {


### PR DESCRIPTION
During the variable substitution, if a missing variable was followed
by an existing one, the empty "err" variable overwrote the previous
non-empty variable.

Unlike with Docker Compose v1, the first found error did not guarantee
that an actual error would be thrown.

Example which would have run before the fix even though var1 is not defined:

```yaml
services:
  bash:
    image: bash:5.0.18-alpine3.15
    environment:
      var12: "_ ${var1:?Error1} _ ${var2:?Error2} _ "
    command:
      - env
```

```bash
# var2=1 docker compose up
```

This change also means that, if multiple variables are missing in one string, the first one will be reported by Docker Compose

Signed-off-by: Ákos Takács <takacs.akos@it-sziget.hu>