### PR TITLE
fix nested var expansion

### DIFF
--- a/interpolation/interpolation_test.go
+++ b/interpolation/interpolation_test.go
@@ -119,6 +119,11 @@ func TestValidUnexistentInterpolation(t *testing.T) {
 		{test: "{{{ ${BAR} }}}", expected: "{{{  }}}"},
 		{test: "${FOO:?baz} }}}", errMsg: "baz"},
 		{test: "${FOO?baz} }}}", errMsg: "baz"},
+		// nested variables
+		{test: "${FOO:-${BAR:-${ZOT:-qix}}}", expected: "qix"},
+		{test: "${FOO:-${BAR:-x}_test_${BAR:-y}}", expected: "x_test_y"},
+		{test: "${FOO:-${BAR:-x}_test}", expected: "x_test"},
+		{test: "${FOO:-${BAR:-${ZOT:-x}}_test}", expected: "x_test"},
 	}
 
 	getServiceConfig := func(val string) map[string]interface{} {

--- a/template/template.go
+++ b/template/template.go
@@ -28,7 +28,7 @@ import (
 var delimiter = "\\$"
 var substitutionNamed = "[_a-z][_a-z0-9]*"
 
-var substitutionBraced = "[_a-z][_a-z0-9]*(?::?[-+?](.*}|[^}]*))?"
+var substitutionBraced = "[_a-z][_a-z0-9]*(?::?[-+?](.*))?"
 
 var patternString = fmt.Sprintf(
 	"%s(?i:(?P<escaped>%s)|(?P<named>%s)|{(?:(?P<braced>%s)}|(?P<invalid>)))",


### PR DESCRIPTION
The previously used pattern `(.*}|[^}]*)` basically means "_either a nested value, identified by a closing brace, or a plain text value with no brace_". This is pretty complicated way to say we need to take anything that comes next, and recursively interpolate value.

closes https://github.com/compose-spec/compose-go/issues/401