### PR TITLE
introduce ResolveServicesEnvironment and resolve service environment AFTER profiles have been applied

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -167,6 +167,14 @@ func WithLoadOptions(loadOptions ...func(*loader.Options)) ProjectOptionsFn {
 	}
 }
 
+// WithProfiles sets profiles to be activated
+func WithProfiles(profiles []string) ProjectOptionsFn {
+	return func(o *ProjectOptions) error {
+		o.loadOptions = append(o.loadOptions, loader.WithProfiles(profiles))
+		return nil
+	}
+}
+
 // WithOsEnv imports environment variables from OS
 func WithOsEnv(o *ProjectOptions) error {
 	for k, v := range utils.GetAsEqualsMap(os.Environ()) {

--- a/loader/normalize.go
+++ b/loader/normalize.go
@@ -85,6 +85,9 @@ func normalize(project *types.Project, resolvePaths bool) error {
 			}
 			s.Build.Args = s.Build.Args.Resolve(fn)
 		}
+		for j, f := range s.EnvFile {
+			s.EnvFile[j] = absPath(project.WorkingDir, f)
+		}
 		s.Environment = s.Environment.Resolve(fn)
 
 		err := relocateLogDriver(&s)

--- a/types/types.go
+++ b/types/types.go
@@ -482,6 +482,21 @@ func NewMapping(values []string) Mapping {
 	return mapping
 }
 
+// ToMappingWithEquals converts Mapping into a MappingWithEquals with pointer references
+func (m Mapping) ToMappingWithEquals() MappingWithEquals {
+	mapping := MappingWithEquals{}
+	for k, v := range m {
+		v := v
+		mapping[k] = &v
+	}
+	return mapping
+}
+
+func (m Mapping) Resolve(s string) (string, bool) {
+	v, ok := m[s]
+	return v, ok
+}
+
 // Labels is a mapping type for labels
 type Labels map[string]string
 


### PR DESCRIPTION
This introduces `WithProfiles` so the loader can directly apply selected profiles, and moves env_file loading logic to a later phase, so we won't try to load for services which have been disabled
Also introduce load option `SkipResolveEnvFiles` to fully bypass this and process `env_files` in a later phase

closes https://github.com/docker/compose/issues/8713