### PR TITLE
Add a public parsing command for SSH config short syntax

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -1019,14 +1019,19 @@ var transformSSHConfig TransformerFunc = func(data interface{}) (interface{}, er
 		}
 		return result, nil
 	case string:
-		if value == "" {
-			value = "default"
-		}
-		key, val := transformValueToMapEntry(value, "=", false)
-		result := []types.SSHKey{{ID: key, Path: val.(string)}}
-		return result, nil
+		return ParseShortSSHSyntax(value)
 	}
 	return nil, errors.Errorf("expected a sting, map or a list, got %T: %#v", data, data)
+}
+
+// ParseShortSSHSyntax parse short syntax for SSH authentications
+func ParseShortSSHSyntax(value string) ([]types.SSHKey, error) {
+	if value == "" {
+		value = "default"
+	}
+	key, val := transformValueToMapEntry(value, "=", false)
+	result := []types.SSHKey{{ID: key, Path: val.(string)}}
+	return result, nil
 }
 
 var transformStringOrNumberList TransformerFunc = func(value interface{}) (interface{}, error) {


### PR DESCRIPTION
To be able to parse the short syntax of an SSH config from a CLI flag, for example with Compose the reference implementation of the spec, I propose to add a simple function to easily convert a `string` to a `SSHConfig` struct

Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>