### PR TITLE
loader: fix panic on invalid type in `name` field

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2337,3 +2337,9 @@ func TestDeviceWriteBps(t *testing.T) {
 	})
 
 }
+
+func TestInvalidProjectNameType(t *testing.T) {
+	p, err := loadYAML(`name: 123`)
+	assert.Error(t, err, "name must be a string")
+	assert.Assert(t, is.Nil(p))
+}


### PR DESCRIPTION
Adjust the cast logic to be safe so that there isn't a panic if a non-string value is used as `name`. The file will fail validation with a type error this way.