### PR TITLE
env: fix errors on valid interpolation expressions

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -31,7 +31,7 @@ var substitutionNamed = "[_a-z][_a-z0-9]*"
 var substitutionBraced = "[_a-z][_a-z0-9]*(?::?[-+?](.*}|[^}]*))?"
 
 var patternString = fmt.Sprintf(
-	"%s(?i:(?P<escaped>%s)|(?P<named>%s)|{(?P<braced>%s)}|(?P<invalid>))",
+	"%s(?i:(?P<escaped>%s)|(?P<named>%s)|{(?:(?P<braced>%s)}|(?P<invalid>)))",
 	delimiter, delimiter, substitutionNamed, substitutionBraced,
 )
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -47,10 +47,24 @@ func TestSubstituteNoMatch(t *testing.T) {
 	assert.Equal(t, "foo", result)
 }
 
+func TestUnescaped(t *testing.T) {
+	templates := []string{
+		"a $ string",
+		"^REGEX$",
+		"$}",
+		"$",
+	}
+
+	for _, expected := range templates {
+		actual, err := Substitute(expected, defaultMapping)
+		assert.NilError(t, err)
+		assert.Equal(t, expected, actual)
+	}
+}
+
 func TestInvalid(t *testing.T) {
 	invalidTemplates := []string{
 		"${",
-		"$}",
 		"${}",
 		"${ }",
 		"${ foo}",


### PR DESCRIPTION
The parser was too strict here and would reject valid constructs that used an unescaped `$` that was not part of a variable expression (and not ambiguous).

Now, only errors for unmatched braced expressions (e.g. `${FOO`) are returned, but other valid cases are ignored and the `$` will be treated literally, e.g. `a $ string` -> `a $ string`, which is the same as in POSIX.