### PR TITLE
Allow brackets in env vars

### DIFF
--- a/dotenv/parser.go
+++ b/dotenv/parser.go
@@ -117,7 +117,7 @@ loop:
 			offset = i + 1
 			inherited = char == '\n'
 			break loop
-		case '_', '.', '-':
+		case '_', '.', '-', '[', ']':
 		default:
 			// variable name should match [A-Za-z0-9_.-]
 			if unicode.IsLetter(rchar) || unicode.IsNumber(rchar) {

--- a/dotenv/parser_test.go
+++ b/dotenv/parser_test.go
@@ -1,0 +1,33 @@
+package dotenv
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+var testInput = `
+a=b
+a[1]=c
+a.propertyKey=d
+`
+
+func TestParseBytes(t *testing.T) {
+	p := newParser()
+
+	var inputBytes = []byte(testInput)
+	expectedOutput := map[string]string{
+		"a":             "b",
+		"a[1]":          "c",
+		"a.propertyKey": "d",
+	}
+
+	out := map[string]string{}
+	err := p.parseBytes([]byte(inputBytes), out, nil)
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(expectedOutput), len(out))
+	for key, value := range expectedOutput {
+		assert.Equal(t, value, out[key])
+	}
+}


### PR DESCRIPTION
Signed-off-by: Laura Brehm <laurabrehm@hey.com>

Allows using environment variables containing square brackets, such as `kinesis.property[1].propertyId=1`, to align with V1 behavior.

Fixes https://github.com/compose-spec/compose-go/issues/337