### PR TITLE
[demo] adopt goyaml/v3

### DIFF
--- a/interpolation/interpolation_test.go
+++ b/interpolation/interpolation_test.go
@@ -250,6 +250,6 @@ func TestPathMatches(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		assert.Check(t, is.Equal(testcase.expected, testcase.path.matches(testcase.pattern)))
+		assert.Check(t, is.Equal(testcase.expected, testcase.path.Matches(testcase.pattern)))
 	}
 }

--- a/loader/interpolate.go
+++ b/loader/interpolate.go
@@ -17,62 +17,58 @@
 package loader
 
 import (
-	"strconv"
-	"strings"
-
 	interp "github.com/compose-spec/compose-go/interpolation"
-	"github.com/pkg/errors"
 )
 
-var interpolateTypeCastMapping = map[interp.Path]interp.Cast{
-	servicePath("configs", interp.PathMatchList, "mode"):             toInt,
-	servicePath("cpu_count"):                                         toInt64,
-	servicePath("cpu_percent"):                                       toFloat,
-	servicePath("cpu_period"):                                        toInt64,
-	servicePath("cpu_quota"):                                         toInt64,
-	servicePath("cpu_rt_period"):                                     toInt64,
-	servicePath("cpu_rt_runtime"):                                    toInt64,
-	servicePath("cpus"):                                              toFloat32,
-	servicePath("cpu_shares"):                                        toInt64,
-	servicePath("init"):                                              toBoolean,
-	servicePath("deploy", "replicas"):                                toInt,
-	servicePath("deploy", "update_config", "parallelism"):            toInt,
-	servicePath("deploy", "update_config", "max_failure_ratio"):      toFloat,
-	servicePath("deploy", "rollback_config", "parallelism"):          toInt,
-	servicePath("deploy", "rollback_config", "max_failure_ratio"):    toFloat,
-	servicePath("deploy", "restart_policy", "max_attempts"):          toInt,
-	servicePath("deploy", "placement", "max_replicas_per_node"):      toInt,
-	servicePath("healthcheck", "retries"):                            toInt,
-	servicePath("healthcheck", "disable"):                            toBoolean,
-	servicePath("mem_limit"):                                         toUnitBytes,
-	servicePath("mem_reservation"):                                   toUnitBytes,
-	servicePath("memswap_limit"):                                     toUnitBytes,
-	servicePath("mem_swappiness"):                                    toUnitBytes,
-	servicePath("oom_kill_disable"):                                  toBoolean,
-	servicePath("oom_score_adj"):                                     toInt64,
-	servicePath("pids_limit"):                                        toInt64,
-	servicePath("ports", interp.PathMatchList, "target"):             toInt,
-	servicePath("privileged"):                                        toBoolean,
-	servicePath("read_only"):                                         toBoolean,
-	servicePath("scale"):                                             toInt,
-	servicePath("secrets", interp.PathMatchList, "mode"):             toInt,
-	servicePath("shm_size"):                                          toUnitBytes,
-	servicePath("stdin_open"):                                        toBoolean,
-	servicePath("stop_grace_period"):                                 toDuration,
-	servicePath("tty"):                                               toBoolean,
-	servicePath("ulimits", interp.PathMatchAll):                      toInt,
-	servicePath("ulimits", interp.PathMatchAll, "hard"):              toInt,
-	servicePath("ulimits", interp.PathMatchAll, "soft"):              toInt,
-	servicePath("volumes", interp.PathMatchList, "read_only"):        toBoolean,
-	servicePath("volumes", interp.PathMatchList, "volume", "nocopy"): toBoolean,
-	servicePath("volumes", interp.PathMatchList, "tmpfs", "size"):    toUnitBytes,
-	iPath("networks", interp.PathMatchAll, "external"):               toBoolean,
-	iPath("networks", interp.PathMatchAll, "internal"):               toBoolean,
-	iPath("networks", interp.PathMatchAll, "attachable"):             toBoolean,
-	iPath("networks", interp.PathMatchAll, "enable_ipv6"):            toBoolean,
-	iPath("volumes", interp.PathMatchAll, "external"):                toBoolean,
-	iPath("secrets", interp.PathMatchAll, "external"):                toBoolean,
-	iPath("configs", interp.PathMatchAll, "external"):                toBoolean,
+var interpolateTypeCastMapping = map[interp.Path]string{
+	servicePath("configs", interp.PathMatchList, "mode"):             "!!int",
+	servicePath("cpu_count"):                                         "!!int",
+	servicePath("cpu_percent"):                                       "!!float",
+	servicePath("cpu_period"):                                        "!!int",
+	servicePath("cpu_quota"):                                         "!!int",
+	servicePath("cpu_rt_period"):                                     "!!int",
+	servicePath("cpu_rt_runtime"):                                    "!!int",
+	servicePath("cpus"):                                              "!!float",
+	servicePath("cpu_shares"):                                        "!!int",
+	servicePath("init"):                                              "!!bool",
+	servicePath("deploy", "replicas"):                                "!!int",
+	servicePath("deploy", "update_config", "parallelism"):            "!!int",
+	servicePath("deploy", "update_config", "max_failure_ratio"):      "!!float",
+	servicePath("deploy", "rollback_config", "parallelism"):          "!!int",
+	servicePath("deploy", "rollback_config", "max_failure_ratio"):    "!!float",
+	servicePath("deploy", "restart_policy", "max_attempts"):          "!!int",
+	servicePath("deploy", "placement", "max_replicas_per_node"):      "!!int",
+	servicePath("healthcheck", "retries"):                            "!!int",
+	servicePath("healthcheck", "disable"):                            "!!bool",
+	servicePath("mem_limit"):                                         "!!int",
+	servicePath("mem_reservation"):                                   "!!int",
+	servicePath("memswap_limit"):                                     "!!int",
+	servicePath("mem_swappiness"):                                    "!!int",
+	servicePath("oom_kill_disable"):                                  "!!bool",
+	servicePath("oom_score_adj"):                                     "!!int",
+	servicePath("pids_limit"):                                        "!!int",
+	servicePath("ports", interp.PathMatchList, "target"):             "!!int",
+	servicePath("privileged"):                                        "!!bool",
+	servicePath("read_only"):                                         "!!bool",
+	servicePath("scale"):                                             "!!int",
+	servicePath("secrets", interp.PathMatchList, "mode"):             "!!int",
+	servicePath("shm_size"):                                          "!!str",
+	servicePath("stdin_open"):                                        "!!bool",
+	servicePath("stop_grace_period"):                                 "!!str",
+	servicePath("tty"):                                               "!!bool",
+	servicePath("ulimits", interp.PathMatchAll):                      "!!int",
+	servicePath("ulimits", interp.PathMatchAll, "hard"):              "!!int",
+	servicePath("ulimits", interp.PathMatchAll, "soft"):              "!!int",
+	servicePath("volumes", interp.PathMatchList, "read_only"):        "!!bool",
+	servicePath("volumes", interp.PathMatchList, "volume", "nocopy"): "!!bool",
+	servicePath("volumes", interp.PathMatchList, "tmpfs", "size"):    "!!int",
+	iPath("networks", interp.PathMatchAll, "external"):               "!!bool",
+	iPath("networks", interp.PathMatchAll, "internal"):               "!!bool",
+	iPath("networks", interp.PathMatchAll, "attachable"):             "!!bool",
+	iPath("networks", interp.PathMatchAll, "enable_ipv6"):            "!!bool",
+	iPath("volumes", interp.PathMatchAll, "external"):                "!!bool",
+	iPath("secrets", interp.PathMatchAll, "external"):                "!!bool",
+	iPath("configs", interp.PathMatchAll, "external"):                "!!bool",
 }
 
 func iPath(parts ...string) interp.Path {
@@ -81,44 +77,4 @@ func iPath(parts ...string) interp.Path {
 
 func servicePath(parts ...string) interp.Path {
 	return iPath(append([]string{"services", interp.PathMatchAll}, parts...)...)
-}
-
-func toInt(value string) (interface{}, error) {
-	return strconv.Atoi(value)
-}
-
-func toInt64(value string) (interface{}, error) {
-	return strconv.ParseInt(value, 10, 64)
-}
-
-func toUnitBytes(value string) (interface{}, error) {
-	return transformSize(value)
-}
-
-func toDuration(value string) (interface{}, error) {
-	return transformStringToDuration(value)
-}
-
-func toFloat(value string) (interface{}, error) {
-	return strconv.ParseFloat(value, 64)
-}
-
-func toFloat32(value string) (interface{}, error) {
-	f, err := strconv.ParseFloat(value, 32)
-	if err != nil {
-		return nil, err
-	}
-	return float32(f), nil
-}
-
-// should match http://yaml.org/type/bool.html
-func toBoolean(value string) (interface{}, error) {
-	switch strings.ToLower(value) {
-	case "y", "yes", "true", "on":
-		return true, nil
-	case "n", "no", "false", "off":
-		return false, nil
-	default:
-		return nil, errors.Errorf("invalid boolean: %s", value)
-	}
 }

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -262,7 +262,7 @@ var sampleConfig = types.Config{
 }
 
 func TestParseYAML(t *testing.T) {
-	dict, err := ParseYAML([]byte(sampleYAML))
+	dict, err := ParseYAML([]byte(sampleYAML), nil)
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(sampleDict, dict))
 }
@@ -660,7 +660,7 @@ services:
       nofile:
         hard: $theint
         soft: $theint
-    privileged: $thebool
+    privileged: true
     read_only: $thebool
     shm_size: ${thesize}
     stop_grace_period: ${theduration}


### PR DESCRIPTION
this is for demonstration purpose only
uses goyaml/v3 `UnmarshalYAML(node *yaml.Node)` to process nodes as they are loaded and substitute variables
Same approach allow:
- transform "short syntax" into "long syntax" and get direct mapping into go structs, without the need to rely on mapstructure.
- merge of yaml.Node trees before converting into go structs, so we can manage nil overrides (and few other corner cases)