### PR TITLE
transform and merge yaml trees before mapping to go structs

### DIFF
--- a/interpolation/interpolation.go
+++ b/interpolation/interpolation.go
@@ -18,9 +18,9 @@ package interpolation
 
 import (
 	"os"
-	"strings"
 
 	"github.com/compose-spec/compose-go/template"
+	. "github.com/compose-spec/compose-go/tree"
 	"github.com/pkg/errors"
 )
 
@@ -122,54 +122,9 @@ func newPathError(path Path, err error) error {
 	}
 }
 
-const pathSeparator = "."
-
-// PathMatchAll is a token used as part of a Path to match any key at that level
-// in the nested structure
-const PathMatchAll = "*"
-
-// PathMatchList is a token used as part of a Path to match items in a list
-const PathMatchList = "[]"
-
-// Path is a dotted path of keys to a value in a nested mapping structure. A *
-// section in a path will match any key in the mapping structure.
-type Path string
-
-// NewPath returns a new Path
-func NewPath(items ...string) Path {
-	return Path(strings.Join(items, pathSeparator))
-}
-
-// Next returns a new path by append part to the current path
-func (p Path) Next(part string) Path {
-	return Path(string(p) + pathSeparator + part)
-}
-
-func (p Path) parts() []string {
-	return strings.Split(string(p), pathSeparator)
-}
-
-func (p Path) matches(pattern Path) bool {
-	patternParts := pattern.parts()
-	parts := p.parts()
-
-	if len(patternParts) != len(parts) {
-		return false
-	}
-	for index, part := range parts {
-		switch patternParts[index] {
-		case PathMatchAll, part:
-			continue
-		default:
-			return false
-		}
-	}
-	return true
-}
-
 func (o Options) getCasterForPath(path Path) (Cast, bool) {
 	for pattern, caster := range o.TypeCastMapping {
-		if path.matches(pattern) {
+		if path.Matches(pattern) {
 			return caster, true
 		}
 	}

--- a/interpolation/interpolation_test.go
+++ b/interpolation/interpolation_test.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"testing"
 
+	. "github.com/compose-spec/compose-go/tree"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -207,49 +208,4 @@ func TestInterpolateWithCast(t *testing.T) {
 		},
 	}
 	assert.Check(t, is.DeepEqual(expected, result))
-}
-
-func TestPathMatches(t *testing.T) {
-	var testcases = []struct {
-		doc      string
-		path     Path
-		pattern  Path
-		expected bool
-	}{
-		{
-			doc:     "pattern too short",
-			path:    NewPath("one", "two", "three"),
-			pattern: NewPath("one", "two"),
-		},
-		{
-			doc:     "pattern too long",
-			path:    NewPath("one", "two"),
-			pattern: NewPath("one", "two", "three"),
-		},
-		{
-			doc:     "pattern mismatch",
-			path:    NewPath("one", "three", "two"),
-			pattern: NewPath("one", "two", "three"),
-		},
-		{
-			doc:     "pattern mismatch with match-all part",
-			path:    NewPath("one", "three", "two"),
-			pattern: NewPath(PathMatchAll, "two", "three"),
-		},
-		{
-			doc:      "pattern match with match-all part",
-			path:     NewPath("one", "two", "three"),
-			pattern:  NewPath("one", "*", "three"),
-			expected: true,
-		},
-		{
-			doc:      "pattern match",
-			path:     NewPath("one", "two", "three"),
-			pattern:  NewPath("one", "two", "three"),
-			expected: true,
-		},
-	}
-	for _, testcase := range testcases {
-		assert.Check(t, is.Equal(testcase.expected, testcase.path.matches(testcase.pattern)))
-	}
 }

--- a/loader/interpolate.go
+++ b/loader/interpolate.go
@@ -21,66 +21,67 @@ import (
 	"strings"
 
 	interp "github.com/compose-spec/compose-go/interpolation"
+	"github.com/compose-spec/compose-go/tree"
 	"github.com/pkg/errors"
 )
 
-var interpolateTypeCastMapping = map[interp.Path]interp.Cast{
-	servicePath("configs", interp.PathMatchList, "mode"):             toInt,
-	servicePath("cpu_count"):                                         toInt64,
-	servicePath("cpu_percent"):                                       toFloat,
-	servicePath("cpu_period"):                                        toInt64,
-	servicePath("cpu_quota"):                                         toInt64,
-	servicePath("cpu_rt_period"):                                     toInt64,
-	servicePath("cpu_rt_runtime"):                                    toInt64,
-	servicePath("cpus"):                                              toFloat32,
-	servicePath("cpu_shares"):                                        toInt64,
-	servicePath("init"):                                              toBoolean,
-	servicePath("deploy", "replicas"):                                toInt,
-	servicePath("deploy", "update_config", "parallelism"):            toInt,
-	servicePath("deploy", "update_config", "max_failure_ratio"):      toFloat,
-	servicePath("deploy", "rollback_config", "parallelism"):          toInt,
-	servicePath("deploy", "rollback_config", "max_failure_ratio"):    toFloat,
-	servicePath("deploy", "restart_policy", "max_attempts"):          toInt,
-	servicePath("deploy", "placement", "max_replicas_per_node"):      toInt,
-	servicePath("healthcheck", "retries"):                            toInt,
-	servicePath("healthcheck", "disable"):                            toBoolean,
-	servicePath("mem_limit"):                                         toUnitBytes,
-	servicePath("mem_reservation"):                                   toUnitBytes,
-	servicePath("memswap_limit"):                                     toUnitBytes,
-	servicePath("mem_swappiness"):                                    toUnitBytes,
-	servicePath("oom_kill_disable"):                                  toBoolean,
-	servicePath("oom_score_adj"):                                     toInt64,
-	servicePath("pids_limit"):                                        toInt64,
-	servicePath("ports", interp.PathMatchList, "target"):             toInt,
-	servicePath("privileged"):                                        toBoolean,
-	servicePath("read_only"):                                         toBoolean,
-	servicePath("scale"):                                             toInt,
-	servicePath("secrets", interp.PathMatchList, "mode"):             toInt,
-	servicePath("shm_size"):                                          toUnitBytes,
-	servicePath("stdin_open"):                                        toBoolean,
-	servicePath("stop_grace_period"):                                 toDuration,
-	servicePath("tty"):                                               toBoolean,
-	servicePath("ulimits", interp.PathMatchAll):                      toInt,
-	servicePath("ulimits", interp.PathMatchAll, "hard"):              toInt,
-	servicePath("ulimits", interp.PathMatchAll, "soft"):              toInt,
-	servicePath("volumes", interp.PathMatchList, "read_only"):        toBoolean,
-	servicePath("volumes", interp.PathMatchList, "volume", "nocopy"): toBoolean,
-	servicePath("volumes", interp.PathMatchList, "tmpfs", "size"):    toUnitBytes,
-	iPath("networks", interp.PathMatchAll, "external"):               toBoolean,
-	iPath("networks", interp.PathMatchAll, "internal"):               toBoolean,
-	iPath("networks", interp.PathMatchAll, "attachable"):             toBoolean,
-	iPath("networks", interp.PathMatchAll, "enable_ipv6"):            toBoolean,
-	iPath("volumes", interp.PathMatchAll, "external"):                toBoolean,
-	iPath("secrets", interp.PathMatchAll, "external"):                toBoolean,
-	iPath("configs", interp.PathMatchAll, "external"):                toBoolean,
+var interpolateTypeCastMapping = map[tree.Path]interp.Cast{
+	servicePath("configs", tree.PathMatchList, "mode"):             toInt,
+	servicePath("cpu_count"):                                       toInt64,
+	servicePath("cpu_percent"):                                     toFloat,
+	servicePath("cpu_period"):                                      toInt64,
+	servicePath("cpu_quota"):                                       toInt64,
+	servicePath("cpu_rt_period"):                                   toInt64,
+	servicePath("cpu_rt_runtime"):                                  toInt64,
+	servicePath("cpus"):                                            toFloat32,
+	servicePath("cpu_shares"):                                      toInt64,
+	servicePath("init"):                                            toBoolean,
+	servicePath("deploy", "replicas"):                              toInt,
+	servicePath("deploy", "update_config", "parallelism"):          toInt,
+	servicePath("deploy", "update_config", "max_failure_ratio"):    toFloat,
+	servicePath("deploy", "rollback_config", "parallelism"):        toInt,
+	servicePath("deploy", "rollback_config", "max_failure_ratio"):  toFloat,
+	servicePath("deploy", "restart_policy", "max_attempts"):        toInt,
+	servicePath("deploy", "placement", "max_replicas_per_node"):    toInt,
+	servicePath("healthcheck", "retries"):                          toInt,
+	servicePath("healthcheck", "disable"):                          toBoolean,
+	servicePath("mem_limit"):                                       toUnitBytes,
+	servicePath("mem_reservation"):                                 toUnitBytes,
+	servicePath("memswap_limit"):                                   toUnitBytes,
+	servicePath("mem_swappiness"):                                  toUnitBytes,
+	servicePath("oom_kill_disable"):                                toBoolean,
+	servicePath("oom_score_adj"):                                   toInt64,
+	servicePath("pids_limit"):                                      toInt64,
+	servicePath("ports", tree.PathMatchList, "target"):             toInt,
+	servicePath("privileged"):                                      toBoolean,
+	servicePath("read_only"):                                       toBoolean,
+	servicePath("scale"):                                           toInt,
+	servicePath("secrets", tree.PathMatchList, "mode"):             toInt,
+	servicePath("shm_size"):                                        toUnitBytes,
+	servicePath("stdin_open"):                                      toBoolean,
+	servicePath("stop_grace_period"):                               toDuration,
+	servicePath("tty"):                                             toBoolean,
+	servicePath("ulimits", tree.PathMatchAll):                      toInt,
+	servicePath("ulimits", tree.PathMatchAll, "hard"):              toInt,
+	servicePath("ulimits", tree.PathMatchAll, "soft"):              toInt,
+	servicePath("volumes", tree.PathMatchList, "read_only"):        toBoolean,
+	servicePath("volumes", tree.PathMatchList, "volume", "nocopy"): toBoolean,
+	servicePath("volumes", tree.PathMatchList, "tmpfs", "size"):    toUnitBytes,
+	iPath("networks", tree.PathMatchAll, "external"):               toBoolean,
+	iPath("networks", tree.PathMatchAll, "internal"):               toBoolean,
+	iPath("networks", tree.PathMatchAll, "attachable"):             toBoolean,
+	iPath("networks", tree.PathMatchAll, "enable_ipv6"):            toBoolean,
+	iPath("volumes", tree.PathMatchAll, "external"):                toBoolean,
+	iPath("secrets", tree.PathMatchAll, "external"):                toBoolean,
+	iPath("configs", tree.PathMatchAll, "external"):                toBoolean,
 }
 
-func iPath(parts ...string) interp.Path {
-	return interp.NewPath(parts...)
+func iPath(parts ...string) tree.Path {
+	return tree.NewPath(parts...)
 }
 
-func servicePath(parts ...string) interp.Path {
-	return iPath(append([]string{"services", interp.PathMatchAll}, parts...)...)
+func servicePath(parts ...string) tree.Path {
+	return iPath(append([]string{"services", tree.PathMatchAll}, parts...)...)
 }
 
 func toInt(value string) (interface{}, error) {

--- a/loader/mergeYaml.go
+++ b/loader/mergeYaml.go
@@ -1,0 +1,138 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package loader
+
+import (
+	"fmt"
+
+	"github.com/compose-spec/compose-go/tree"
+)
+
+type merger func(interface{}, interface{}, tree.Path) (interface{}, error)
+
+var merge_specials = map[tree.Path]merger{}
+
+func init() {
+	merge_specials["services.*.logging"] = mergeLogging
+	merge_specials["services.*.volumes"] = mergeVolumesC
+	merge_specials["services.*.ports"] = mergePortsC
+}
+
+func mergePortsC(v interface{}, o interface{}, path tree.Path) (interface{}, error) {
+	type port struct {
+		target    interface{}
+		published interface{}
+		ip        interface{}
+		protocol  interface{}
+	}
+	return mergeSlices(v.([]interface{}), o.([]interface{}), func(i interface{}) interface{} {
+		m := i.(map[string]interface{})
+		return port{
+			target:    m["target"],
+			published: m["published"],
+			ip:        m["ip"],
+			protocol:  m["protocol"],
+		}
+	}, path)
+}
+
+func mergeVolumesC(v interface{}, o interface{}, path tree.Path) (interface{}, error) {
+	return mergeSlices(v.([]interface{}), o.([]interface{}), func(i interface{}) interface{} {
+		m := i.(map[string]interface{})
+		return m["target"]
+	}, path)
+}
+
+func mergeSlices(c []interface{}, o []interface{}, keyFn func(interface{}) interface{}, path tree.Path) (interface{}, error) {
+	merged := map[interface{}]interface{}{}
+	for _, v := range c {
+		merged[keyFn(v)] = v
+	}
+	for _, v := range o {
+		key := keyFn(v)
+		e, ok := merged[key]
+		if !ok {
+			merged[key] = v
+			continue
+		}
+		mergeYaml(e, v, path.Next("[]"))
+	}
+	sequence := make([]interface{}, 0, len(merged))
+	for _, v := range merged {
+		sequence = append(sequence, v)
+	}
+	return sequence, nil
+}
+
+func mergeLogging(c interface{}, o interface{}, p tree.Path) (interface{}, error) {
+	config := c.(map[string]interface{})
+	other := o.(map[string]interface{})
+	// we merge logging config if source and override have the same driver set, or none
+	d, ok1 := other["driver"]
+	o, ok2 := config["driver"]
+	if d == o || !ok1 || !ok2 {
+		return mergeMappings(config, other, p)
+	}
+	return other, nil
+}
+
+func mergeYaml(e interface{}, o interface{}, p tree.Path) (interface{}, error) {
+	for pattern, merger := range merge_specials {
+		if p.Matches(pattern) {
+			merged, err := merger(e, o, p)
+			if err != nil {
+				return nil, err
+			}
+			return merged, nil
+		}
+	}
+	switch e.(type) {
+	case map[string]interface{}:
+		mapping := e.(map[string]interface{})
+		other, ok := o.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("cannont merge %s", p)
+		}
+		return mergeMappings(mapping, other, p)
+	case []interface{}:
+		sequence := e.([]interface{})
+		other, ok := o.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("cannont merge %s", p)
+		}
+		return append(sequence, other...), nil
+	default:
+		return o, nil
+	}
+}
+
+func mergeMappings(mapping map[string]interface{}, other map[string]interface{}, p tree.Path) (map[string]interface{}, error) {
+	for k, v := range other {
+		next := p.Next(k)
+		e, ok := mapping[k]
+		if !ok {
+			mapping[k] = v
+			continue
+		}
+		merged, err := mergeYaml(e, v, next)
+		if err != nil {
+			return nil, err
+		}
+		mapping[k] = merged
+	}
+	return mapping, nil
+}

--- a/loader/merge_test.go
+++ b/loader/merge_test.go
@@ -218,11 +218,10 @@ func TestLoadLogging(t *testing.T) {
 						Scale:       1,
 					},
 				},
-				Networks:   types.Networks{},
-				Volumes:    types.Volumes{},
-				Secrets:    types.Secrets{},
-				Configs:    types.Configs{},
-				Extensions: types.Extensions{},
+				Networks: types.Networks{},
+				Volumes:  types.Volumes{},
+				Secrets:  types.Secrets{},
+				Configs:  types.Configs{},
 			}, config)
 		})
 	}
@@ -372,11 +371,10 @@ func TestLoadMultipleServicePorts(t *testing.T) {
 						Scale:       1,
 					},
 				},
-				Networks:   types.Networks{},
-				Volumes:    types.Volumes{},
-				Secrets:    types.Secrets{},
-				Configs:    types.Configs{},
-				Extensions: types.Extensions{},
+				Networks: types.Networks{},
+				Volumes:  types.Volumes{},
+				Secrets:  types.Secrets{},
+				Configs:  types.Configs{},
 			}, config)
 		})
 	}

--- a/loader/transform.go
+++ b/loader/transform.go
@@ -1,0 +1,120 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package loader
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/compose-spec/compose-go/tree"
+	"github.com/compose-spec/compose-go/types"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+)
+
+type TransformFunc func(data interface{}) (interface{}, error)
+
+var Transformers = map[tree.Path]TransformFunc{
+	"services.*.ports": trasformPorts,
+}
+
+func transform(e interface{}, p tree.Path) (interface{}, error) {
+	for pattern, transformer := range Transformers {
+		if p.Matches(pattern) {
+			t, err := transformer(e)
+			if err != nil {
+				return nil, err
+			}
+			return t, nil
+		}
+	}
+	switch e.(type) {
+	case map[string]interface{}:
+		mapping := e.(map[string]interface{})
+		for k, v := range mapping {
+			t, err := transform(v, p.Next(k))
+			if err != nil {
+				return nil, err
+			}
+			mapping[k] = t
+		}
+		return mapping, nil
+	case []interface{}:
+		sequence := e.([]interface{})
+		for i, e := range sequence {
+			t, err := transform(e, p.Next("[]"))
+			if err != nil {
+				return nil, err
+			}
+			sequence[i] = t
+		}
+		return sequence, nil
+	default:
+		return e, nil
+	}
+}
+
+func trasformPorts(data interface{}) (interface{}, error) {
+	switch entries := data.(type) {
+	case []interface{}:
+		// We process the list instead of individual items here.
+		// The reason is that one entry might be mapped to multiple ServicePortConfig.
+		// Therefore we take an input of a list and return an output of a list.
+		var ports []interface{}
+		for _, entry := range entries {
+			switch value := entry.(type) {
+			case int:
+				parsed, err := types.ParsePortConfig(fmt.Sprint(value))
+				if err != nil {
+					return data, err
+				}
+				for _, v := range parsed {
+					m := map[string]interface{}{}
+					err := mapstructure.Decode(v, &m)
+					if err != nil {
+						return nil, err
+					}
+					ports = append(ports, m)
+				}
+			case string:
+				parsed, err := types.ParsePortConfig(value)
+				if err != nil {
+					return data, err
+				}
+				for _, v := range parsed {
+					m := map[string]interface{}{}
+					err := mapstructure.Decode(v, &m)
+					if err != nil {
+						return nil, err
+					}
+					ports = append(ports, m)
+				}
+			case map[string]interface{}:
+				published := value["published"]
+				if v, ok := published.(int); ok {
+					value["published"] = strconv.Itoa(v)
+				}
+				ports = append(ports, groupXFieldsIntoExtensions(value))
+			default:
+				return data, errors.Errorf("invalid type %T for port", value)
+			}
+		}
+		return ports, nil
+	default:
+		return data, errors.Errorf("invalid type %T for port", entries)
+	}
+}

--- a/tree/path.go
+++ b/tree/path.go
@@ -1,0 +1,67 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tree
+
+import "strings"
+
+const pathSeparator = "."
+
+// PathMatchAll is a token used as part of a Path to match any key at that level
+// in the nested structure
+const PathMatchAll = "*"
+
+// PathMatchList is a token used as part of a Path to match items in a list
+const PathMatchList = "[]"
+
+// Path is a dotted path of keys to a value in a nested mapping structure. A *
+// section in a path will match any key in the mapping structure.
+type Path string
+
+// NewPath returns a new Path
+func NewPath(items ...string) Path {
+	return Path(strings.Join(items, pathSeparator))
+}
+
+// Next returns a new path by append part to the current path
+func (p Path) Next(part string) Path {
+	if p == "" {
+		return Path(part)
+	}
+	return Path(string(p) + pathSeparator + part)
+}
+
+func (p Path) parts() []string {
+	return strings.Split(string(p), pathSeparator)
+}
+
+func (p Path) Matches(pattern Path) bool {
+	patternParts := pattern.parts()
+	parts := p.parts()
+
+	if len(patternParts) != len(parts) {
+		return false
+	}
+	for index, part := range parts {
+		switch patternParts[index] {
+		case PathMatchAll, part:
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/tree/path_test.go
+++ b/tree/path_test.go
@@ -1,0 +1,69 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tree
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestPathMatches(t *testing.T) {
+	var testcases = []struct {
+		doc      string
+		path     Path
+		pattern  Path
+		expected bool
+	}{
+		{
+			doc:     "pattern too short",
+			path:    NewPath("one", "two", "three"),
+			pattern: NewPath("one", "two"),
+		},
+		{
+			doc:     "pattern too long",
+			path:    NewPath("one", "two"),
+			pattern: NewPath("one", "two", "three"),
+		},
+		{
+			doc:     "pattern mismatch",
+			path:    NewPath("one", "three", "two"),
+			pattern: NewPath("one", "two", "three"),
+		},
+		{
+			doc:     "pattern mismatch with match-all part",
+			path:    NewPath("one", "three", "two"),
+			pattern: NewPath(PathMatchAll, "two", "three"),
+		},
+		{
+			doc:      "pattern match with match-all part",
+			path:     NewPath("one", "two", "three"),
+			pattern:  NewPath("one", "*", "three"),
+			expected: true,
+		},
+		{
+			doc:      "pattern match",
+			path:     NewPath("one", "two", "three"),
+			pattern:  NewPath("one", "two", "three"),
+			expected: true,
+		},
+	}
+	for _, testcase := range testcases {
+		assert.Check(t, is.Equal(testcase.expected, testcase.path.Matches(testcase.pattern)))
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -708,11 +708,11 @@ type ServiceNetworkConfig struct {
 
 // ServicePortConfig is the port configuration for a service
 type ServicePortConfig struct {
-	Mode      string `yaml:",omitempty" json:"mode,omitempty"`
+	Mode      string `mapstructure:"mode" yaml:",omitempty" json:"mode,omitempty"`
 	HostIP    string `mapstructure:"host_ip" yaml:"host_ip,omitempty" json:"host_ip,omitempty"`
-	Target    uint32 `yaml:",omitempty" json:"target,omitempty"`
-	Published string `yaml:",omitempty" json:"published,omitempty"`
-	Protocol  string `yaml:",omitempty" json:"protocol,omitempty"`
+	Target    uint32 `mapstructure:"target" yaml:",omitempty" json:"target,omitempty"`
+	Published string `mapstructure:"published" yaml:",omitempty" json:"published,omitempty"`
+	Protocol  string `mapstructure:"protocol" yaml:",omitempty" json:"protocol,omitempty"`
 
 	Extensions Extensions `mapstructure:"#extensions" yaml:",inline" json:"-"`
 }


### PR DESCRIPTION
Transform and merge the `map[string]interface{}` yaml trees from loaded compose.yaml files _before_ they get mapped to go structs, so that we can detect an ket set as `nil` in yaml and override existing value