### PR TITLE
build: ensure compatibility for all supported Go versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 on: [push, pull_request]
 name: Continuous integration
+
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: validate
@@ -7,7 +11,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Lint code
         uses: golangci/golangci-lint-action@v2
       - name: Check license
@@ -16,16 +20,18 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: ['1.17', '1.18', '>=1.19.0-rc.2']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 5
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v2
+        check-latest: true
+        cache: true
     - name: Test
       run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/compose-spec/compose-go
 
-go 1.18
+go 1.17
 
 require (
 	github.com/distribution/distribution/v3 v3.0.0-20220725133111-4bf3547399eb


### PR DESCRIPTION
Use matrix testing to test on currently supported Go versions,
including 1.19 pre-release.

The `go.mod` compatibility level is also set to 1.17. Once 1.19
is released, we should bump to 1.18, as Go always supports the
current version and one older, so we should stick with this as
well.