### PR TITLE
introduce NetworkConfig.ID to track actual resource identified by Name

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -922,6 +922,7 @@ func (u *UlimitsConfig) MarshalJSON() ([]byte, error) {
 
 // NetworkConfig for a network
 type NetworkConfig struct {
+	ID         string            `yaml:"-,omitempty" json:"-,omitempty"`
 	Name       string            `yaml:"name,omitempty" json:"name,omitempty"`
 	Driver     string            `yaml:"driver,omitempty" json:"driver,omitempty"`
 	DriverOpts map[string]string `yaml:"driver_opts,omitempty" json:"driver_opts,omitempty"`


### PR DESCRIPTION
see discussion on https://github.com/docker/compose/pull/10612

As `network.Name` is not unique on moby, we can't safely rely on this as a unique identifier, and need to resolve into an actual ID.