### PR TITLE
ignore .env can't be read if not explicitly set by user

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -277,12 +277,27 @@ func GetEnvFromFile(currentEnv map[string]string, workingDir string, filenames [
 		}
 		dotEnvFile = abs
 
+		s, err := os.Stat(dotEnvFile)
+		if os.IsNotExist(err) {
+			if len(filenames) == 0 {
+				return envMap, nil
+			}
+			return envMap, errors.Errorf("Couldn't find env file: %s", dotEnvFile)
+		}
+		if err != nil {
+			return envMap, err
+		}
+
+		if s.IsDir() {
+			if len(filenames) == 0 {
+				return envMap, nil
+			}
+			return envMap, errors.Errorf("%s is a directory", dotEnvFile)
+		}
+
 		b, err := os.ReadFile(dotEnvFile)
 		if os.IsNotExist(err) {
-			if len(filenames) > 0 {
-				return nil, errors.Errorf("Couldn't read env file: %s", dotEnvFile)
-			}
-			return envMap, nil
+			return nil, errors.Errorf("Couldn't read env file: %s", dotEnvFile)
 		}
 		if err != nil {
 			return envMap, err

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -307,4 +308,17 @@ func TestEnvMap(t *testing.T) {
 	assert.Equal(t, l[0], "foo=bar")
 	m = utils.GetAsEqualsMap(l)
 	assert.Equal(t, m["foo"], "bar")
+}
+
+func TestGetEnvFromFile(t *testing.T) {
+	wd := t.TempDir()
+	f := filepath.Join(wd, ".env")
+	err := os.Mkdir(f, 0o700)
+	assert.NilError(t, err)
+
+	_, err = GetEnvFromFile(nil, wd, nil)
+	assert.NilError(t, err)
+
+	_, err = GetEnvFromFile(nil, wd, []string{f})
+	assert.Check(t, strings.HasSuffix(err.Error(), ".env is a directory"))
 }


### PR DESCRIPTION
fixes https://github.com/docker/compose/issues/10430

added a test case so we don't re-introduce this regression in the future

I'm a bit sad we can't (in a portable way) just check err == EISDIR after `os.ReadFile` and need to preventively check `os.Stat`. 