### PR TITLE
reset MUST handle `services` as a map

### DIFF
--- a/loader/merge_test.go
+++ b/loader/merge_test.go
@@ -1377,6 +1377,13 @@ services:
     read_only: true
     environment:
       FOO: BAR
+    ports:
+      - "8080:80"
+  bar:
+    image: test
+    ports:
+      - "8443:443"
+
 `
 	override := `
 services:
@@ -1386,6 +1393,7 @@ services:
     read_only: !reset false
     environment:
       FOO: !reset
+    ports: !reset []
 `
 	configDetails := types.ConfigDetails{
 		Environment: map[string]string{},
@@ -1401,9 +1409,18 @@ services:
 		WorkingDir: "",
 		Services: []types.ServiceConfig{
 			{
+				Name:        "bar",
+				Image:       "test",
+				Environment: types.MappingWithEquals{},
+				Ports:       []types.ServicePortConfig{{Mode: "ingress", Target: 443, Published: "8443", Protocol: "tcp"}},
+				Scale:       1,
+			},
+			{
+				Build:       nil,
 				Name:        "foo",
 				Image:       "foo",
 				Environment: types.MappingWithEquals{},
+				Ports:       nil,
 				ReadOnly:    false,
 				Scale:       1,
 			},


### PR DESCRIPTION
While `services` is a mapping in yaml, this is a slice in compose-go structs.
As a result, we need to convert the yaml paths from `services.[index]` into `service.Name` as index might not match between source and override compose files, also subject to change after sort has been applied. This latter case is demonstrated by test case using a second service `bar` that becomes `services[0]` in final result

see https://dockercommunity.slack.com/archives/C2X82D9PA/p1684916162518289?thread_ts=1684571165.209559&cid=C2X82D9PA for more context