### PR TITLE
Fix typo in types.Resource Pid field

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -640,7 +640,7 @@ type Resource struct {
 	// TODO: types to convert from units and ratios
 	NanoCPUs         string            `yaml:"cpus,omitempty" json:"cpus,omitempty"`
 	MemoryBytes      UnitBytes         `yaml:"memory,omitempty" json:"memory,omitempty"`
-	PIds             int64             `yaml:"pids,omitempty" json:"pids,omitempty"`
+	Pids             int64             `yaml:"pids,omitempty" json:"pids,omitempty"`
 	Devices          []DeviceRequest   `yaml:"devices,omitempty" json:"devices,omitempty"`
 	GenericResources []GenericResource `yaml:"generic_resources,omitempty" json:"generic_resources,omitempty"`
 


### PR DESCRIPTION
This is pretty small and isolated, but unfortunately still a breaking change :(. For better or worse, this change doesn't appear to break any `compose-go` source or tests. If there are any existing or new tests that you'd like me to add to include in this, please let me know and i'm happy to add them!

fixes #400.