### PR TITLE
Clarify committer name must be one's real name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,8 @@ Then you just add a line to every git commit message:
 
     Signed-off-by: Joe Smith <joe.smith@email.com>
 
-Use your real name (sorry, no pseudonyms or anonymous contributions.)
+Use your real name. (sorry, no pseudonyms or anonymous contributions.)
+Committer name (`user.name` in git config) also must be your real name.
 
 If you set your `user.name` and `user.email` git configs, you can sign your
 commit automatically with `git commit -s`.


### PR DESCRIPTION
Inconsistency with signed-off comment and committer name results DCO check fail.

Not documented in https://probot.github.io/apps/dco/ but failed in https://github.com/compose-spec/compose-go/runs/6267860293.

It would be nice it was clarified in CONTRIBUTING.md.
