### PR TITLE
Apply package name constraints to env vars, dirs

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -18,7 +18,6 @@ package cli
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -64,9 +63,9 @@ func NewProjectOptions(configs []string, opts ...ProjectOptionsFn) (*ProjectOpti
 // WithName defines ProjectOptions' name
 func WithName(name string) ProjectOptionsFn {
 	return func(o *ProjectOptions) error {
-		if name != loader.NormalizeProjectName(name) {
-			return fmt.Errorf("%q is not a valid project name: it must contain "+
-				"only characters from [a-z0-9_-] and start with [a-z0-9]", name)
+		normalized := loader.NormalizeProjectName(name)
+		if err := loader.CheckOriginalProjectNameIsNormalized(name, normalized); err != nil {
+			return err
 		}
 		o.Name = name
 		return nil

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -52,6 +52,20 @@ func TestProjectName(t *testing.T) {
 		assert.Equal(t, p.Name, "42my_project_env")
 	})
 
+	t.Run("by name must not be empty", func(t *testing.T) {
+		_, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithName(""))
+		assert.ErrorContains(t, err, `project name must not be empty`)
+	})
+
+	t.Run("by name must not come from root directory", func(t *testing.T) {
+		opts, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"},
+			WithWorkingDirectory("/"))
+		assert.NilError(t, err)
+		p, err := ProjectFromOptions(opts)
+		assert.ErrorContains(t, err, `"/" is not a valid project name`)
+		assert.Assert(t, p == nil)
+	})
+
 	t.Run("by name start with invalid char '-'", func(t *testing.T) {
 		_, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithName("-my_project"))
 		assert.ErrorContains(t, err, `"-my_project" is not a valid project name`)

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -62,7 +62,10 @@ func TestProjectName(t *testing.T) {
 			WithWorkingDirectory("/"))
 		assert.NilError(t, err)
 		p, err := ProjectFromOptions(opts)
-		assert.ErrorContains(t, err, `"/" is not a valid project name`)
+
+		// On macOS and Linux, the message will start with "/". On Windows, it will
+		// start with "\\\\". So we leave that part of the error off here.
+		assert.ErrorContains(t, err, `is not a valid project name`)
 		assert.Assert(t, p == nil)
 	})
 

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -61,8 +61,8 @@ func TestProjectName(t *testing.T) {
 		}))
 		assert.NilError(t, err)
 		p, err := ProjectFromOptions(opts)
-		assert.NilError(t, err)
-		assert.Equal(t, p.Name, "my_project")
+		assert.ErrorContains(t, err, `"-my_project" is not a valid project name`)
+		assert.Assert(t, p == nil)
 	})
 
 	t.Run("by name start with invalid char '_'", func(t *testing.T) {
@@ -74,8 +74,8 @@ func TestProjectName(t *testing.T) {
 		}))
 		assert.NilError(t, err)
 		p, err := ProjectFromOptions(opts)
-		assert.NilError(t, err)
-		assert.Equal(t, p.Name, "my_project")
+		assert.ErrorContains(t, err, `"_my_project" is not a valid project name`)
+		assert.Assert(t, p == nil)
 	})
 
 	t.Run("by name contains dots", func(t *testing.T) {
@@ -87,8 +87,8 @@ func TestProjectName(t *testing.T) {
 		}))
 		assert.NilError(t, err)
 		p, err := ProjectFromOptions(opts)
-		assert.NilError(t, err)
-		assert.Equal(t, p.Name, "wwwmyproject")
+		assert.ErrorContains(t, err, `"www.my.project" is not a valid project name`)
+		assert.Assert(t, p == nil)
 	})
 
 	t.Run("by name uppercase", func(t *testing.T) {
@@ -96,12 +96,12 @@ func TestProjectName(t *testing.T) {
 		assert.ErrorContains(t, err, `"MY_PROJECT" is not a valid project name`)
 
 		opts, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithEnv([]string{
-			fmt.Sprintf("%s=%s", consts.ComposeProjectName, "_my_project"),
+			fmt.Sprintf("%s=%s", consts.ComposeProjectName, "MY_PROJECT"),
 		}))
 		assert.NilError(t, err)
 		p, err := ProjectFromOptions(opts)
-		assert.NilError(t, err)
-		assert.Equal(t, p.Name, "my_project")
+		assert.ErrorContains(t, err, `"MY_PROJECT" is not a valid project name`)
+		assert.Assert(t, p == nil)
 	})
 
 	t.Run("by working dir", func(t *testing.T) {

--- a/cli/options_windows_test.go
+++ b/cli/options_windows_test.go
@@ -28,13 +28,13 @@ func TestConvertWithEnvVar(t *testing.T) {
 	defer os.Unsetenv("COMPOSE_CONVERT_WINDOWS_PATHS")
 	opts, _ := NewProjectOptions([]string{"testdata/simple/compose-with-paths.yaml"},
 		WithOsEnv,
-		WithWorkingDirectory("C:\\\\"))
+		WithWorkingDirectory("C:\\project-dir\\"))
 
 	p, err := ProjectFromOptions(opts)
 
 	assert.NilError(t, err)
 	assert.Equal(t, len(p.Services[0].Volumes), 3)
 	assert.Equal(t, p.Services[0].Volumes[0].Source, "/c/docker/project")
-	assert.Equal(t, p.Services[0].Volumes[1].Source, "/c/relative")
-	assert.Equal(t, p.Services[0].Volumes[2].Source, "/c/relative2")
+	assert.Equal(t, p.Services[0].Volumes[1].Source, "/c/project-dir/relative")
+	assert.Equal(t, p.Services[0].Volumes[2].Source, "/c/project-dir/relative2")
 }

--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -1047,6 +1047,7 @@ func fullExampleJSON(workingDir, homeDir string) string {
       "external": false
     }
   },
+  "name": "full_example_project_name",
   "networks": {
     "external-network": {
       "name": "external-network",

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -64,6 +64,8 @@ type Options struct {
 	projectName string
 	// Indicates when the projectName was imperatively set or guessed from path
 	projectNameImperativelySet bool
+	// The value of projectName before normalization
+	projectNameBeforeNormalization string
 	// Profiles set profiles to enable
 	Profiles []string
 }
@@ -71,6 +73,7 @@ type Options struct {
 func (o *Options) SetProjectName(name string, imperativelySet bool) {
 	o.projectName = NormalizeProjectName(name)
 	o.projectNameImperativelySet = imperativelySet
+	o.projectNameBeforeNormalization = name
 }
 
 func (o Options) GetProjectName() (string, bool) {
@@ -264,8 +267,18 @@ func Load(configDetails types.ConfigDetails, options ...func(*Options)) (*types.
 	return project, err
 }
 
+func CheckOriginalProjectNameIsNormalized(original, normalized string) error {
+	if original != normalized {
+		return fmt.Errorf("%q is not a valid project name: it must contain only "+
+			"characters from [a-z0-9_-] and start with [a-z0-9]", original)
+	}
+	return nil
+}
+
 func projectName(details types.ConfigDetails, opts *Options) (string, error) {
 	projectName, projectNameImperativelySet := opts.GetProjectName()
+	projectNameBeforeNormalization := opts.projectNameBeforeNormalization
+
 	var pjNameFromConfigFile string
 
 	for _, configFile := range details.ConfigFiles {
@@ -284,9 +297,15 @@ func projectName(details types.ConfigDetails, opts *Options) (string, error) {
 		}
 		pjNameFromConfigFile = interpolated["name"].(string)
 	}
-	pjNameFromConfigFile = NormalizeProjectName(pjNameFromConfigFile)
-	if !projectNameImperativelySet && pjNameFromConfigFile != "" {
-		projectName = pjNameFromConfigFile
+	pjNameFromConfigFileNormalized := NormalizeProjectName(pjNameFromConfigFile)
+	if !projectNameImperativelySet && pjNameFromConfigFileNormalized != "" {
+		projectName = pjNameFromConfigFileNormalized
+		projectNameBeforeNormalization = pjNameFromConfigFile
+	}
+
+	if err := CheckOriginalProjectNameIsNormalized(
+		projectNameBeforeNormalization, projectName); err != nil {
+		return "", err
 	}
 
 	if _, ok := details.Environment[consts.ComposeProjectName]; !ok && projectName != "" {

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -271,6 +271,8 @@ func CheckOriginalProjectNameIsNormalized(original, normalized string) error {
 	if original != normalized {
 		return fmt.Errorf("%q is not a valid project name: it must contain only "+
 			"characters from [a-z0-9_-] and start with [a-z0-9]", original)
+	} else if normalized == "" {
+		return fmt.Errorf("project name must not be empty")
 	}
 	return nil
 }

--- a/loader/testdata/compose-test-extends-with-context-url.yaml
+++ b/loader/testdata/compose-test-extends-with-context-url.yaml
@@ -1,3 +1,4 @@
+name: compose-test-extends-with-context-url
 services:
   importer-with-https-url:
     extends:

--- a/loader/testdata/compose-test-extends.yaml
+++ b/loader/testdata/compose-test-extends.yaml
@@ -1,3 +1,4 @@
+name: compose-test-extends
 services:
   importer:
     extends:

--- a/loader/testdata/compose-test-with-version.yaml
+++ b/loader/testdata/compose-test-with-version.yaml
@@ -1,4 +1,5 @@
 version: "2"
+name: compose-test-with-version
 
 volumes:
   data:

--- a/types/project.go
+++ b/types/project.go
@@ -457,6 +457,7 @@ func (p *Project) MarshalYAML() ([]byte, error) {
 // MarshalJSON makes Config implement json.Marshaler
 func (p *Project) MarshalJSON() ([]byte, error) {
 	m := map[string]interface{}{
+		"name":     p.Name,
 		"services": p.Services,
 	}
 


### PR DESCRIPTION
Applies the constraints articulated in compose-spec/compose-spec#314 for project names from `COMPOSE_PROJECT_NAME`, the project dir, or the working dir.

Before this change, the constraints applied only when using `docker compose -p` or the `name:` config file property. Non-normalized project names from `COMPOSE_PROJECT_NAME`, the project dir, or the working dir were still allowed, which `docker compose` would then normalize.

The constraints are enforced by:

- `cli.ProjectFromOptions()` setting `withNamePrecedenceLoad()` as an option to `loader.Load()`.
- `loader.Load()` applies `withNamePrecedenceLoad()`, which tries to get the project name from the command line options, then `COMPOSE_PROJECT_NAME`, then the project or working dir.
- `withNamePrecedenceLoad()` calls `loader.Options.SetProjectName()`, which now also saves the original name as well as the normalized name.
- `loader.Load()` then calls `loader.projectName()`, which reads the project name from the config file(s) if it's not already set.
- `loader.projectName()` then applies the new `CheckOriginalProjectNameIsNormalized()` function extracted from `cli.WithName()`.

Only a handful of test cases required updating in `cli/options_test.go`. These test cases were checking that invalid project names were rejected by `cli.WithName()`, but that `cli.ProjectFromOptions()` would normalize them. Now `cli.ProjectFromOptions()` rejects them with the same error.

There's no need for new test cases specifically for `COMPOSE_PROJECT_NAME` or directory-based project names, because the `CheckOriginalProjectNameIsNormalized()` function is applied regardless of the source. Other existing test cases are validating that `cli.ProjectFromOptions` does also use `COMPOSE_PROJECT_NAME` or directory names when necessary.

Closes #363.