### PR TITLE
loader: fix overly aggressive project name validation

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -103,11 +103,8 @@ func WithName(name string) ProjectOptionsFn {
 		// however, on the options object, the name is optional: if unset,
 		// a name will be inferred by the loader, so it's legal to set the
 		// name to an empty string here
-		if name != "" {
-			normalized := loader.NormalizeProjectName(name)
-			if err := loader.CheckOriginalProjectNameIsNormalized(name, normalized); err != nil {
-				return err
-			}
+		if name != loader.NormalizeProjectName(name) {
+			return loader.InvalidProjectNameErr(name)
 		}
 		o.Name = name
 		return nil
@@ -439,7 +436,10 @@ func withNamePrecedenceLoad(absWorkingDir string, options *ProjectOptions) func(
 		} else if nameFromEnv, ok := options.Environment[consts.ComposeProjectName]; ok && nameFromEnv != "" {
 			opts.SetProjectName(nameFromEnv, true)
 		} else {
-			opts.SetProjectName(filepath.Base(absWorkingDir), false)
+			opts.SetProjectName(
+				loader.NormalizeProjectName(filepath.Base(absWorkingDir)),
+				false,
+			)
 		}
 	}
 }

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -82,9 +82,9 @@ func TestProjectName(t *testing.T) {
 		assert.NilError(t, err)
 		p, err := ProjectFromOptions(opts)
 
-		// On macOS and Linux, the message will start with "/". On Windows, it will
-		// start with "\\\\". So we leave that part of the error off here.
-		assert.ErrorContains(t, err, `is not a valid project name`)
+		// root directory will resolve to an empty project name since there
+		// IS no directory name!
+		assert.ErrorContains(t, err, `project name must not be empty`)
 		assert.Assert(t, p == nil)
 	})
 
@@ -154,6 +154,14 @@ func TestProjectName(t *testing.T) {
 		p, err := ProjectFromOptions(opts)
 		assert.NilError(t, err)
 		assert.Equal(t, p.Name, "simple")
+	})
+
+	t.Run("by compose file parent dir special", func(t *testing.T) {
+		opts, err := NewProjectOptions([]string{"testdata/UNNORMALIZED PATH/compose.yaml"})
+		assert.NilError(t, err)
+		p, err := ProjectFromOptions(opts)
+		assert.NilError(t, err)
+		assert.Equal(t, p.Name, "unnormalizedpath")
 	})
 
 	t.Run("by COMPOSE_PROJECT_NAME", func(t *testing.T) {

--- a/cli/testdata/UNNORMALIZED PATH/compose.yaml
+++ b/cli/testdata/UNNORMALIZED PATH/compose.yaml
@@ -1,0 +1,3 @@
+services:
+  nginx:
+    image: nginx


### PR DESCRIPTION
There were cases where the loader would infer a perfectly valid project name by normalizing a directory, but would then re-validate the un-normalized project directory and throw an error.

This moves all the validation into a single spot during the load, which is the only point that it has all the context.

Some of this logic needs to be pushed out of here: it should NOT be reading the config files, for example.

For now, this resolves the main issues.