### PR TITLE
service can use x-* name

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -605,6 +605,7 @@ func LoadServices(filename string, servicesDict map[string]interface{}, workingD
 		for k, v := range x.(map[string]interface{}) {
 			servicesDict[k] = v
 		}
+		delete(servicesDict, extensions)
 	}
 
 	for name := range servicesDict {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2385,3 +2385,21 @@ volumes:
 		},
 	})
 }
+
+func TestXService(t *testing.T) {
+	p, err := loadYAML(`
+name: 'test-x-service'
+services:
+  x-foo:
+    image: busybox
+`)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, p.Services, types.Services{
+		{
+			Name:        "x-foo",
+			Image:       "busybox",
+			Environment: types.MappingWithEquals{},
+			Scale:       1,
+		},
+	})
+}


### PR DESCRIPTION
extensions are not supported inside the `services` top-level attribute, this allows users to declare services with name starting by `x-...` Unfortunately support for this is buggy, and here is a fix + test-case :)

closes https://github.com/docker/compose/issues/8809