### PR TITLE
do not override a value that has been set by higher-priority environment source

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -170,6 +170,9 @@ func WithLoadOptions(loadOptions ...func(*loader.Options)) ProjectOptionsFn {
 // WithOsEnv imports environment variables from OS
 func WithOsEnv(o *ProjectOptions) error {
 	for k, v := range getAsEqualsMap(os.Environ()) {
+		if _, set := o.Environment[k]; set {
+			continue
+		}
 		o.Environment[k] = v
 	}
 	return nil
@@ -237,6 +240,9 @@ func WithDotEnv(o *ProjectOptions) error {
 	}
 	for k, v := range env {
 		if _, ok := notInEnvSet[k]; ok {
+			continue
+		}
+		if _, set := o.Environment[k]; set {
 			continue
 		}
 		o.Environment[k] = v


### PR DESCRIPTION
assuming we have FOO=BAR by os variable, and dot env file :
```
FOO=default
BAZ=${FOO}
```
we expect os env var wins, and also set `BAZ`.
For this to happen, loading dot env file MUST NOT replace a variable previously set from os.Env

closes https://github.com/docker/compose/issues/9442