### PR TITLE
remove `extends` from model after service has been extended

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1934,19 +1934,10 @@ func TestLoadWithExtends(t *testing.T) {
 
 	expectedEnvFilePath := filepath.Join(extendsDir, "extra.env")
 
-	expectedExtendsPath := filepath.Join(
-		extendsDir,
-		"compose-test-extends-imported.yaml",
-	)
-
 	expServices := types.Services{
 		{
 			Name:  "importer",
 			Image: "nginx",
-			Extends: types.ExtendsConfig{
-				"file":    &expectedExtendsPath,
-				"service": strPtr("imported"),
-			},
 			Environment: types.MappingWithEquals{
 				"SOURCE": strPtr("extends"),
 			},
@@ -1979,23 +1970,12 @@ func TestLoadWithExtendsWithContextUrl(t *testing.T) {
 	actual, err := Load(configDetails)
 	assert.NilError(t, err)
 
-	expectedExtendsPath, err := filepath.Abs(
-		filepath.Join(
-			"testdata",
-			"compose-test-extends-with-context-url-imported.yaml",
-		),
-	)
-	assert.NilError(t, err)
 	expServices := types.Services{
 		{
 			Name: "importer-with-https-url",
 			Build: &types.BuildConfig{
 				Context:    "https://github.com/docker/compose.git",
 				Dockerfile: "Dockerfile",
-			},
-			Extends: types.ExtendsConfig{
-				"file":    &expectedExtendsPath,
-				"service": strPtr("imported-with-https-url"),
 			},
 			Environment: types.MappingWithEquals{},
 			Networks:    map[string]*types.ServiceNetworkConfig{"default": nil},
@@ -2304,6 +2284,7 @@ volumes:
 
 func TestLoadServiceExtension(t *testing.T) {
 	dict := `
+name: test
 services:
   extension: # this name should be allowed
     image: web

--- a/loader/normalize.go
+++ b/loader/normalize.go
@@ -91,9 +91,8 @@ func Normalize(project *types.Project, resolvePaths bool) error {
 		}
 		s.Environment = s.Environment.Resolve(fn)
 
-		if extendFile := s.Extends["file"]; extendFile != nil && *extendFile != "" {
-			p := absPath(project.WorkingDir, *extendFile)
-			s.Extends["file"] = &p
+		if s.Extends != nil && s.Extends.File != "" {
+			s.Extends.File = absPath(project.WorkingDir, s.Extends.File)
 		}
 
 		for _, link := range s.Links {

--- a/loader/testdata/subdir/compose-test-extends-imported.yaml
+++ b/loader/testdata/subdir/compose-test-extends-imported.yaml
@@ -2,6 +2,6 @@ services:
   imported:
     image: nginx
     env_file:
-      - extra.env
+      - ./extra.env # expected to be loaded relative to this file, not the extending one
     volumes:
       - /opt/data:/var/lib/mysql

--- a/types/types.go
+++ b/types/types.go
@@ -132,7 +132,7 @@ type ServiceConfig struct {
 	Environment     MappingWithEquals                `yaml:",omitempty" json:"environment,omitempty"`
 	EnvFile         StringList                       `mapstructure:"env_file" yaml:"env_file,omitempty" json:"env_file,omitempty"`
 	Expose          StringOrNumberList               `yaml:",omitempty" json:"expose,omitempty"`
-	Extends         ExtendsConfig                    `yaml:"extends,omitempty" json:"extends,omitempty"`
+	Extends         *ExtendsConfig                   `yaml:"extends,omitempty" json:"extends,omitempty"`
 	ExternalLinks   []string                         `mapstructure:"external_links" yaml:"external_links,omitempty" json:"external_links,omitempty"`
 	ExtraHosts      HostsList                        `mapstructure:"extra_hosts" yaml:"extra_hosts,omitempty" json:"extra_hosts,omitempty"`
 	GroupAdd        []string                         `mapstructure:"group_add" yaml:"group_add,omitempty" json:"group_add,omitempty"`
@@ -1008,7 +1008,10 @@ type ServiceDependency struct {
 	Extensions Extensions `mapstructure:"#extensions" yaml:",inline" json:"-"`
 }
 
-type ExtendsConfig MappingWithEquals
+type ExtendsConfig struct {
+	File    string `yaml:",omitempty" json:"file,omitempty"`
+	Service string `yaml:",omitempty" json:"service,omitempty"`
+}
 
 // SecretConfig for a secret
 type SecretConfig FileObjectConfig


### PR DESCRIPTION
- Makes `ExtendsConfig` a struct (not sure why this was set as a MappingWithEquals, while the json schema is strict)
- Removes `extends` attribute from model after service has been extended, so that we return the actual service definition.
- Fix broken test on master 😅