### PR TITLE
fix !reset support to override attributes with custom yaml name

### DIFF
--- a/loader/merge_test.go
+++ b/loader/merge_test.go
@@ -1374,6 +1374,7 @@ services:
     build:
       context: .
       dockerfile: foo.Dockerfile
+    read_only: true
     environment:
       FOO: BAR
 `
@@ -1382,6 +1383,7 @@ services:
   foo:
     image: foo
     build: !reset  
+    read_only: !reset false
     environment:
       FOO: !reset
 `
@@ -1402,6 +1404,7 @@ services:
 				Name:        "foo",
 				Image:       "foo",
 				Environment: types.MappingWithEquals{},
+				ReadOnly:    false,
 				Scale:       1,
 			},
 		},

--- a/loader/null.go
+++ b/loader/null.go
@@ -133,7 +133,9 @@ func (p *ResetProcessor) applyNullOverrides(val reflect.Value, path tree.Path) e
 			field := typ.Field(i)
 			name := field.Name
 			attr := strings.ToLower(name)
-			if tag := field.Tag.Get("mapstructure"); tag != "" {
+			tag := field.Tag.Get("yaml")
+			tag = strings.Split(tag, ",")[0]
+			if tag != "" && tag != "-" {
 				attr = tag
 			}
 			next := path.Next(attr)


### PR DESCRIPTION
After https://github.com/compose-spec/compose-go/pull/392 support for `!reset` can't rely anymore on mapstructure tags to get the yaml name for a go struct field

closes https://github.com/docker/compose/issues/8866