### PR TITLE
expand additional context relative paths

### DIFF
--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -57,7 +57,7 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 				Target:             "foo",
 				Network:            "foo",
 				CacheFrom:          []string{"foo", "bar"},
-				AdditionalContexts: map[string]*string{"foo": strPtr("/bar")},
+				AdditionalContexts: types.Mapping{"foo": "/bar"},
 				Labels:             map[string]string{"FOO": "BAR"},
 				Secrets: []types.ServiceSecretConfig{
 					{

--- a/loader/normalize_test.go
+++ b/loader/normalize_test.go
@@ -241,3 +241,55 @@ networks:
 	assert.NilError(t, err)
 	assert.Equal(t, expected, string(marshal))
 }
+
+func TestNormalizeAdditionalContexts(t *testing.T) {
+	project := types.Project{
+		Name: "myProject",
+		Services: types.Services{
+			types.ServiceConfig{
+				Name: "test",
+				Build: &types.BuildConfig{
+					Context:    ".",
+					Dockerfile: "Dockerfile",
+					AdditionalContexts: map[string]string{
+						"image":    "docker-image://foo",
+						"oci":      "oci-layout://foo",
+						"abs_path": "/tmp",
+						"rel_path": "./testdata",
+					},
+				},
+			},
+		},
+	}
+
+	absCwd, _ := filepath.Abs(".")
+	expected := types.Project{
+		Name: "myProject",
+		Services: types.Services{
+			types.ServiceConfig{
+				Name: "test",
+				Build: &types.BuildConfig{
+					Context:    absCwd,
+					Dockerfile: "Dockerfile",
+					AdditionalContexts: map[string]string{
+						"image":    "docker-image://foo",
+						"oci":      "oci-layout://foo",
+						"abs_path": "/tmp",
+						"rel_path": filepath.Join(absCwd, "testdata"),
+					},
+				},
+				Networks: map[string]*types.ServiceNetworkConfig{
+					"default": nil,
+				},
+			},
+		},
+		Networks: types.Networks{"default": types.NetworkConfig{
+			Name: "myProject_default",
+		}},
+		WorkingDir:   absCwd,
+		ComposeFiles: []string{},
+	}
+	err := Normalize(&project, true)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, expected, project)
+}

--- a/types/types.go
+++ b/types/types.go
@@ -303,7 +303,7 @@ type BuildConfig struct {
 	CacheFrom          StringList            `mapstructure:"cache_from" yaml:"cache_from,omitempty" json:"cache_from,omitempty"`
 	CacheTo            StringList            `mapstructure:"cache_to" yaml:"cache_to,omitempty" json:"cache_to,omitempty"`
 	NoCache            bool                  `mapstructure:"no_cache" yaml:"no_cache,omitempty" json:"no_cache,omitempty"`
-	AdditionalContexts MappingWithEquals     `mapstructure:"additional_contexts" yaml:"additional_contexts,omitempty" json:"additional_contexts,omitempty"`
+	AdditionalContexts Mapping               `mapstructure:"additional_contexts" yaml:"additional_contexts,omitempty" json:"additional_contexts,omitempty"`
 	Pull               bool                  `mapstructure:"pull" yaml:"pull,omitempty" json:"pull,omitempty"`
 	ExtraHosts         HostsList             `mapstructure:"extra_hosts" yaml:"extra_hosts,omitempty" json:"extra_hosts,omitempty"`
 	Isolation          string                `yaml:",omitempty" json:"isolation,omitempty"`


### PR DESCRIPTION
With introduction for  `additional_contexts` a user can set context to a local path, and as we support relative paths in many places it also make sense to expand relative paths for such additional contexts. Challenge here is that such a context can be a path or URL (just like context) but also builder specific string. I'm assuming here such a custom string will ALWAYS use a `<type>://` prefix as buildx does

see https://github.com/docker/compose/pull/10369