### PR TITLE
env: fix path resolution with `extends`

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -190,7 +190,11 @@ func WithOsEnv(o *ProjectOptions) error {
 // WithEnvFile set an alternate env file
 // deprecated - use WithEnvFiles
 func WithEnvFile(file string) ProjectOptionsFn {
-	return WithEnvFiles(file)
+	var files []string
+	if file != "" {
+		files = []string{file}
+	}
+	return WithEnvFiles(files...)
 }
 
 // WithEnvFiles set alternate env files

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -583,6 +583,10 @@ func loadServiceWithExtends(filename, name string, servicesDict map[string]inter
 				}
 				baseService.Volumes[i].Source = resolveMaybeUnixPath(vol.Source, baseFileParent, lookupEnv)
 			}
+
+			for i, envFile := range baseService.EnvFile {
+				baseService.EnvFile[i] = resolveMaybeUnixPath(envFile, baseFileParent, lookupEnv)
+			}
 		}
 
 		serviceConfig, err = _merge(baseService, serviceConfig)

--- a/loader/normalize.go
+++ b/loader/normalize.go
@@ -90,6 +90,11 @@ func normalize(project *types.Project, resolvePaths bool) error {
 		}
 		s.Environment = s.Environment.Resolve(fn)
 
+		if extendFile := s.Extends["file"]; extendFile != nil && *extendFile != "" {
+			p := absPath(project.WorkingDir, *extendFile)
+			s.Extends["file"] = &p
+		}
+
 		err := relocateLogDriver(&s)
 		if err != nil {
 			return err

--- a/loader/testdata/compose-test-extends.yaml
+++ b/loader/testdata/compose-test-extends.yaml
@@ -1,5 +1,5 @@
 services:
   importer:
     extends:
-      file: compose-test-extends-imported.yaml
+      file: subdir/compose-test-extends-imported.yaml
       service: imported

--- a/loader/testdata/subdir/compose-test-extends-imported.yaml
+++ b/loader/testdata/subdir/compose-test-extends-imported.yaml
@@ -1,5 +1,7 @@
 services:
   imported:
     image: nginx
+    env_file:
+      - extra.env
     volumes:
       - /opt/data:/var/lib/mysql

--- a/loader/testdata/subdir/extra.env
+++ b/loader/testdata/subdir/extra.env
@@ -1,0 +1,1 @@
+SOURCE=extends

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -313,6 +313,7 @@ func TestMarshalServiceEntrypoint(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
* Fix an issue with `WithEnvFile` helper to not pass empty values
* Rewrite `env_file` paths from `extends` file to be relative to the included file rather than parent (this was a regression)
* Normalize `extends.file` path to be absolute when doing the same for other paths

See docker/compose#10258.