### PR TITLE
cli: allow setting empty name in options (to infer)

### DIFF
--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -22,9 +22,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/compose-spec/compose-go/consts"
 	"github.com/compose-spec/compose-go/utils"
-	"gotest.tools/v3/assert"
 )
 
 func TestProjectName(t *testing.T) {
@@ -52,9 +53,27 @@ func TestProjectName(t *testing.T) {
 		assert.Equal(t, p.Name, "42my_project_env")
 	})
 
-	t.Run("by name must not be empty", func(t *testing.T) {
-		_, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithName(""))
-		assert.ErrorContains(t, err, `project name must not be empty`)
+	t.Run("by name empty", func(t *testing.T) {
+		opts, err := NewProjectOptions(
+			[]string{"testdata/simple/compose.yaml"},
+			WithName(""),
+		)
+		assert.NilError(t, err)
+		p, err := ProjectFromOptions(opts)
+		assert.NilError(t, err)
+		assert.Equal(t, p.Name, "simple")
+	})
+
+	t.Run("by name empty working dir", func(t *testing.T) {
+		opts, err := NewProjectOptions(
+			[]string{"testdata/simple/compose.yaml"},
+			WithName(""),
+			WithWorkingDirectory("/path/to/proj"),
+		)
+		assert.NilError(t, err)
+		p, err := ProjectFromOptions(opts)
+		assert.NilError(t, err)
+		assert.Equal(t, p.Name, "proj")
 	})
 
 	t.Run("by name must not come from root directory", func(t *testing.T) {


### PR DESCRIPTION
The `ProjectOptions` includes config to pass to the loader, but most of the fields, including `Name`, are optional. If unset/empty, the loader will determine a project name (if possible).

Allow (re-)setting it to empty here. This is mostly for convenience based on the way these helpers are used in practice, so that it's possible to pass a value from e.g. a CLI flag in, which will be empty if unset.

Also added a bunch of documentation to the type.