### PR TITLE
introduce ResolveRelativePaths as a distinct operation vs Normalization

### DIFF
--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -177,8 +177,8 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 				"ENV_WITH_UNDERSCORE": strPtr("ok"),
 			},
 			EnvFile: []string{
-				"./example1.env",
-				"./example2.env",
+				filepath.Join(workingDir, "example1.env"),
+				filepath.Join(workingDir, "example2.env"),
 			},
 			Expose: []string{"3000", "8000"},
 			ExternalLinks: []string{
@@ -728,8 +728,8 @@ services:
       FOO: foo_from_env_file
       QUX: qux_from_environment
     env_file:
-      - ./example1.env
-      - ./example2.env
+      - %s
+      - %s
     expose:
       - "3000"
       - "8000"
@@ -1035,6 +1035,8 @@ x-nested:
   bar: baz
   foo: bar
 `,
+		filepath.Join(workingDir, "example1.env"),
+		filepath.Join(workingDir, "example2.env"),
 		workingDir,
 		filepath.Join(workingDir, "static"),
 		filepath.Join(homeDir, "configs"),
@@ -1327,8 +1329,8 @@ func fullExampleJSON(workingDir, homeDir string) string {
         "QUX": "qux_from_environment"
       },
       "env_file": [
-        "./example1.env",
-        "./example2.env"
+        "%s",
+        "%s"
       ],
       "expose": [
         "3000",
@@ -1677,6 +1679,8 @@ func fullExampleJSON(workingDir, homeDir string) string {
 		toPath(workingDir, "config_data"),
 		toPath(homeDir, "config_data"),
 		toPath(workingDir, "secret_data"),
+		toPath(workingDir, "example1.env"),
+		toPath(workingDir, "example2.env"),
 		toPath(workingDir),
 		toPath(workingDir, "static"),
 		toPath(homeDir, "configs"),

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -185,6 +185,7 @@ func Load(configDetails types.ConfigDetails, options ...func(*Options)) (*types.
 			LookupValue:     configDetails.LookupEnv,
 			TypeCastMapping: interpolateTypeCastMapping,
 		},
+		ResolvePaths: true,
 	}
 
 	for _, op := range options {
@@ -248,14 +249,6 @@ func Load(configDetails types.ConfigDetails, options ...func(*Options)) (*types.
 		model = merged
 	}
 
-	for _, s := range model.Services {
-		var newEnvFiles types.StringList
-		for _, ef := range s.EnvFile {
-			newEnvFiles = append(newEnvFiles, absPath(configDetails.WorkingDir, ef))
-		}
-		s.EnvFile = newEnvFiles
-	}
-
 	project := &types.Project{
 		Name:        projectName,
 		WorkingDir:  configDetails.WorkingDir,
@@ -268,8 +261,24 @@ func Load(configDetails types.ConfigDetails, options ...func(*Options)) (*types.
 		Extensions:  model.Extensions,
 	}
 
+	if opts.ResolvePaths {
+		err = ResolveRelativePaths(project)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if opts.ConvertWindowsPaths {
+		for i, service := range project.Services {
+			for j, volume := range service.Volumes {
+				service.Volumes[j] = convertVolumePath(volume)
+			}
+			project.Services[i] = service
+		}
+	}
+
 	if !opts.SkipNormalization {
-		err = Normalize(project, opts.ResolvePaths)
+		err = Normalize(project)
 		if err != nil {
 			return nil, err
 		}
@@ -428,11 +437,11 @@ func loadSections(filename string, config map[string]interface{}, configDetails 
 	if err != nil {
 		return nil, err
 	}
-	cfg.Secrets, err = LoadSecrets(getSection(config, "secrets"), configDetails, opts.ResolvePaths)
+	cfg.Secrets, err = LoadSecrets(getSection(config, "secrets"))
 	if err != nil {
 		return nil, err
 	}
-	cfg.Configs, err = LoadConfigObjs(getSection(config, "configs"), configDetails, opts.ResolvePaths)
+	cfg.Configs, err = LoadConfigObjs(getSection(config, "configs"))
 	if err != nil {
 		return nil, err
 	}
@@ -634,7 +643,7 @@ func loadServiceWithExtends(filename, name string, servicesDict map[string]inter
 		target = map[string]interface{}{}
 	}
 
-	serviceConfig, err := LoadService(name, target.(map[string]interface{}), workingDir, lookupEnv, opts.ResolvePaths, opts.ConvertWindowsPaths)
+	serviceConfig, err := LoadService(name, target.(map[string]interface{}))
 	if err != nil {
 		return nil, err
 	}
@@ -672,21 +681,9 @@ func loadServiceWithExtends(filename, name string, servicesDict map[string]inter
 			// make the paths relative to `file` rather than `baseFilePath` so
 			// that the resulting paths won't be absolute if `file` isn't an
 			// absolute path.
+
 			baseFileParent := filepath.Dir(file)
-			if baseService.Build != nil {
-				baseService.Build.Context = resolveBuildContextPath(baseFileParent, baseService.Build.Context)
-			}
-
-			for i, vol := range baseService.Volumes {
-				if vol.Type != types.VolumeTypeBind {
-					continue
-				}
-				baseService.Volumes[i].Source = resolveMaybeUnixPath(vol.Source, baseFileParent, lookupEnv)
-			}
-
-			for i, envFile := range baseService.EnvFile {
-				baseService.EnvFile[i] = resolveMaybeUnixPath(envFile, baseFileParent, lookupEnv)
-			}
+			ResolveServiceRelativePaths(baseFileParent, baseService)
 		}
 
 		serviceConfig, err = _merge(baseService, serviceConfig)
@@ -699,22 +696,9 @@ func loadServiceWithExtends(filename, name string, servicesDict map[string]inter
 	return serviceConfig, nil
 }
 
-func resolveBuildContextPath(baseFileParent string, context string) string {
-	// Checks if the context is an HTTP(S) URL or a remote git repository URL
-	for _, prefix := range []string{"https://", "http://", "git://", "github.com/", "git@"} {
-		if strings.HasPrefix(context, prefix) {
-			return context
-		}
-	}
-
-	// Note that the Dockerfile is always defined relative to the
-	// build context, so there's no need to update the Dockerfile field.
-	return absPath(baseFileParent, context)
-}
-
 // LoadService produces a single ServiceConfig from a compose file Dict
 // the serviceDict is not validated if directly used. Use Load() to enable validation
-func LoadService(name string, serviceDict map[string]interface{}, workingDir string, lookupEnv template.Mapping, resolvePaths bool, convertPaths bool) (*types.ServiceConfig, error) {
+func LoadService(name string, serviceDict map[string]interface{}) (*types.ServiceConfig, error) {
 	serviceConfig := &types.ServiceConfig{
 		Scale: 1,
 	}
@@ -731,13 +715,6 @@ func LoadService(name string, serviceDict map[string]interface{}, workingDir str
 			return nil, errors.New(`invalid mount config for type "bind": field Source must not be empty`)
 		}
 
-		if resolvePaths || convertPaths {
-			volume = resolveVolumePath(volume, workingDir, lookupEnv)
-		}
-
-		if convertPaths {
-			volume = convertVolumePath(volume)
-		}
 		serviceConfig.Volumes[i] = volume
 	}
 
@@ -759,8 +736,8 @@ func convertVolumePath(volume types.ServiceVolumeConfig) types.ServiceVolumeConf
 	return volume
 }
 
-func resolveMaybeUnixPath(path string, workingDir string, lookupEnv template.Mapping) string {
-	filePath := expandUser(path, lookupEnv)
+func resolveMaybeUnixPath(workingDir string, path string) string {
+	filePath := expandUser(path)
 	// Check if source is an absolute path (either Unix or Windows), to
 	// handle a Windows client with a Unix daemon or vice-versa.
 	//
@@ -773,20 +750,15 @@ func resolveMaybeUnixPath(path string, workingDir string, lookupEnv template.Map
 	return filePath
 }
 
-func resolveVolumePath(volume types.ServiceVolumeConfig, workingDir string, lookupEnv template.Mapping) types.ServiceVolumeConfig {
-	volume.Source = resolveMaybeUnixPath(volume.Source, workingDir, lookupEnv)
-	return volume
-}
-
 func resolveSecretsPath(secret types.SecretConfig, workingDir string, lookupEnv template.Mapping) types.SecretConfig {
 	if !secret.External.External && secret.File != "" {
-		secret.File = resolveMaybeUnixPath(secret.File, workingDir, lookupEnv)
+		secret.File = resolveMaybeUnixPath(workingDir, secret.File)
 	}
 	return secret
 }
 
 // TODO: make this more robust
-func expandUser(path string, lookupEnv template.Mapping) string {
+func expandUser(path string) string {
 	if strings.HasPrefix(path, "~") {
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -886,44 +858,39 @@ func LoadVolumes(source map[string]interface{}) (map[string]types.VolumeConfig, 
 
 // LoadSecrets produces a SecretConfig map from a compose file Dict
 // the source Dict is not validated if directly used. Use Load() to enable validation
-func LoadSecrets(source map[string]interface{}, details types.ConfigDetails, resolvePaths bool) (map[string]types.SecretConfig, error) {
+func LoadSecrets(source map[string]interface{}) (map[string]types.SecretConfig, error) {
 	secrets := make(map[string]types.SecretConfig)
 	if err := Transform(source, &secrets); err != nil {
 		return secrets, err
 	}
 	for name, secret := range secrets {
-		obj, err := loadFileObjectConfig(name, "secret", types.FileObjectConfig(secret), details, false)
+		obj, err := loadFileObjectConfig(name, "secret", types.FileObjectConfig(secret))
 		if err != nil {
 			return nil, err
 		}
-		secretConfig := types.SecretConfig(obj)
-		if resolvePaths {
-			secretConfig = resolveSecretsPath(secretConfig, details.WorkingDir, details.LookupEnv)
-		}
-		secrets[name] = secretConfig
+		secrets[name] = types.SecretConfig(obj)
 	}
 	return secrets, nil
 }
 
 // LoadConfigObjs produces a ConfigObjConfig map from a compose file Dict
 // the source Dict is not validated if directly used. Use Load() to enable validation
-func LoadConfigObjs(source map[string]interface{}, details types.ConfigDetails, resolvePaths bool) (map[string]types.ConfigObjConfig, error) {
+func LoadConfigObjs(source map[string]interface{}) (map[string]types.ConfigObjConfig, error) {
 	configs := make(map[string]types.ConfigObjConfig)
 	if err := Transform(source, &configs); err != nil {
 		return configs, err
 	}
 	for name, config := range configs {
-		obj, err := loadFileObjectConfig(name, "config", types.FileObjectConfig(config), details, resolvePaths)
+		obj, err := loadFileObjectConfig(name, "config", types.FileObjectConfig(config))
 		if err != nil {
 			return nil, err
 		}
-		configConfig := types.ConfigObjConfig(obj)
-		configs[name] = configConfig
+		configs[name] = types.ConfigObjConfig(obj)
 	}
 	return configs, nil
 }
 
-func loadFileObjectConfig(name string, objType string, obj types.FileObjectConfig, details types.ConfigDetails, resolvePaths bool) (types.FileObjectConfig, error) {
+func loadFileObjectConfig(name string, objType string, obj types.FileObjectConfig) (types.FileObjectConfig, error) {
 	// if "external: true"
 	switch {
 	case obj.External.External:
@@ -943,24 +910,9 @@ func loadFileObjectConfig(name string, objType string, obj types.FileObjectConfi
 		if obj.File != "" {
 			return obj, errors.Errorf("%[1]s %[2]s: %[1]s.driver and %[1]s.file conflict; only use %[1]s.driver", objType, name)
 		}
-	default:
-		if obj.File != "" && resolvePaths {
-			obj.File = absPath(details.WorkingDir, obj.File)
-		}
 	}
 
 	return obj, nil
-}
-
-func absPath(workingDir string, filePath string) string {
-	if strings.HasPrefix(filePath, "~") {
-		home, _ := os.UserHomeDir()
-		return filepath.Join(home, filePath[1:])
-	}
-	if filepath.IsAbs(filePath) {
-		return filePath
-	}
-	return filepath.Join(workingDir, filePath)
 }
 
 var transformMapStringString TransformerFunc = func(data interface{}) (interface{}, error) {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -843,6 +843,7 @@ services:
 	// Default behavior keeps the `env_file` entries
 	configWithEnvFiles, err := Load(configDetails, func(options *Options) {
 		options.SkipNormalization = true
+		options.ResolvePaths = false
 	})
 	assert.NilError(t, err)
 	assert.DeepEqual(t, configWithEnvFiles.Services[0].EnvFile, types.StringList{"example1.env",
@@ -1453,8 +1454,7 @@ func TestLoadSecretsWarnOnDeprecatedExternalNameVersion35(t *testing.T) {
 			},
 		},
 	}
-	details := types.ConfigDetails{}
-	secrets, err := LoadSecrets(source, details, true)
+	secrets, err := LoadSecrets(source)
 	assert.NilError(t, err)
 	expected := map[string]types.SecretConfig{
 		"foo": {
@@ -1929,8 +1929,7 @@ func TestLoadWithExtends(t *testing.T) {
 	actual, err := Load(configDetails)
 	assert.NilError(t, err)
 
-	extendsDir, err := filepath.Abs(filepath.Join("testdata", "subdir"))
-	assert.NilError(t, err)
+	extendsDir := filepath.Join("testdata", "subdir")
 
 	expectedEnvFilePath := filepath.Join(extendsDir, "extra.env")
 
@@ -2089,7 +2088,7 @@ func TestLoadServiceWithVolumes(t *testing.T) {
 			},
 		},
 	}
-	s, err := LoadService("Test Name", m, ".", nil, true, false)
+	s, err := LoadService("Test Name", m)
 	assert.NilError(t, err)
 	assert.Equal(t, len(s.Volumes), 2)
 	assert.Equal(t, "/path 1", s.Volumes[0].Target)

--- a/loader/paths.go
+++ b/loader/paths.go
@@ -1,0 +1,131 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package loader
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/compose-spec/compose-go/types"
+)
+
+// ResolveRelativePaths resolves relative paths based on project WorkingDirectory
+func ResolveRelativePaths(project *types.Project) error {
+	absComposeFiles, err := absComposeFiles(project.ComposeFiles)
+	if err != nil {
+		return err
+	}
+	project.ComposeFiles = absComposeFiles
+
+	for i, s := range project.Services {
+		ResolveServiceRelativePaths(project.WorkingDir, &s)
+		project.Services[i] = s
+	}
+
+	for i, obj := range project.Configs {
+		if obj.File != "" {
+			obj.File = absPath(project.WorkingDir, obj.File)
+			project.Configs[i] = obj
+		}
+	}
+
+	for i, obj := range project.Secrets {
+		if obj.File != "" {
+			obj.File = resolveMaybeUnixPath(project.WorkingDir, obj.File)
+			project.Secrets[i] = obj
+		}
+	}
+
+	for name, config := range project.Volumes {
+		if config.Driver == "local" && config.DriverOpts["o"] == "bind" {
+			// This is actually a bind mount
+			config.DriverOpts["device"] = resolveMaybeUnixPath(project.WorkingDir, config.DriverOpts["device"])
+			project.Volumes[name] = config
+		}
+	}
+	return nil
+}
+
+func ResolveServiceRelativePaths(workingDir string, s *types.ServiceConfig) {
+	if s.Build != nil && s.Build.Context != "" && !isRemoteContext(s.Build.Context) {
+		// Build context might be a remote http/git context. Unfortunately supported "remote"
+		// syntax is highly ambiguous in moby/moby and not defined by compose-spec,
+		// so let's assume runtime will check
+		localContext := absPath(workingDir, s.Build.Context)
+		if _, err := os.Stat(localContext); err == nil {
+			s.Build.Context = localContext
+		}
+		for name, path := range s.Build.AdditionalContexts {
+			if strings.Contains(path, "://") { // `docker-image://` or any builder specific context type
+				continue
+			}
+			if isRemoteContext(path) {
+				continue
+			}
+			path = absPath(workingDir, path)
+			if _, err := os.Stat(path); err == nil {
+				s.Build.AdditionalContexts[name] = path
+			}
+		}
+	}
+	for j, f := range s.EnvFile {
+		s.EnvFile[j] = absPath(workingDir, f)
+	}
+
+	if s.Extends != nil && s.Extends.File != "" {
+		s.Extends.File = absPath(workingDir, s.Extends.File)
+	}
+
+	for i, vol := range s.Volumes {
+		if vol.Type != types.VolumeTypeBind {
+			continue
+		}
+		s.Volumes[i].Source = resolveMaybeUnixPath(workingDir, vol.Source)
+	}
+}
+
+func absPath(workingDir string, filePath string) string {
+	if strings.HasPrefix(filePath, "~") {
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, filePath[1:])
+	}
+	if filepath.IsAbs(filePath) {
+		return filePath
+	}
+	return filepath.Join(workingDir, filePath)
+}
+
+func absComposeFiles(composeFiles []string) ([]string, error) {
+	for i, composeFile := range composeFiles {
+		absComposefile, err := filepath.Abs(composeFile)
+		if err != nil {
+			return nil, err
+		}
+		composeFiles[i] = absComposefile
+	}
+	return composeFiles, nil
+}
+
+func isRemoteContext(maybeURL string) bool {
+	for _, prefix := range []string{"https://", "http://", "git://", "github.com/", "git@"} {
+		if strings.HasPrefix(maybeURL, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/loader/paths_test.go
+++ b/loader/paths_test.go
@@ -1,0 +1,131 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package loader
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/compose-spec/compose-go/types"
+	"gotest.tools/v3/assert"
+)
+
+func TestResolveComposeFilePaths(t *testing.T) {
+	absWorkingDir, _ := filepath.Abs("testdata")
+	absComposeFile, _ := filepath.Abs(filepath.Join("testdata", "simple", "compose.yaml"))
+	absOverrideFile, _ := filepath.Abs(filepath.Join("testdata", "simple", "compose-with-overrides.yaml"))
+
+	project := types.Project{
+		Name:         "myProject",
+		WorkingDir:   absWorkingDir,
+		ComposeFiles: []string{filepath.Join("testdata", "simple", "compose.yaml"), filepath.Join("testdata", "simple", "compose-with-overrides.yaml")},
+	}
+
+	expected := types.Project{
+		Name:         "myProject",
+		WorkingDir:   absWorkingDir,
+		ComposeFiles: []string{absComposeFile, absOverrideFile},
+	}
+	err := ResolveRelativePaths(&project)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, expected, project)
+}
+
+func TestResolveBuildContextPaths(t *testing.T) {
+	wd, _ := os.Getwd()
+	project := types.Project{
+		Name:       "myProject",
+		WorkingDir: wd,
+		Services: []types.ServiceConfig{
+			{
+				Name: "foo",
+				Build: &types.BuildConfig{
+					Context:    "./testdata",
+					Dockerfile: "Dockerfile-sample",
+				},
+				Scale: 1,
+			},
+		},
+	}
+
+	expected := types.Project{
+		Name:       "myProject",
+		WorkingDir: wd,
+		Services: []types.ServiceConfig{
+			{
+				Name: "foo",
+				Build: &types.BuildConfig{
+					Context:    filepath.Join(wd, "testdata"),
+					Dockerfile: "Dockerfile-sample",
+				},
+				Scale: 1,
+			},
+		},
+	}
+	err := ResolveRelativePaths(&project)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, expected, project)
+}
+
+func TestResolveAdditionalContexts(t *testing.T) {
+	wd, _ := filepath.Abs(".")
+	project := types.Project{
+		Name:       "myProject",
+		WorkingDir: wd,
+		Services: types.Services{
+			types.ServiceConfig{
+				Name: "test",
+				Build: &types.BuildConfig{
+					Context:    ".",
+					Dockerfile: "Dockerfile",
+					AdditionalContexts: map[string]string{
+						"image":    "docker-image://foo",
+						"oci":      "oci-layout://foo",
+						"abs_path": "/tmp",
+						"github":   "github.com/compose-spec/compose-go",
+						"rel_path": "./testdata",
+					},
+				},
+			},
+		},
+	}
+
+	expected := types.Project{
+		Name:       "myProject",
+		WorkingDir: wd,
+		Services: types.Services{
+			types.ServiceConfig{
+				Name: "test",
+				Build: &types.BuildConfig{
+					Context:    wd,
+					Dockerfile: "Dockerfile",
+					AdditionalContexts: map[string]string{
+						"image":    "docker-image://foo",
+						"oci":      "oci-layout://foo",
+						"abs_path": "/tmp",
+						"github":   "github.com/compose-spec/compose-go",
+						"rel_path": filepath.Join(wd, "testdata"),
+					},
+				},
+			},
+		},
+	}
+	err := ResolveRelativePaths(&project)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, expected, project)
+}


### PR DESCRIPTION
`Normalization` is used both to define implicit resources _and_ to resolve relative paths, so it brings a parameter so apply load option `ResolvePaths`
this PR introduces and explicit `ResolveRelativePaths` to manage this option as an explicit load operation
this also allows to avoid duplicating the code when loading service `extends` and resolving basefile-relative paths