### PR TITLE
Add substitution with options

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -17,6 +17,7 @@
 package template
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -71,75 +72,141 @@ type Mapping func(string) (string, bool)
 // the substitution and an error.
 type SubstituteFunc func(string, Mapping) (string, bool, error)
 
-// SubstituteWith substitute variables in the string with their values.
-// It accepts additional substitute function.
-func SubstituteWith(template string, mapping Mapping, pattern *regexp.Regexp, subsFuncs ...SubstituteFunc) (string, error) {
-	var outerErr error
+// ReplacementFunc is a user-supplied function that is apply to the matching
+// substring. Returns the value as a string and an error.
+type ReplacementFunc func(string, Mapping, config) (string, error)
+
+type config struct {
+	pattern         *regexp.Regexp
+	substituteFunc  SubstituteFunc
+	replacementFunc ReplacementFunc
+	logging         bool
+}
+
+type Option func(*config)
+
+func WithPattern(pattern *regexp.Regexp) Option {
+	return func(cfg *config) {
+		cfg.pattern = pattern
+	}
+}
+
+func WithSubstitutionFunction(subsFunc SubstituteFunc) Option {
+	return func(cfg *config) {
+		cfg.substituteFunc = subsFunc
+	}
+}
+
+func WithReplacementFunction(replacementFunc ReplacementFunc) Option {
+	return func(cfg *config) {
+		cfg.replacementFunc = replacementFunc
+	}
+}
+
+func WithoutLogging(cfg *config) {
+	cfg.logging = false
+}
+
+// SubstituteWithOptions substitute variables in the string with their values.
+// It accepts additional options such as a custom function or pattern.
+func SubstituteWithOptions(template string, mapping Mapping, options ...Option) (string, error) {
 	var returnErr error
 
-	result := pattern.ReplaceAllStringFunc(template, func(substring string) string {
-		_, subsFunc := getSubstitutionFunctionForTemplate(substring)
-		if len(subsFuncs) > 0 {
-			subsFunc = subsFuncs[0]
-		}
+	cfg := &config{
+		pattern:         defaultPattern,
+		replacementFunc: DefaultReplacementFunc,
+		logging:         true,
+	}
+	for _, o := range options {
+		o(cfg)
+	}
 
-		closingBraceIndex := getFirstBraceClosingIndex(substring)
-		rest := ""
-		if closingBraceIndex > -1 {
-			rest = substring[closingBraceIndex+1:]
-			substring = substring[0 : closingBraceIndex+1]
-		}
-
-		matches := pattern.FindStringSubmatch(substring)
-		groups := matchGroups(matches, pattern)
-		if escaped := groups["escaped"]; escaped != "" {
-			return escaped
-		}
-
-		braced := false
-		substitution := groups["named"]
-		if substitution == "" {
-			substitution = groups["braced"]
-			braced = true
-		}
-
-		if substitution == "" {
-			outerErr = &InvalidTemplateError{Template: template}
+	result := cfg.pattern.ReplaceAllStringFunc(template, func(substring string) string {
+		replacement, err := cfg.replacementFunc(substring, mapping, *cfg)
+		if err != nil {
+			// Add the template for template errors
+			var tmplErr *InvalidTemplateError
+			if errors.As(err, &tmplErr) {
+				if tmplErr.Template == "" {
+					tmplErr.Template = template
+				}
+			}
+			// Save the first error to be returned
 			if returnErr == nil {
-				returnErr = outerErr
+				returnErr = err
 			}
-			return ""
-		}
 
-		if braced {
-			var (
-				value   string
-				applied bool
-			)
-			value, applied, outerErr = subsFunc(substitution, mapping)
-			if outerErr != nil {
-				if returnErr == nil {
-					returnErr = outerErr
-				}
-				return ""
-			}
-			if applied {
-				interpolatedNested, err := SubstituteWith(rest, mapping, pattern)
-				if err != nil {
-					return ""
-				}
-				return value + interpolatedNested
-			}
 		}
-
-		value, ok := mapping(substitution)
-		if !ok {
-			logrus.Warnf("The %q variable is not set. Defaulting to a blank string.", substitution)
-		}
-		return value
+		return replacement
 	})
 
 	return result, returnErr
+}
+
+func DefaultReplacementFunc(substring string, mapping Mapping, cfg config) (string, error) {
+	pattern := cfg.pattern
+	subsFunc := cfg.substituteFunc
+	if subsFunc == nil {
+		_, subsFunc = getSubstitutionFunctionForTemplate(substring)
+	}
+
+	closingBraceIndex := getFirstBraceClosingIndex(substring)
+	rest := ""
+	if closingBraceIndex > -1 {
+		rest = substring[closingBraceIndex+1:]
+		substring = substring[0 : closingBraceIndex+1]
+	}
+
+	matches := pattern.FindStringSubmatch(substring)
+	groups := matchGroups(matches, pattern)
+	if escaped := groups["escaped"]; escaped != "" {
+		return escaped, nil
+	}
+
+	braced := false
+	substitution := groups["named"]
+	if substitution == "" {
+		substitution = groups["braced"]
+		braced = true
+	}
+
+	if substitution == "" {
+		return "", &InvalidTemplateError{}
+	}
+
+	if braced {
+		value, applied, err := subsFunc(substitution, mapping)
+		if err != nil {
+			return "", err
+		}
+		if applied {
+			interpolatedNested, err := SubstituteWith(rest, mapping, pattern)
+			if err != nil {
+				return "", err
+			}
+			return value + interpolatedNested, nil
+		}
+	}
+
+	value, ok := mapping(substitution)
+	if !ok && cfg.logging {
+		logrus.Warnf("The %q variable is not set. Defaulting to a blank string.", substitution)
+	}
+
+	return value, nil
+}
+
+// SubstituteWith substitute variables in the string with their values.
+// It accepts additional substitute function.
+func SubstituteWith(template string, mapping Mapping, pattern *regexp.Regexp, subsFuncs ...SubstituteFunc) (string, error) {
+	options := []Option{
+		WithPattern(pattern),
+	}
+	if len(subsFuncs) > 0 {
+		options = append(options, WithSubstitutionFunction(subsFuncs[0]))
+	}
+
+	return SubstituteWithOptions(template, mapping, options...)
 }
 
 func getSubstitutionFunctionForTemplate(template string) (string, SubstituteFunc) {

--- a/template/template.go
+++ b/template/template.go
@@ -74,36 +74,36 @@ type SubstituteFunc func(string, Mapping) (string, bool, error)
 
 // ReplacementFunc is a user-supplied function that is apply to the matching
 // substring. Returns the value as a string and an error.
-type ReplacementFunc func(string, Mapping, config) (string, error)
+type ReplacementFunc func(string, Mapping, *Config) (string, error)
 
-type config struct {
+type Config struct {
 	pattern         *regexp.Regexp
 	substituteFunc  SubstituteFunc
 	replacementFunc ReplacementFunc
 	logging         bool
 }
 
-type Option func(*config)
+type Option func(*Config)
 
 func WithPattern(pattern *regexp.Regexp) Option {
-	return func(cfg *config) {
+	return func(cfg *Config) {
 		cfg.pattern = pattern
 	}
 }
 
 func WithSubstitutionFunction(subsFunc SubstituteFunc) Option {
-	return func(cfg *config) {
+	return func(cfg *Config) {
 		cfg.substituteFunc = subsFunc
 	}
 }
 
 func WithReplacementFunction(replacementFunc ReplacementFunc) Option {
-	return func(cfg *config) {
+	return func(cfg *Config) {
 		cfg.replacementFunc = replacementFunc
 	}
 }
 
-func WithoutLogging(cfg *config) {
+func WithoutLogging(cfg *Config) {
 	cfg.logging = false
 }
 
@@ -112,7 +112,7 @@ func WithoutLogging(cfg *config) {
 func SubstituteWithOptions(template string, mapping Mapping, options ...Option) (string, error) {
 	var returnErr error
 
-	cfg := &config{
+	cfg := &Config{
 		pattern:         defaultPattern,
 		replacementFunc: DefaultReplacementFunc,
 		logging:         true,
@@ -122,7 +122,7 @@ func SubstituteWithOptions(template string, mapping Mapping, options ...Option) 
 	}
 
 	result := cfg.pattern.ReplaceAllStringFunc(template, func(substring string) string {
-		replacement, err := cfg.replacementFunc(substring, mapping, *cfg)
+		replacement, err := cfg.replacementFunc(substring, mapping, cfg)
 		if err != nil {
 			// Add the template for template errors
 			var tmplErr *InvalidTemplateError
@@ -143,7 +143,7 @@ func SubstituteWithOptions(template string, mapping Mapping, options ...Option) 
 	return result, returnErr
 }
 
-func DefaultReplacementFunc(substring string, mapping Mapping, cfg config) (string, error) {
+func DefaultReplacementFunc(substring string, mapping Mapping, cfg *Config) (string, error) {
 	pattern := cfg.pattern
 	subsFunc := cfg.substituteFunc
 	if subsFunc == nil {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -381,7 +381,7 @@ func TestSubstituteWithReplacementFunc(t *testing.T) {
 	options := []Option{
 		WithReplacementFunction(func(s string, m Mapping, c *Config) (string, error) {
 			if s == "${NOTHERE}" {
-				return "", fmt.Errorf("bad choice dude: %q", s)
+				return "", fmt.Errorf("bad choice: %q", s)
 			}
 			r, err := DefaultReplacementFunc(s, m, c)
 			if err == nil && r != "" {
@@ -399,7 +399,7 @@ func TestSubstituteWithReplacementFunc(t *testing.T) {
 	assert.Check(t, is.Equal("ok foobar", result))
 
 	_, err = SubstituteWithOptions("ok ${NOTHERE}", defaultMapping, options...)
-	assert.Check(t, is.ErrorContains(err, "bad choice dude"))
+	assert.Check(t, is.ErrorContains(err, "bad choice"))
 }
 
 // TestPrecedence tests is the precedence on '-' and '?' is of the first match

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -374,7 +374,6 @@ func TestSubstituteWithCustomFunc(t *testing.T) {
 	assert.Check(t, is.Equal("ok ", result))
 
 	_, err = SubstituteWith("ok ${NOTHERE}", defaultMapping, defaultPattern, errIsMissing)
-	fmt.Println(err)
 	assert.Check(t, is.ErrorContains(err, "required variable"))
 }
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -374,6 +374,7 @@ func TestSubstituteWithCustomFunc(t *testing.T) {
 	assert.Check(t, is.Equal("ok ", result))
 
 	_, err = SubstituteWith("ok ${NOTHERE}", defaultMapping, defaultPattern, errIsMissing)
+	fmt.Println(err)
 	assert.Check(t, is.ErrorContains(err, "required variable"))
 }
 


### PR DESCRIPTION
This PR introduces the `SubstituteWithOptions()` function including options for custom patterns, custom substitution functions and a **new** replacement function for allowing to customize the replacement behavior if e.g. no mapping was found.
The existing `SubstituteWith` function is switched over to the newly introduced function.