### PR TITLE
Fix possible nil in extended docker-compose.yml configuration

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -515,6 +515,10 @@ func loadServiceWithExtends(filename, name string, servicesDict map[string]inter
 		return nil, fmt.Errorf("cannot extend service %q in %s: service not found", name, filename)
 	}
 
+	if target == nil {
+		target = map[string]interface{}{}
+	}
+
 	serviceConfig, err := LoadService(name, target.(map[string]interface{}), workingDir, lookupEnv, opts.ResolvePaths, opts.ConvertWindowsPaths)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
in practice, the missing service name in extended configuration means that nothing is extended

current state was that the docker-compose command fails with following error:
```
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 1 [running]:
github.com/compose-spec/compose-go/loader.loadServiceWithExtends({0xc0007c4230, 0x50}, {0xc000502880, 0x7}, 0xc0005fc720?, {0xc0007c4230, 0x40}, 0xc0004d22d0?, 0xc000480390, 0xc0007cb1f8)
        github.com/compose-spec/compose-go@v1.6.0/loader/loader.go:511 +0x6ab
github.com/compose-spec/compose-go/loader.loadServiceWithExtends({0xc0007b4780, 0x55}, {0xc000795e98, 0x7}, 0xc0005f3fb0?, {0xc0007b4780, 0x40}, 0xc00058c7e0?, 0xc000480390, 0xc0007cb1f8)
        github.com/compose-spec/compose-go@v1.6.0/loader/loader.go:539 +0x31a
github.com/compose-spec/compose-go/loader.loadServiceWithExtends({0xc000067180, 0x4f}, {0xc0001edac0, 0x7}, 0x4156d0?, {0xc000067180, 0x40}, 0x7fb739ec2fff?, 0xc000480390, 0xc0007cb1f8)
        github.com/compose-spec/compose-go@v1.6.0/loader/loader.go:539 +0x31a
github.com/compose-spec/compose-go/loader.loadServiceWithExtends({0xc0000665f0, 0x4c}, {0xc0002b4090, 0x7}, 0x0?, {0xc0000665f0, 0x39}, 0x203000?, 0xc000480390, 0xc0007cb1f8)
        github.com/compose-spec/compose-go@v1.6.0/loader/loader.go:539 +0x31a
github.com/compose-spec/compose-go/loader.LoadServices({0xc0000665f0, 0x4c}, 0x1d97a32?, {0xc0000665f0, 0x39}, 0xc000669850?, 0xa86b35?)
        github.com/compose-spec/compose-go@v1.6.0/loader/loader.go:490 +0x1d1
github.com/compose-spec/compose-go/loader.loadSections({0xc0000665f0, 0x4c}, 0x202ec0?, {{0x0, 0x0}, {0xc0000665f0, 0x39}, {0xc0004802d0, 0x1, 0x1}, ...}, ...)
        github.com/compose-spec/compose-go@v1.6.0/loader/loader.go:314 +0x2cb
github.com/compose-spec/compose-go/loader.Load({{0x0, 0x0}, {0xc0000665f0, 0x39}, {0xc0004802d0, 0x1, 0x1}, 0xc000480360}, {0xc00041c480, 0x6, ...})
        github.com/compose-spec/compose-go@v1.6.0/loader/loader.go:187 +0x892
github.com/compose-spec/compose-go/cli.ProjectFromOptions(0xc000498230)
        github.com/compose-spec/compose-go@v1.6.0/cli/options.go:358 +0x2e9
github.com/docker/compose/v2/cmd/compose.(*projectOptions).toProject(0xc000393700, {0x2f24c78, 0x0, 0x0}, {0xc000867960?, 0x8?, 0x0?})
        github.com/docker/compose/v2/cmd/compose/compose.go:185 +0x10f
github.com/docker/compose/v2/cmd/compose.runConvert({0x20a23a0?, 0xc00041c640}, {0x20b7578, 0xc0003bc0e0}, {0xc000393700, {0x1d91e19, 0x4}, {0x0, 0x0}, 0x0, ...}, ...)
        github.com/docker/compose/v2/cmd/compose/convert.go:117 +0x16a
github.com/docker/compose/v2/cmd/compose.convertCommand.func2({0x20a23a0?, 0xc00041c640?}, {0x2f24c78?, 0xc0000061a0?, 0x18bdcba?})
        github.com/docker/compose/v2/cmd/compose/convert.go:94 +0xdc
github.com/docker/compose/v2/cmd/compose.Adapt.func1({0x20a23a0?, 0xc00041c640?}, 0x2?, {0x2f24c78?, 0x1?, 0x0?})
        github.com/docker/compose/v2/cmd/compose/compose.go:90 +0x36
github.com/docker/compose/v2/cmd/compose.AdaptCmd.func1(0xc0001d0000, {0x2f24c78, 0x0, 0x0})
        github.com/docker/compose/v2/cmd/compose/compose.go:69 +0x21c
github.com/spf13/cobra.(*Command).execute(0xc0001d0000, {0xc00027d5d0, 0x0, 0x0})
        github.com/spf13/cobra@v1.6.0/command.go:916 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xc0003c5b00)
        github.com/spf13/cobra@v1.6.0/command.go:1040 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.6.0/command.go:968
github.com/docker/cli/cli-plugins/plugin.RunPlugin(0xc0002c8fc0?, 0xc0002d6300, {{0x1d92070, 0x5}, {0x1d9b150, 0xb}, {0x2081d28, 0x7}, {0x0, 0x0}, ...})
        github.com/docker/cli@v20.10.19+incompatible/cli-plugins/plugin/plugin.go:51 +0x130
github.com/docker/cli/cli-plugins/plugin.Run(0x1ea8680, {{0x1d92070, 0x5}, {0x1d9b150, 0xb}, {0x2081d28, 0x7}, {0x0, 0x0}, {0x0, ...}, ...})
        github.com/docker/cli@v20.10.19+incompatible/cli-plugins/plugin/plugin.go:64 +0xee
main.pluginMain()
        github.com/docker/compose/v2/cmd/main.go:36 +0xdf
main.main()
        github.com/docker/compose/v2/cmd/main.go:68 +0x198
```