### PR TITLE
schema: fix name of `dockerfile_inline` field in YAML

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -296,7 +296,7 @@ func (s set) toSlice() []string {
 type BuildConfig struct {
 	Context            string                `yaml:",omitempty" json:"context,omitempty"`
 	Dockerfile         string                `yaml:",omitempty" json:"dockerfile,omitempty"`
-	DockerfileInline   string                `yaml:",omitempty" json:"dockerfile_inline,omitempty"`
+	DockerfileInline   string                `yaml:"dockerfile_inline,omitempty" json:"dockerfile_inline,omitempty"`
 	Args               MappingWithEquals     `yaml:",omitempty" json:"args,omitempty"`
 	SSH                SSHConfig             `yaml:"ssh,omitempty" json:"ssh,omitempty"`
 	Labels             Labels                `yaml:",omitempty" json:"labels,omitempty"`


### PR DESCRIPTION
Missing Go struct tag here, so the field name in YAML was actually `dockerfileinline`.

(This isn't a breaking change: it was a mistake/broken before and not even usable since the schema validation would prevent you from using the typo'd field name.)

See also:
* docker/compose#10456