### PR TITLE
validate healthcheck is well configured

### DIFF
--- a/loader/validate.go
+++ b/loader/validate.go
@@ -38,6 +38,14 @@ func checkConsistency(project *types.Project) error {
 			}
 		}
 
+		if s.HealthCheck != nil && len(s.HealthCheck.Test) > 0 {
+			switch s.HealthCheck.Test[0] {
+			case "CMD", "CMD-SHELL", "NONE":
+			default:
+				return errors.New(`healthcheck.test must start either by "CMD", "CMD-SHELL" or "NONE"`)
+			}
+		}
+
 		for dependedService := range s.DependsOn {
 			if _, err := project.GetService(dependedService); err != nil {
 				return errors.Wrap(errdefs.ErrInvalid, fmt.Sprintf("service %q depends on undefined service %s", s.Name, dependedService))


### PR DESCRIPTION
Moby doesn't validate healthcheck type is set
This is confusing for users, as container is created without any error reported, but "service XXX has no healthcheck configured"

closes https://github.com/docker/compose/issues/10155