### PR TITLE
use '-' as default separator and support of compatibility mode

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -350,7 +350,8 @@ func ProjectFromOptions(options *ProjectOptions) (*types.Project, error) {
 
 	options.loadOptions = append(options.loadOptions,
 		withNamePrecedenceLoad(absWorkingDir, options),
-		withConvertWindowsPaths(options))
+		withConvertWindowsPaths(options),
+		withSeparator(options))
 
 	project, err := loader.Load(types.ConfigDetails{
 		ConfigFiles: configs,
@@ -381,6 +382,15 @@ func withConvertWindowsPaths(options *ProjectOptions) func(*loader.Options) {
 	return func(o *loader.Options) {
 		o.ConvertWindowsPaths = utils.StringToBool(options.Environment["COMPOSE_CONVERT_WINDOWS_PATHS"])
 		o.ResolvePaths = true
+	}
+}
+
+// withSeparator defines loader.Options separator used to define resource names
+func withSeparator(options *ProjectOptions) func(*loader.Options) {
+	return func(o *loader.Options) {
+		if utils.StringToBool(options.Environment["COMPOSE_COMPATIBILITY"]) {
+			o.Separator = loader.CompatibilitySeparator
+		}
 	}
 }
 

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -237,3 +237,29 @@ func TestEnvMap(t *testing.T) {
 	m = utils.GetAsEqualsMap(l)
 	assert.Equal(t, m["foo"], "bar")
 }
+
+func TestWithSeparator(t *testing.T) {
+	t.Run("With default separator", func(t *testing.T) {
+		opts, err := NewProjectOptions([]string{
+			"testdata/simple/compose-with-network-and-volume.yaml",
+		}, WithName("my-project"))
+		assert.NilError(t, err)
+		p, err := ProjectFromOptions(opts)
+		assert.NilError(t, err)
+		assert.Equal(t, p.Networks["test-network"].Name, "my-project-test-network")
+
+	})
+
+	t.Run("With compatibility separator", func(t *testing.T) {
+		os.Setenv("COMPOSE_COMPATIBILITY", "true") //nolint:errcheck
+		defer os.Unsetenv("COMPOSE_COMPATIBILITY") //nolint:errcheck
+		opts, err := NewProjectOptions([]string{
+			"testdata/simple/compose-with-network-and-volume.yaml",
+		}, WithName("my-project"), WithOsEnv)
+		assert.NilError(t, err)
+		p, err := ProjectFromOptions(opts)
+		assert.NilError(t, err)
+		assert.Equal(t, p.Networks["test-network"].Name, "my-project_test-network")
+
+	})
+}

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -251,8 +251,7 @@ func TestWithSeparator(t *testing.T) {
 	})
 
 	t.Run("With compatibility separator", func(t *testing.T) {
-		os.Setenv("COMPOSE_COMPATIBILITY", "true") //nolint:errcheck
-		defer os.Unsetenv("COMPOSE_COMPATIBILITY") //nolint:errcheck
+		t.Setenv("COMPOSE_COMPATIBILITY", "true")
 		opts, err := NewProjectOptions([]string{
 			"testdata/simple/compose-with-network-and-volume.yaml",
 		}, WithName("my-project"), WithOsEnv)

--- a/cli/testdata/simple/compose-with-network-and-volume.yaml
+++ b/cli/testdata/simple/compose-with-network-and-volume.yaml
@@ -1,0 +1,11 @@
+services:
+  simple:
+    image: nginx
+    networks:
+      - test-network
+    volumes:
+      - test-volume
+networks:
+  test-network:
+volumes:
+  test-volume:

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -43,6 +43,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	DefaultSeparator       = "-"
+	CompatibilitySeparator = "_"
+)
+
 // Options supported by Load
 type Options struct {
 	// Skip schema validation
@@ -67,6 +72,8 @@ type Options struct {
 	projectName string
 	// Indicates when the projectName was imperatively set or guessed from path
 	projectNameImperativelySet bool
+	// Set separator used for naming resources
+	Separator string
 }
 
 func (o *Options) SetProjectName(name string, imperativelySet bool) {
@@ -155,6 +162,7 @@ func Load(configDetails types.ConfigDetails, options ...func(*Options)) (*types.
 			LookupValue:     configDetails.LookupEnv,
 			TypeCastMapping: interpolateTypeCastMapping,
 		},
+		Separator: DefaultSeparator,
 	}
 
 	for _, op := range options {
@@ -223,7 +231,7 @@ func Load(configDetails types.ConfigDetails, options ...func(*Options)) (*types.
 	}
 
 	if !opts.SkipNormalization {
-		err = normalize(project, opts.ResolvePaths)
+		err = normalize(project, opts.ResolvePaths, opts.Separator)
 		if err != nil {
 			return nil, err
 		}

--- a/loader/normalize.go
+++ b/loader/normalize.go
@@ -28,7 +28,7 @@ import (
 )
 
 // normalize compose project by moving deprecated attributes to their canonical position and injecting implicit defaults
-func normalize(project *types.Project, resolvePaths bool) error {
+func normalize(project *types.Project, resolvePaths bool, separator string) error {
 	absWorkingDir, err := filepath.Abs(project.WorkingDir)
 	if err != nil {
 		return err
@@ -110,7 +110,7 @@ func normalize(project *types.Project, resolvePaths bool) error {
 		project.Services[i] = s
 	}
 
-	setNameFromKey(project)
+	setNameFromKey(project, separator)
 
 	return nil
 }
@@ -143,31 +143,31 @@ func absComposeFiles(composeFiles []string) ([]string, error) {
 }
 
 // Resources with no explicit name are actually named by their key in map
-func setNameFromKey(project *types.Project) {
+func setNameFromKey(project *types.Project, separator string) {
 	for i, n := range project.Networks {
 		if n.Name == "" {
-			n.Name = fmt.Sprintf("%s_%s", project.Name, i)
+			n.Name = fmt.Sprintf("%s%s%s", project.Name, separator, i)
 			project.Networks[i] = n
 		}
 	}
 
 	for i, v := range project.Volumes {
 		if v.Name == "" {
-			v.Name = fmt.Sprintf("%s_%s", project.Name, i)
+			v.Name = fmt.Sprintf("%s%s%s", project.Name, separator, i)
 			project.Volumes[i] = v
 		}
 	}
 
 	for i, c := range project.Configs {
 		if c.Name == "" {
-			c.Name = fmt.Sprintf("%s_%s", project.Name, i)
+			c.Name = fmt.Sprintf("%s%s%s", project.Name, separator, i)
 			project.Configs[i] = c
 		}
 	}
 
 	for i, s := range project.Secrets {
 		if s.Name == "" {
-			s.Name = fmt.Sprintf("%s_%s", project.Name, i)
+			s.Name = fmt.Sprintf("%s%s%s", project.Name, separator, i)
 			project.Secrets[i] = s
 		}
 	}

--- a/loader/normalize_test.go
+++ b/loader/normalize_test.go
@@ -73,16 +73,16 @@ services:
       default: null
 networks:
   default:
-    name: myProject_default
+    name: myProject-default
   myExternalnet:
     name: myExternalnet
     external: true
   myNamedNet:
     name: CustomName
   mynet:
-    name: myProject_mynet
+    name: myProject-mynet
 `
-	err := normalize(&project, false)
+	err := normalize(&project, false, DefaultSeparator)
 	assert.NilError(t, err)
 	marshal, err := yaml.Marshal(project)
 	assert.NilError(t, err)
@@ -116,9 +116,9 @@ services:
       default: null
 networks:
   default:
-    name: myProject_default
+    name: myProject-default
 `, filepath.Join(wd, "testdata"))
-	err := normalize(&project, true)
+	err := normalize(&project, true, DefaultSeparator)
 	assert.NilError(t, err)
 	marshal, err := yaml.Marshal(project)
 	assert.NilError(t, err)
@@ -138,11 +138,11 @@ func TestNormalizeAbsolutePaths(t *testing.T) {
 
 	expected := types.Project{
 		Name:         "myProject",
-		Networks:     types.Networks{"default": {Name: "myProject_default"}},
+		Networks:     types.Networks{"default": {Name: "myProject-default"}},
 		WorkingDir:   absWorkingDir,
 		ComposeFiles: []string{absComposeFile, absOverrideFile},
 	}
-	err := normalize(&project, false)
+	err := normalize(&project, false, DefaultSeparator)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, expected, project)
 }
@@ -166,13 +166,13 @@ func TestNormalizeVolumes(t *testing.T) {
 	absCwd, _ := filepath.Abs(".")
 	expected := types.Project{
 		Name:     "myProject",
-		Networks: types.Networks{"default": {Name: "myProject_default"}},
+		Networks: types.Networks{"default": {Name: "myProject-default"}},
 		Volumes: types.Volumes{
 			"myExternalVol": {
 				Name:     "myExternalVol",
 				External: types.External{External: true},
 			},
-			"myvol": {Name: "myProject_myvol"},
+			"myvol": {Name: "myProject-myvol"},
 			"myNamedVol": {
 				Name: "CustomName",
 			},
@@ -180,7 +180,29 @@ func TestNormalizeVolumes(t *testing.T) {
 		WorkingDir:   absCwd,
 		ComposeFiles: []string{},
 	}
-	err := normalize(&project, false)
+	err := normalize(&project, false, DefaultSeparator)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, expected, project)
+}
+
+func TestNormalizeWithCompatibilitySeparator(t *testing.T) {
+	project := types.Project{
+		Name:         "myProject",
+		WorkingDir:   "testdata",
+		Networks:     types.Networks{},
+		ComposeFiles: []string{filepath.Join("testdata", "simple", "compose.yaml"), filepath.Join("testdata", "simple", "compose-with-overrides.yaml")},
+	}
+	absWorkingDir, _ := filepath.Abs("testdata")
+	absComposeFile, _ := filepath.Abs(filepath.Join("testdata", "simple", "compose.yaml"))
+	absOverrideFile, _ := filepath.Abs(filepath.Join("testdata", "simple", "compose-with-overrides.yaml"))
+
+	expected := types.Project{
+		Name:         "myProject",
+		Networks:     types.Networks{"default": {Name: "myProject_default"}},
+		WorkingDir:   absWorkingDir,
+		ComposeFiles: []string{absComposeFile, absOverrideFile},
+	}
+	err := normalize(&project, false, "_")
 	assert.NilError(t, err)
 	assert.DeepEqual(t, expected, project)
 }


### PR DESCRIPTION
Change the default separator used between project name and resources to `-`. This is especially needed for container names to avoid issue with hostname support.

Also add detection of the `COMPOSE_COMPATIBILITY` env variable to support the compatibility usage of the `_` separator

Fix https://github.com/docker/compose/issues/9618