### PR TITLE
prefer list format for extra_hosts to preserve backward compatibility

### DIFF
--- a/loader/full-example.yml
+++ b/loader/full-example.yml
@@ -160,8 +160,8 @@ services:
     #   somehost: "162.242.195.82"
     #   otherhost: "50.31.209.229"
     extra_hosts:
-      - "somehost:162.242.195.82"
       - "otherhost:50.31.209.229"
+      - "somehost:162.242.195.82"
 
     hostname: foo
 

--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -716,8 +716,8 @@ services:
     - project_db_1:mysql
     - project_db_1:postgresql
     extra_hosts:
-      otherhost: 50.31.209.229
-      somehost: 162.242.195.82
+    - otherhost:50.31.209.229
+    - somehost:162.242.195.82
     hostname: foo
     healthcheck:
       test:
@@ -1302,10 +1302,10 @@ func fullExampleJSON(workingDir, homeDir string) string {
         "project_db_1:mysql",
         "project_db_1:postgresql"
       ],
-      "extra_hosts": {
-        "otherhost": "50.31.209.229",
-        "somehost": "162.242.195.82"
-      },
+      "extra_hosts": [
+        "otherhost:50.31.209.229",
+        "somehost:162.242.195.82"
+      ],
       "hostname": "foo",
       "healthcheck": {
         "test": [

--- a/types/types.go
+++ b/types/types.go
@@ -539,6 +539,18 @@ func (h HostsList) AsList() []string {
 	return l
 }
 
+func (h HostsList) MarshalYAML() (interface{}, error) {
+	list := h.AsList()
+	sort.Strings(list)
+	return list, nil
+}
+
+func (h HostsList) MarshalJSON() ([]byte, error) {
+	list := h.AsList()
+	sort.Strings(list)
+	return json.Marshal(list)
+}
+
 // LoggingConfig the logging configuration for a service
 type LoggingConfig struct {
 	Driver  string            `yaml:",omitempty" json:"driver,omitempty"`


### PR DESCRIPTION
While map format is supported by Docker Compose v1, and proposed to be officially documented (https://github.com/compose-spec/compose-spec/pull/285), still most users rely on the list format and we should prefer this one to enforce backward compatibility.

close https://github.com/docker/compose/issues/10038