### PR TITLE
schema: add tmpfs.mode field

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -406,6 +406,9 @@
                           {"type": "integer", "minimum": 0},
                           {"type": "string"}
                         ]
+                      },
+                      "mode": {
+                        "type": "number"
                       }
                     },
                     "additionalProperties": false,

--- a/types/types.go
+++ b/types/types.go
@@ -828,6 +828,8 @@ type ServiceVolumeVolume struct {
 type ServiceVolumeTmpfs struct {
 	Size UnitBytes `yaml:",omitempty" json:"size,omitempty"`
 
+	Mode uint32 `yaml:",omitempty" json:"mode,omitempty"`
+
 	Extensions map[string]interface{} `yaml:",inline" json:"-"`
 }
 


### PR DESCRIPTION
Schema included `size` for `tmpfs` mounts but not `mode`. This appears to have been an oversight.

See https://github.com/compose-spec/compose-spec/blob/1eb16a20675324b35258b74b8375b48399893eab/spec.md?plain=1#L1868-L1870.

Fixes #302.