### PR TITLE
Revival support for legacy boolean from YAML 1.1 and earlier

### DIFF
--- a/interpolation/interpolation.go
+++ b/interpolation/interpolation.go
@@ -72,7 +72,7 @@ func recursiveInterpolate(value interface{}, path Path, opts Options) (interface
 	switch value := value.(type) {
 	case string:
 		newValue, err := opts.Substitute(value, template.Mapping(opts.LookupValue))
-		if err != nil || newValue == value {
+		if err != nil {
 			return value, newPathError(path, err)
 		}
 		caster, ok := opts.getCasterForPath(path)

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2126,6 +2126,17 @@ services:
 	assert.ErrorContains(t, err, "services.test.build.ssh must be a mapping")
 }
 
+func TestLoadLegacyBoolean(t *testing.T) {
+	actual, err := loadYAML(`
+name: load-legacy-boolean
+services:
+  test:
+    init: yes # used to be a valid YAML bool, removed in YAML 1.2 
+`)
+	assert.NilError(t, err)
+	assert.Check(t, *actual.Services[0].Init)
+}
+
 func TestLoadSSHWithDefaultValueInBuildConfig(t *testing.T) {
 	actual, err := loadYAML(`
 name: load-ssh-with-default-value-in-build-config


### PR DESCRIPTION
Revival support for legacy boolean from YAML 1.1 and earlier, as originally intended in the pull request compose-spec/compose-go#382