### PR TITLE
resolve variables in .env file based on previously set variables

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -222,7 +222,7 @@ func WithDotEnv(o *ProjectOptions) error {
 
 	notInEnvSet := make(map[string]interface{})
 	env, err := dotenv.ParseWithLookup(file, func(k string) (string, bool) {
-		v, ok := os.LookupEnv(k)
+		v, ok := o.Environment[k]
 		if !ok {
 			notInEnvSet[k] = nil
 			return "", true


### PR DESCRIPTION
variable substitution in `.env` file MUST not assume values from os.Env, but use previously registered environment variables (set either by `WithOsEnv` or by direct assignment to `projectOptions.Environment`) 

variables MUST NOT override a previously defined variable, so that one can use:
- `FOO=BAR`  set by os.env
- `QIX=${FOO}` set by .env file
- `FOO=...` set by .env file does not override value set by os.env


see https://github.com/docker/compose/issues/9442