### PR TITLE
Fix absolute paths in secrets and inherited volumes

### DIFF
--- a/loader/full-example.yml
+++ b/loader/full-example.yml
@@ -428,6 +428,8 @@ secrets:
     environment: BAR
     x-bar: baz
     x-foo: bar
+  secret5:
+    file: /abs/secret_data
 x-bar: baz
 x-foo: bar
 x-nested:

--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -574,6 +574,9 @@ func secrets(workingDir string) map[string]types.SecretConfig {
 				"x-foo": "bar",
 			},
 		},
+		"secret5": {
+			File: "/abs/secret_data",
+		},
 	}
 }
 
@@ -985,6 +988,8 @@ secrets:
     environment: BAR
     x-bar: baz
     x-foo: bar
+  secret5:
+    file: /abs/secret_data
 configs:
   config1:
     file: %s
@@ -1105,6 +1110,10 @@ func fullExampleJSON(workingDir, homeDir string) string {
     "secret4": {
       "name": "bar",
       "environment": "BAR",
+      "external": false
+    },
+    "secret5": {
+      "file": "/abs/secret_data",
       "external": false
     }
   },

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -660,8 +660,8 @@ func resolveEnvironment(serviceConfig *types.ServiceConfig, workingDir string, l
 	return nil
 }
 
-func resolveVolumePath(volume types.ServiceVolumeConfig, workingDir string, lookupEnv template.Mapping) types.ServiceVolumeConfig {
-	filePath := expandUser(volume.Source, lookupEnv)
+func resolveMaybeUnixPath(path string, workingDir string, lookupEnv template.Mapping) string {
+	filePath := expandUser(path, lookupEnv)
 	// Check if source is an absolute path (either Unix or Windows), to
 	// handle a Windows client with a Unix daemon or vice-versa.
 	//
@@ -671,8 +671,19 @@ func resolveVolumePath(volume types.ServiceVolumeConfig, workingDir string, look
 	if !paths.IsAbs(filePath) && !isAbs(filePath) {
 		filePath = absPath(workingDir, filePath)
 	}
-	volume.Source = filePath
+	return filePath
+}
+
+func resolveVolumePath(volume types.ServiceVolumeConfig, workingDir string, lookupEnv template.Mapping) types.ServiceVolumeConfig {
+	volume.Source = resolveMaybeUnixPath(volume.Source, workingDir, lookupEnv)
 	return volume
+}
+
+func resolveSecretsPath(secret types.SecretConfig, workingDir string, lookupEnv template.Mapping) types.SecretConfig {
+	if ! secret.External.External && secret.File != "" {
+		secret.File = resolveMaybeUnixPath(secret.File, workingDir, lookupEnv)
+	}
+	return secret
 }
 
 // TODO: make this more robust
@@ -782,11 +793,14 @@ func LoadSecrets(source map[string]interface{}, details types.ConfigDetails, res
 		return secrets, err
 	}
 	for name, secret := range secrets {
-		obj, err := loadFileObjectConfig(name, "secret", types.FileObjectConfig(secret), details, resolvePaths)
+		obj, err := loadFileObjectConfig(name, "secret", types.FileObjectConfig(secret), details, false)
 		if err != nil {
 			return nil, err
 		}
 		secretConfig := types.SecretConfig(obj)
+		if resolvePaths {
+			secretConfig = resolveSecretsPath(secretConfig, details.WorkingDir, details.LookupEnv)
+		}
 		secrets[name] = secretConfig
 	}
 	return secrets, nil

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -556,7 +556,7 @@ func loadServiceWithExtends(filename, name string, servicesDict map[string]inter
 				if vol.Type != types.VolumeTypeBind {
 					continue
 				}
-				baseService.Volumes[i].Source = absPath(baseFileParent, vol.Source)
+				baseService.Volumes[i].Source = resolveMaybeUnixPath(vol.Source, baseFileParent, lookupEnv)
 			}
 		}
 

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1834,6 +1834,12 @@ func TestLoadWithExtends(t *testing.T) {
 			},
 			Environment: types.MappingWithEquals{},
 			Networks:    map[string]*types.ServiceNetworkConfig{"default": nil},
+			Volumes:     []types.ServiceVolumeConfig{{
+				Type:   "bind",
+				Source: "/opt/data",
+				Target: "/var/lib/mysql",
+				Bind:   &types.ServiceVolumeBind{CreateHostPath: true},
+			}},
 			Scale:       1,
 		},
 	}

--- a/loader/testdata/compose-test-extends-imported.yaml
+++ b/loader/testdata/compose-test-extends-imported.yaml
@@ -1,3 +1,5 @@
 services:
   imported:
     image: nginx
+    volumes:
+      - /opt/data:/var/lib/mysql


### PR DESCRIPTION
Volumes detect and handle unix-like absolute paths also on Windows. Secrets are translated to bind mounts, so handle them the same way. While at it, fix also inherited absolute path volumes from extended services.

Fixes #304 