### PR TITLE
make HostsLists a map[string]string to better handle merging config

### DIFF
--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -178,9 +178,9 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 				"project_db_1:mysql",
 				"project_db_1:postgresql",
 			},
-			ExtraHosts: []string{
-				"somehost:162.242.195.82",
-				"otherhost:50.31.209.229",
+			ExtraHosts: types.HostsList{
+				"somehost":  "162.242.195.82",
+				"otherhost": "50.31.209.229",
 			},
 			Extensions: map[string]interface{}{
 				"x-bar": "baz",
@@ -700,8 +700,8 @@ services:
     - project_db_1:mysql
     - project_db_1:postgresql
     extra_hosts:
-    - somehost:162.242.195.82
-    - otherhost:50.31.209.229
+      otherhost: 50.31.209.229
+      somehost: 162.242.195.82
     hostname: foo
     healthcheck:
       test:
@@ -1270,10 +1270,10 @@ func fullExampleJSON(workingDir, homeDir string) string {
         "project_db_1:mysql",
         "project_db_1:postgresql"
       ],
-      "extra_hosts": [
-        "somehost:162.242.195.82",
-        "otherhost:50.31.209.229"
-      ],
+      "extra_hosts": {
+        "otherhost": "50.31.209.229",
+        "somehost": "162.242.195.82"
+      },
       "hostname": "foo",
       "healthcheck": {
         "test": [

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1232,8 +1232,8 @@ services:
 	assert.NilError(t, err)
 
 	expected := types.HostsList{
-		"alpha:50.31.209.229",
-		"zulu:162.242.195.82",
+		"alpha": "50.31.209.229",
+		"zulu":  "162.242.195.82",
 	}
 
 	assert.Assert(t, is.Len(config.Services, 1))
@@ -1246,16 +1246,14 @@ services:
   web:
     image: busybox
     extra_hosts:
-      - "zulu:162.242.195.82"
       - "alpha:50.31.209.229"
       - "zulu:ff02::1"
 `)
 	assert.NilError(t, err)
 
 	expected := types.HostsList{
-		"zulu:162.242.195.82",
-		"alpha:50.31.209.229",
-		"zulu:ff02::1",
+		"alpha": "50.31.209.229",
+		"zulu":  "ff02::1",
 	}
 
 	assert.Assert(t, is.Len(config.Services, 1))

--- a/loader/merge_test.go
+++ b/loader/merge_test.go
@@ -1256,3 +1256,28 @@ func TestMergeEnvironments(t *testing.T) {
 	assert.Assert(t, *env["NAME"] == "DEV")
 	assert.Assert(t, env["VALUE"] == nil)
 }
+
+func TestMergeExtraHosts(t *testing.T) {
+	base := types.HostsList{
+		"kept":              "192.168.1.100",
+		"extra1.domain.org": "192.168.1.101",
+		"extra2.domain.org": "192.168.1.102",
+	}
+	override := types.HostsList{
+		"extra1.domain.org": "10.0.0.1",
+		"extra2.domain.org": "10.0.0.2",
+		"added":             "10.0.0.3",
+	}
+	err := mergo.Merge(&base, &override, mergo.WithOverride)
+	assert.NilError(t, err)
+	assert.DeepEqual(
+		t,
+		base,
+		types.HostsList{
+			"kept":              "192.168.1.100",
+			"extra1.domain.org": "10.0.0.1",
+			"extra2.domain.org": "10.0.0.2",
+			"added":             "10.0.0.3",
+		},
+	)
+}

--- a/types/types.go
+++ b/types/types.go
@@ -468,7 +468,16 @@ func (s SSHKey) MarshalJSON() ([]byte, error) {
 type MappingWithColon map[string]string
 
 // HostsList is a list of colon-separated host-ip mappings
-type HostsList []string
+type HostsList map[string]string
+
+// AsList return host-ip mappings as a list of colon-separated strings
+func (h HostsList) AsList() []string {
+	l := make([]string, 0, len(h))
+	for k, v := range h {
+		l = append(l, fmt.Sprintf("%s:%s", k, v))
+	}
+	return l
+}
 
 // LoggingConfig the logging configuration for a service
 type LoggingConfig struct {


### PR DESCRIPTION
Also introduces `.AsList()` for backward compatibility

fixes https://github.com/docker/compose/issues/9361