### PR TITLE
support the 2 currently maintained Golang releases (1.18 & 1.19)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ['1.17', '1.18', '>=1.19.0-rc.2']
+        go-version: ['1.18', '1.19']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 5


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>