### PR TITLE
Fix interpolation error msg output

### DIFF
--- a/interpolation/interpolation.go
+++ b/interpolation/interpolation.go
@@ -115,7 +115,7 @@ func newPathError(path Path, err error) error {
 		return nil
 	case *template.InvalidTemplateError:
 		return errors.Errorf(
-			"invalid interpolation format for %s: %#v. You may need to escape any $ with another $",
+			"invalid interpolation format for %s.\nYou may need to escape any $ with another $.\n%s",
 			path, err.Template)
 	default:
 		return errors.Wrapf(err, "error while interpolating %s", path)

--- a/interpolation/interpolation_test.go
+++ b/interpolation/interpolation_test.go
@@ -73,7 +73,9 @@ func TestInvalidInterpolation(t *testing.T) {
 		},
 	}
 	_, err := Interpolate(services, Options{LookupValue: defaultMapping})
-	assert.Error(t, err, `invalid interpolation format for servicea.image: "${". You may need to escape any $ with another $`)
+	assert.Error(t, err, `invalid interpolation format for servicea.image.
+You may need to escape any $ with another $.
+${`)
 }
 
 func TestInterpolateWithDefaults(t *testing.T) {
@@ -131,8 +133,8 @@ func TestValidUnexistentInterpolation(t *testing.T) {
 	}
 
 	getFullErrorMsg := func(msg string) string {
-		return fmt.Sprintf("invalid interpolation format for myservice.environment.TESTVAR: "+
-			"\"required variable FOO is missing a value: %s\". You may need to escape any $ with another $", msg)
+		return fmt.Sprintf("invalid interpolation format for myservice.environment.TESTVAR.\n"+
+			"You may need to escape any $ with another $.\nrequired variable FOO is missing a value: %s", msg)
 	}
 
 	for _, testcase := range testcases {


### PR DESCRIPTION
This refactors the error message when a variable is required but not found to have its msg as last string in the output and with the right formatting.