### PR TITLE
allow '.' (dot) in environment variable name

### DIFF
--- a/dotenv/parser.go
+++ b/dotenv/parser.go
@@ -105,9 +105,9 @@ loop:
 			offset = i + 1
 			inherited = char == '\n'
 			break loop
-		case '_':
+		case '_', '.':
 		default:
-			// variable name should match [A-Za-z0-9_]
+			// variable name should match [A-Za-z0-9_.]
 			if unicode.IsLetter(rchar) || unicode.IsNumber(rchar) {
 				continue
 			}

--- a/loader/example1.env
+++ b/loader/example1.env
@@ -1,5 +1,7 @@
 # passed through
 FOO=foo_from_env_file
+ENV.WITH.DOT=ok
+ENV_WITH_UNDERSCORE=ok
 
 # overridden in example2.env
 BAR=bar_from_env_file

--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -164,10 +164,12 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 			DomainName: "foo.com",
 			Entrypoint: []string{"/code/entrypoint.sh", "-p", "3000"},
 			Environment: map[string]*string{
-				"FOO": strPtr("foo_from_env_file"),
-				"BAR": strPtr("this is a secret"),
-				"BAZ": strPtr("baz_from_service_def"),
-				"QUX": strPtr("qux_from_environment"),
+				"FOO":                 strPtr("foo_from_env_file"),
+				"BAR":                 strPtr("this is a secret"),
+				"BAZ":                 strPtr("baz_from_service_def"),
+				"QUX":                 strPtr("qux_from_environment"),
+				"ENV.WITH.DOT":        strPtr("ok"),
+				"ENV_WITH_UNDERSCORE": strPtr("ok"),
 			},
 			EnvFile: []string{
 				"./example1.env",
@@ -691,6 +693,8 @@ services:
     environment:
       BAR: this is a secret
       BAZ: baz_from_service_def
+      ENV.WITH.DOT: ok
+      ENV_WITH_UNDERSCORE: ok
       FOO: foo_from_env_file
       QUX: qux_from_environment
     env_file:
@@ -1261,6 +1265,8 @@ func fullExampleJSON(workingDir, homeDir string) string {
       "environment": {
         "BAR": "this is a secret",
         "BAZ": "baz_from_service_def",
+        "ENV.WITH.DOT": "ok",
+        "ENV_WITH_UNDERSCORE": "ok",
         "FOO": "foo_from_env_file",
         "QUX": "qux_from_environment"
       },

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -766,10 +766,12 @@ func TestDiscardEnvFileOption(t *testing.T) {
      - example2.env
 `
 	expectedEnvironmentMap := types.MappingWithEquals{
-		"FOO": strPtr("foo_from_env_file"),
-		"BAZ": strPtr("baz_from_env_file"),
-		"BAR": strPtr("bar_from_env_file_2"), // Original value is overwritten by example2.env
-		"QUX": strPtr("quz_from_env_file_2"),
+		"FOO":                 strPtr("foo_from_env_file"),
+		"BAZ":                 strPtr("baz_from_env_file"),
+		"BAR":                 strPtr("bar_from_env_file_2"), // Original value is overwritten by example2.env
+		"QUX":                 strPtr("quz_from_env_file_2"),
+		"ENV.WITH.DOT":        strPtr("ok"),
+		"ENV_WITH_UNDERSCORE": strPtr("ok"),
 	}
 	configDetails := buildConfigDetails(dict, nil)
 


### PR DESCRIPTION
Fix https://github.com/docker/compose/issues/8862