### PR TITLE
dependabot: disable version bump checks/only keep security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,10 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  open-pull-requests-limit: 10
+  # compose-go is a library, so to maximize compatibility for downstream
+  # users with go's minimal version selection for dependencies we should
+  # ignore version bumps and only update when there are security updates
+  open-pull-requests-limit: 0
   ignore:
   - dependency-name: github.com/sirupsen/logrus
     versions:


### PR DESCRIPTION
Go uses a minimal version selection algorithm to select the version of modules used in a build (see https://github.com/golang/go/wiki/Modules#version-selection).

From the go wiki:

```
[...] if your module depends on module A which has a require D v1.0.0, and your module
also depends on module B which has a require D v1.1.1, then minimal version selection
would choose v1.1.1 of D to include in the build (given it is the highest listed require version).
```

Since `compose-go` is a library and meant to be used by downstream implementations, in order to maximize compatibility with other imports we should try to use the lowest version of any dependencies we need, as opposed to using whatever latest version is available.

This commit changes the dependabot config to disable version bumps, keeping security updates enabled.
(see: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates)