### PR TITLE
fix `make lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build-validate-image:
 
 .PHONY: lint
 lint: build-validate-image
-	docker run --rm $(IMAGE_PREFIX)validate bash -c "golangci-lint run --config ./golangci.yml ./..."
+	docker run --rm $(IMAGE_PREFIX)validate bash -c "golangci-lint run --config ./.golangci.yml ./..."
 
 .PHONY: check-license
 check-license: build-validate-image

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -750,13 +750,6 @@ func resolveMaybeUnixPath(workingDir string, path string) string {
 	return filePath
 }
 
-func resolveSecretsPath(secret types.SecretConfig, workingDir string, lookupEnv template.Mapping) types.SecretConfig {
-	if !secret.External.External && secret.File != "" {
-		secret.File = resolveMaybeUnixPath(workingDir, secret.File)
-	}
-	return secret
-}
-
 // TODO: make this more robust
 func expandUser(path string) string {
 	if strings.HasPrefix(path, "~") {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1901,10 +1901,7 @@ func TestComposeFileWithVersion(t *testing.T) {
 	config, err := loadYAMLWithEnv(string(b), env)
 	assert.NilError(t, err)
 
-	workingDir, err := os.Getwd()
-	assert.NilError(t, err)
-
-	expectedConfig := withVersionExampleConfig(workingDir, homeDir)
+	expectedConfig := withVersionExampleConfig()
 
 	sort.Slice(config.Services, func(i, j int) bool {
 		return config.Services[i].Name > config.Services[j].Name

--- a/loader/with-version-struct_test.go
+++ b/loader/with-version-struct_test.go
@@ -20,15 +20,15 @@ import (
 	"github.com/compose-spec/compose-go/types"
 )
 
-func withVersionExampleConfig(workingDir, homeDir string) *types.Config {
+func withVersionExampleConfig() *types.Config {
 	return &types.Config{
-		Services: withVersionServices(workingDir, homeDir),
+		Services: withVersionServices(),
 		Networks: withVersionNetworks(),
 		Volumes:  withVersionVolumes(),
 	}
 }
 
-func withVersionServices(workingDir, homeDir string) []types.ServiceConfig {
+func withVersionServices() []types.ServiceConfig {
 	return []types.ServiceConfig{
 		{
 			Name: "web",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -17,19 +17,18 @@
 package schema
 
 import (
+	// Enable support for embedded static resources
+	_ "embed"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/xeipuuv/gojsonschema"
-
-	// Enable support for embedded static resources
-	_ "embed"
 )
 
 type portsFormatChecker struct{}
 
-func (checker portsFormatChecker) IsFormat(input interface{}) bool {
+func (checker portsFormatChecker) IsFormat(_ interface{}) bool {
 	// TODO: implement this
 	return true
 }


### PR DESCRIPTION
after https://github.com/compose-spec/compose-go/commit/497296ffa772a1660dc77d98439b39d5ac0b8ad0 `make lint` target is broken as the config file name has changed