### PR TITLE
schema: add `mapstructure` struct tag to `dockerfile_inline`

### DIFF
--- a/loader/full-example.yml
+++ b/loader/full-example.yml
@@ -1,7 +1,13 @@
 name: full_example_project_name
 services:
-  foo:
 
+  bar:
+    build:
+      dockerfile_inline: |
+        FROM alpine
+        RUN echo "hello" > /world.txt
+
+  foo:
     build:
       context: ./dir
       dockerfile: Dockerfile

--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -432,6 +432,14 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 			},
 			WorkingDir: "/code",
 		},
+		{
+			Name: "bar",
+			Build: &types.BuildConfig{
+				DockerfileInline: "FROM alpine\nRUN echo \"hello\" > /world.txt\n",
+			},
+			Environment: types.MappingWithEquals{},
+			Scale:       1,
+		},
 	}
 }
 
@@ -585,6 +593,11 @@ func secrets(workingDir string) map[string]types.SecretConfig {
 func fullExampleYAML(workingDir, homeDir string) string {
 	return fmt.Sprintf(`name: full_example_project_name
 services:
+  bar:
+    build:
+      dockerfile_inline: |
+        FROM alpine
+        RUN echo "hello" > /world.txt
   foo:
     build:
       context: ./dir
@@ -1124,6 +1137,13 @@ func fullExampleJSON(workingDir, homeDir string) string {
     }
   },
   "services": {
+    "bar": {
+      "build": {
+        "dockerfile_inline": "FROM alpine\nRUN echo \"hello\" \u003e /world.txt\n"
+      },
+      "command": null,
+      "entrypoint": null
+    },
     "foo": {
       "build": {
         "context": "./dir",

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1008,7 +1008,7 @@ func TestFullExample(t *testing.T) {
 	expectedConfig := fullExampleProject(workingDir, homeDir)
 
 	assert.Check(t, is.DeepEqual(expectedConfig.Name, config.Name))
-	assert.Check(t, is.DeepEqual(expectedConfig.Services, config.Services))
+	assert.Check(t, is.DeepEqual(serviceSort(expectedConfig.Services), serviceSort(config.Services)))
 	assert.Check(t, is.DeepEqual(expectedConfig.Networks, config.Networks))
 	assert.Check(t, is.DeepEqual(expectedConfig.Volumes, config.Volumes))
 	assert.Check(t, is.DeepEqual(expectedConfig.Secrets, config.Secrets))

--- a/types/types.go
+++ b/types/types.go
@@ -296,7 +296,7 @@ func (s set) toSlice() []string {
 type BuildConfig struct {
 	Context            string                `yaml:",omitempty" json:"context,omitempty"`
 	Dockerfile         string                `yaml:",omitempty" json:"dockerfile,omitempty"`
-	DockerfileInline   string                `yaml:"dockerfile_inline,omitempty" json:"dockerfile_inline,omitempty"`
+	DockerfileInline   string                `mapstructure:"dockerfile_inline,omitempty" yaml:"dockerfile_inline,omitempty" json:"dockerfile_inline,omitempty"`
 	Args               MappingWithEquals     `yaml:",omitempty" json:"args,omitempty"`
 	SSH                SSHConfig             `yaml:"ssh,omitempty" json:"ssh,omitempty"`
 	Labels             Labels                `yaml:",omitempty" json:"labels,omitempty"`


### PR DESCRIPTION
Without the proper struct tag the loader won't populate the `dockerfile_inline` field, and so this wasn't getting converted from the dict -> `BuildConfig` struct.

Adds some tests as well.

**related**:
- https://github.com/compose-spec/compose-go/pull/386
- https://github.com/docker/compose/issues/10456

**cute animal even though it's not required**:

![image](https://user-images.githubusercontent.com/70572044/232907549-755e2664-c0b7-4122-be0c-eea74ecab4a0.png)
