### PR TITLE
introduce `dockerfile_inline`

### DIFF
--- a/loader/normalize.go
+++ b/loader/normalize.go
@@ -72,7 +72,7 @@ func Normalize(project *types.Project, resolvePaths bool) error {
 		}
 
 		if s.Build != nil {
-			if s.Build.Dockerfile == "" {
+			if s.Build.Dockerfile == "" && s.Build.DockerfileInline == "" {
 				s.Build.Dockerfile = "Dockerfile"
 			}
 			localContext := absPath(project.WorkingDir, s.Build.Context)

--- a/loader/validate.go
+++ b/loader/validate.go
@@ -32,6 +32,12 @@ func checkConsistency(project *types.Project) error {
 			return errors.Wrapf(errdefs.ErrInvalid, "service %q has neither an image nor a build context specified", s.Name)
 		}
 
+		if s.Build != nil {
+			if s.Build.DockerfileInline != "" && s.Build.Dockerfile != "" {
+				return errors.Wrapf(errdefs.ErrInvalid, "service %q declares mutualy exclusive dockerfile and dockerfile_inline", s.Name)
+			}
+		}
+
 		for network := range s.Networks {
 			if _, ok := project.Networks[network]; !ok {
 				return errors.Wrap(errdefs.ErrInvalid, fmt.Sprintf("service %q refers to undefined network %s", s.Name, network))

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -91,6 +91,7 @@
               "properties": {
                 "context": {"type": "string"},
                 "dockerfile": {"type": "string"},
+                "dockerfile_inline": {"type": "string"},
                 "args": {"$ref": "#/definitions/list_or_dict"},
                 "ssh": {"$ref": "#/definitions/list_or_dict"},
                 "labels": {"$ref": "#/definitions/list_or_dict"},

--- a/types/types.go
+++ b/types/types.go
@@ -296,6 +296,7 @@ func (s set) toSlice() []string {
 type BuildConfig struct {
 	Context            string                `yaml:",omitempty" json:"context,omitempty"`
 	Dockerfile         string                `yaml:",omitempty" json:"dockerfile,omitempty"`
+	DockerfileInline   string                `yaml:",omitempty" json:"dockerfile_inline,omitempty"`
 	Args               MappingWithEquals     `yaml:",omitempty" json:"args,omitempty"`
 	SSH                SSHConfig             `yaml:"ssh,omitempty" json:"ssh,omitempty"`
 	Labels             Labels                `yaml:",omitempty" json:"labels,omitempty"`


### PR DESCRIPTION
Add support for `dockerfile_inline` to define Dockerfile as inlined content in the compose file.

See:
- Spec update https://github.com/compose-spec/compose-spec/pull/315 
- Use in reference implementation https://github.com/docker/compose/pull/10343