### PR TITLE
load: clarify project name validation rules in errors

### DIFF
--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -91,53 +91,53 @@ func TestProjectName(t *testing.T) {
 
 	t.Run("by name start with invalid char '-'", func(t *testing.T) {
 		_, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithName("-my_project"))
-		assert.ErrorContains(t, err, `"-my_project" is not a valid project name`)
+		assert.ErrorContains(t, err, `invalid project name "-my_project"`)
 
 		opts, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithEnv([]string{
 			fmt.Sprintf("%s=%s", consts.ComposeProjectName, "-my_project"),
 		}))
 		assert.NilError(t, err)
 		p, err := ProjectFromOptions(opts)
-		assert.ErrorContains(t, err, `"-my_project" is not a valid project name`)
+		assert.ErrorContains(t, err, `invalid project name "-my_project"`)
 		assert.Assert(t, p == nil)
 	})
 
 	t.Run("by name start with invalid char '_'", func(t *testing.T) {
 		_, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithName("_my_project"))
-		assert.ErrorContains(t, err, `"_my_project" is not a valid project name`)
+		assert.ErrorContains(t, err, `invalid project name "_my_project"`)
 
 		opts, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithEnv([]string{
 			fmt.Sprintf("%s=%s", consts.ComposeProjectName, "_my_project"),
 		}))
 		assert.NilError(t, err)
 		p, err := ProjectFromOptions(opts)
-		assert.ErrorContains(t, err, `"_my_project" is not a valid project name`)
+		assert.ErrorContains(t, err, `invalid project name "_my_project"`)
 		assert.Assert(t, p == nil)
 	})
 
 	t.Run("by name contains dots", func(t *testing.T) {
 		_, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithName("www.my.project"))
-		assert.ErrorContains(t, err, `"www.my.project" is not a valid project name`)
+		assert.ErrorContains(t, err, `invalid project name "www.my.project"`)
 
 		opts, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithEnv([]string{
 			fmt.Sprintf("%s=%s", consts.ComposeProjectName, "www.my.project"),
 		}))
 		assert.NilError(t, err)
 		p, err := ProjectFromOptions(opts)
-		assert.ErrorContains(t, err, `"www.my.project" is not a valid project name`)
+		assert.ErrorContains(t, err, `invalid project name "www.my.project"`)
 		assert.Assert(t, p == nil)
 	})
 
 	t.Run("by name uppercase", func(t *testing.T) {
 		_, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithName("MY_PROJECT"))
-		assert.ErrorContains(t, err, `"MY_PROJECT" is not a valid project name`)
+		assert.ErrorContains(t, err, `invalid project name "MY_PROJECT"`)
 
 		opts, err := NewProjectOptions([]string{"testdata/simple/compose.yaml"}, WithEnv([]string{
 			fmt.Sprintf("%s=%s", consts.ComposeProjectName, "MY_PROJECT"),
 		}))
 		assert.NilError(t, err)
 		p, err := ProjectFromOptions(opts)
-		assert.ErrorContains(t, err, `"MY_PROJECT" is not a valid project name`)
+		assert.ErrorContains(t, err, `invalid project name "MY_PROJECT"`)
 		assert.Assert(t, p == nil)
 	})
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -294,8 +294,8 @@ func Load(configDetails types.ConfigDetails, options ...func(*Options)) (*types.
 
 func InvalidProjectNameErr(v string) error {
 	return fmt.Errorf(
-		"%q is not a valid project name: it must contain only "+
-			"characters from [a-z0-9_-] and start with [a-z0-9]", v,
+		"invalid project name %q: must consist only of lowercase alphanumeric characters, hyphens, and underscores as well as start with a letter or number",
+		v,
 	)
 }
 


### PR DESCRIPTION
This error message showed a regex previously, which has confused some users, as it's not necessarily apparent that the `a-z` was implying case sensitivity.

Updated message adapted from the release notes.

* docker/compose#10512