### PR TITLE
introduce include to load sub-compose projects as dependencies

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -17,7 +17,6 @@
 package cli
 
 import (
-	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -250,7 +249,7 @@ func WithDotEnv(o *ProjectOptions) error {
 	if err != nil {
 		return err
 	}
-	envMap, err := GetEnvFromFile(o.Environment, wd, o.EnvFiles)
+	envMap, err := dotenv.GetEnvFromFile(o.Environment, wd, o.EnvFiles)
 	if err != nil {
 		return err
 	}
@@ -260,65 +259,6 @@ func WithDotEnv(o *ProjectOptions) error {
 		}
 	}
 	return nil
-}
-
-func GetEnvFromFile(currentEnv map[string]string, workingDir string, filenames []string) (map[string]string, error) {
-	envMap := make(map[string]string)
-
-	dotEnvFiles := filenames
-	if len(dotEnvFiles) == 0 {
-		dotEnvFiles = append(dotEnvFiles, filepath.Join(workingDir, ".env"))
-	}
-	for _, dotEnvFile := range dotEnvFiles {
-		abs, err := filepath.Abs(dotEnvFile)
-		if err != nil {
-			return envMap, err
-		}
-		dotEnvFile = abs
-
-		s, err := os.Stat(dotEnvFile)
-		if os.IsNotExist(err) {
-			if len(filenames) == 0 {
-				return envMap, nil
-			}
-			return envMap, errors.Errorf("Couldn't find env file: %s", dotEnvFile)
-		}
-		if err != nil {
-			return envMap, err
-		}
-
-		if s.IsDir() {
-			if len(filenames) == 0 {
-				return envMap, nil
-			}
-			return envMap, errors.Errorf("%s is a directory", dotEnvFile)
-		}
-
-		b, err := os.ReadFile(dotEnvFile)
-		if os.IsNotExist(err) {
-			return nil, errors.Errorf("Couldn't read env file: %s", dotEnvFile)
-		}
-		if err != nil {
-			return envMap, err
-		}
-
-		env, err := dotenv.ParseWithLookup(bytes.NewReader(b), func(k string) (string, bool) {
-			v, ok := currentEnv[k]
-			if ok {
-				return v, true
-			}
-			v, ok = envMap[k]
-			return v, ok
-		})
-		if err != nil {
-			return envMap, errors.Wrapf(err, "failed to read %s", dotEnvFile)
-		}
-		for k, v := range env {
-			envMap[k] = v
-		}
-	}
-
-	return envMap, nil
 }
 
 // WithInterpolation set ProjectOptions to enable/skip interpolation

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -308,19 +307,6 @@ func TestEnvMap(t *testing.T) {
 	assert.Equal(t, l[0], "foo=bar")
 	m = utils.GetAsEqualsMap(l)
 	assert.Equal(t, m["foo"], "bar")
-}
-
-func TestGetEnvFromFile(t *testing.T) {
-	wd := t.TempDir()
-	f := filepath.Join(wd, ".env")
-	err := os.Mkdir(f, 0o700)
-	assert.NilError(t, err)
-
-	_, err = GetEnvFromFile(nil, wd, nil)
-	assert.NilError(t, err)
-
-	_, err = GetEnvFromFile(nil, wd, []string{f})
-	assert.Check(t, strings.HasSuffix(err.Error(), ".env is a directory"))
 }
 
 func TestEnvVariablePrecedence(t *testing.T) {

--- a/dotenv/env.go
+++ b/dotenv/env.go
@@ -1,0 +1,84 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package dotenv
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+func GetEnvFromFile(currentEnv map[string]string, workingDir string, filenames []string) (map[string]string, error) {
+	envMap := make(map[string]string)
+
+	dotEnvFiles := filenames
+	if len(dotEnvFiles) == 0 {
+		dotEnvFiles = append(dotEnvFiles, filepath.Join(workingDir, ".env"))
+	}
+	for _, dotEnvFile := range dotEnvFiles {
+		abs, err := filepath.Abs(dotEnvFile)
+		if err != nil {
+			return envMap, err
+		}
+		dotEnvFile = abs
+
+		s, err := os.Stat(dotEnvFile)
+		if os.IsNotExist(err) {
+			if len(filenames) == 0 {
+				return envMap, nil
+			}
+			return envMap, errors.Errorf("Couldn't find env file: %s", dotEnvFile)
+		}
+		if err != nil {
+			return envMap, err
+		}
+
+		if s.IsDir() {
+			if len(filenames) == 0 {
+				return envMap, nil
+			}
+			return envMap, errors.Errorf("%s is a directory", dotEnvFile)
+		}
+
+		b, err := os.ReadFile(dotEnvFile)
+		if os.IsNotExist(err) {
+			return nil, errors.Errorf("Couldn't read env file: %s", dotEnvFile)
+		}
+		if err != nil {
+			return envMap, err
+		}
+
+		env, err := ParseWithLookup(bytes.NewReader(b), func(k string) (string, bool) {
+			v, ok := currentEnv[k]
+			if ok {
+				return v, true
+			}
+			v, ok = envMap[k]
+			return v, ok
+		})
+		if err != nil {
+			return envMap, errors.Wrapf(err, "failed to read %s", dotEnvFile)
+		}
+		for k, v := range env {
+			envMap[k] = v
+		}
+	}
+
+	return envMap, nil
+}

--- a/dotenv/godotenv_test.go
+++ b/dotenv/godotenv_test.go
@@ -3,11 +3,12 @@ package dotenv
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/assert"
 )
 
 var noopPresets = make(map[string]string)
@@ -15,9 +16,7 @@ var noopPresets = make(map[string]string)
 func parseAndCompare(t *testing.T, rawEnvLine string, expectedKey string, expectedValue string) {
 	t.Helper()
 	env, err := Parse(strings.NewReader(rawEnvLine))
-	if !assert.NoError(t, err) {
-		return
-	}
+	assert.NilError(t, err)
 	actualValue, ok := env[expectedKey]
 	if !ok {
 		t.Errorf("Key %q was not found in env: %v", expectedKey, env)
@@ -694,4 +693,17 @@ func TestDash(t *testing.T) {
 		"VAR.WITH.DOTS":        "dots",
 		"VAR_WITH_UNDERSCORES": "underscores",
 	}, noopPresets)
+}
+
+func TestGetEnvFromFile(t *testing.T) {
+	wd := t.TempDir()
+	f := filepath.Join(wd, ".env")
+	err := os.Mkdir(f, 0o700)
+	assert.NilError(t, err)
+
+	_, err = GetEnvFromFile(nil, wd, nil)
+	assert.NilError(t, err)
+
+	_, err = GetEnvFromFile(nil, wd, []string{f})
+	assert.Check(t, strings.HasSuffix(err.Error(), ".env is a directory"))
 }

--- a/loader/include.go
+++ b/loader/include.go
@@ -1,0 +1,120 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package loader
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/compose-spec/compose-go/dotenv"
+	"github.com/compose-spec/compose-go/types"
+	"github.com/pkg/errors"
+)
+
+// LoadIncludeConfig parse the require config from raw yaml
+func LoadIncludeConfig(source []interface{}) ([]types.IncludeConfig, error) {
+	var requires []types.IncludeConfig
+	err := Transform(source, &requires)
+	return requires, err
+}
+
+var transformIncludeConfig TransformerFunc = func(data interface{}) (interface{}, error) {
+	switch value := data.(type) {
+	case string:
+		return map[string]interface{}{"path": value}, nil
+	case map[string]interface{}:
+		return value, nil
+	default:
+		return data, errors.Errorf("invalid type %T for `include` configuration", value)
+	}
+}
+
+func loadInclude(configDetails types.ConfigDetails, model *types.Config, options *Options, loaded []string) (*types.Config, error) {
+	for _, r := range model.Include {
+		for i, p := range r.Path {
+			if !filepath.IsAbs(p) {
+				r.Path[i] = filepath.Join(configDetails.WorkingDir, p)
+			}
+		}
+		if r.ProjectDirectory == "" {
+			r.ProjectDirectory = filepath.Dir(r.Path[0])
+		}
+
+		loadOptions := options.clone()
+		loadOptions.SetProjectName(model.Name, true)
+		loadOptions.ResolvePaths = true
+		loadOptions.SkipNormalization = true
+		loadOptions.SkipConsistencyCheck = true
+
+		env, err := dotenv.GetEnvFromFile(configDetails.Environment, r.ProjectDirectory, r.EnvFile)
+		if err != nil {
+			return nil, err
+		}
+
+		imported, err := load(types.ConfigDetails{
+			WorkingDir:  r.ProjectDirectory,
+			ConfigFiles: types.ToConfigFiles(r.Path),
+			Environment: env,
+		}, loadOptions, loaded)
+		if err != nil {
+			return nil, err
+		}
+
+		err = importResources(model, imported, r.Path)
+		if err != nil {
+			return nil, err
+		}
+	}
+	model.Include = nil
+	return model, nil
+}
+
+// importResources import into model all resources defined by imported, and report error on conflict
+func importResources(model *types.Config, imported *types.Project, path []string) error {
+	services := mapByName(model.Services)
+	for _, service := range imported.Services {
+		if _, ok := services[service.Name]; ok {
+			return fmt.Errorf("imported compose file %s defines conflicting service %s", path, service.Name)
+		}
+		model.Services = append(model.Services, service)
+	}
+	for n, network := range imported.Networks {
+		if _, ok := model.Networks[n]; ok {
+			return fmt.Errorf("imported compose file %s defines conflicting network %s", path, n)
+		}
+		model.Networks[n] = network
+	}
+	for n, volume := range imported.Volumes {
+		if _, ok := model.Volumes[n]; ok {
+			return fmt.Errorf("imported compose file %s defines conflicting volume %s", path, n)
+		}
+		model.Volumes[n] = volume
+	}
+	for n, secret := range imported.Secrets {
+		if _, ok := model.Secrets[n]; ok {
+			return fmt.Errorf("imported compose file %s defines conflicting secret %s", path, n)
+		}
+		model.Secrets[n] = secret
+	}
+	for n, config := range imported.Configs {
+		if _, ok := model.Configs[n]; ok {
+			return fmt.Errorf("imported compose file %s defines conflicting config %s", path, n)
+		}
+		model.Configs[n] = config
+	}
+	return nil
+}

--- a/loader/testdata/compose-include.yaml
+++ b/loader/testdata/compose-include.yaml
@@ -1,0 +1,6 @@
+include:
+  - compose-include.yaml
+
+services:
+  foo:
+    image: foo

--- a/loader/testdata/subdir/compose-test-extends-imported.yaml
+++ b/loader/testdata/subdir/compose-test-extends-imported.yaml
@@ -1,6 +1,7 @@
 services:
   imported:
     image: nginx
+    container_name: ${SOURCE:-imported}
     env_file:
       - ./extra.env # expected to be loaded relative to this file, not the extending one
     volumes:

--- a/types/config.go
+++ b/types/config.go
@@ -67,16 +67,24 @@ type ConfigFile struct {
 	Config map[string]interface{}
 }
 
+func ToConfigFiles(path []string) (f []ConfigFile) {
+	for _, p := range path {
+		f = append(f, ConfigFile{Filename: p})
+	}
+	return
+}
+
 // Config is a full compose file configuration and model
 type Config struct {
-	Filename   string     `yaml:"-" json:"-"`
-	Name       string     `yaml:",omitempty" json:"name,omitempty"`
-	Services   Services   `json:"services"`
-	Networks   Networks   `yaml:",omitempty" json:"networks,omitempty"`
-	Volumes    Volumes    `yaml:",omitempty" json:"volumes,omitempty"`
-	Secrets    Secrets    `yaml:",omitempty" json:"secrets,omitempty"`
-	Configs    Configs    `yaml:",omitempty" json:"configs,omitempty"`
-	Extensions Extensions `yaml:",inline" json:"-"`
+	Filename   string          `yaml:"-" json:"-"`
+	Name       string          `yaml:"name,omitempty" json:"name,omitempty"`
+	Services   Services        `yaml:"services" json:"services"`
+	Networks   Networks        `yaml:"networks,omitempty" json:"networks,omitempty"`
+	Volumes    Volumes         `yaml:"volumes,omitempty" json:"volumes,omitempty"`
+	Secrets    Secrets         `yaml:"secrets,omitempty" json:"secrets,omitempty"`
+	Configs    Configs         `yaml:"configs,omitempty" json:"configs,omitempty"`
+	Extensions Extensions      `yaml:",inline" json:"-"`
+	Include    []IncludeConfig `yaml:"include,omitempty" json:"include,omitempty"`
 }
 
 // Volumes is a map of VolumeConfig

--- a/types/types.go
+++ b/types/types.go
@@ -1037,3 +1037,9 @@ type SecretConfig FileObjectConfig
 
 // ConfigObjConfig is the config for the swarm "Config" object
 type ConfigObjConfig FileObjectConfig
+
+type IncludeConfig struct {
+	Path             StringList `yaml:"path,omitempty" json:"path,omitempty"`
+	ProjectDirectory string     `yaml:"project_directory,omitempty" json:"project_directory,omitempty"`
+	EnvFile          StringList `yaml:"env_file,omitempty" json:"env_file,omitempty"`
+}


### PR DESCRIPTION
This adds support for `include` attribute introduced in the compose-specification by https://github.com/compose-spec/compose-spec/pull/363

This supports including compose sub-projects, comparable to language dependency management

usage:
```yaml
include:
   - ../commons/compose.yaml
   - ../another-project/compose.yaml

services:
   foo:
      depends_on:
         - imported-service
```

required projects are resolved based on their own project directory to avoid relative path hell.