### PR TITLE
project: ensure withServices doesn't blow stack on cycles

### DIFF
--- a/types/project.go
+++ b/types/project.go
@@ -142,18 +142,19 @@ func (p Project) WithServices(names []string, fn ServiceFunc) error {
 	return p.withServices(names, fn, map[string]bool{})
 }
 
-func (p Project) withServices(names []string, fn ServiceFunc, done map[string]bool) error {
+func (p Project) withServices(names []string, fn ServiceFunc, seen map[string]bool) error {
 	services, err := p.GetServices(names...)
 	if err != nil {
 		return err
 	}
 	for _, service := range services {
-		if done[service.Name] {
+		if seen[service.Name] {
 			continue
 		}
+		seen[service.Name] = true
 		dependencies := service.GetDependencies()
 		if len(dependencies) > 0 {
-			err := p.withServices(dependencies, fn, done)
+			err := p.withServices(dependencies, fn, seen)
 			if err != nil {
 				return err
 			}
@@ -161,7 +162,6 @@ func (p Project) withServices(names []string, fn ServiceFunc, done map[string]bo
 		if err := fn(service); err != nil {
 			return err
 		}
-		done[service.Name] = true
 	}
 	return nil
 }

--- a/types/project_test.go
+++ b/types/project_test.go
@@ -83,6 +83,13 @@ func Test_ForServices(t *testing.T) {
 	assert.Equal(t, p.DisabledServices[0].Name, "service_3")
 }
 
+func Test_ForServicesCycle(t *testing.T) {
+	p := makeProject()
+	p.Services[0].Links = []string{"service_2"}
+	err := p.ForServices([]string{"service_2"})
+	assert.NilError(t, err)
+}
+
 func makeProject() Project {
 	return Project{
 		Services: append(Services{},


### PR DESCRIPTION
Change `done` map to `seen` and record service was seen before traversing
dependencies.

Fixes docker/compose#9526.

Signed-off-by: Nick Sieger <nick@nicksieger.com>
