### PR TITLE
improve dotenv error messages

### DIFF
--- a/dotenv/parser.go
+++ b/dotenv/parser.go
@@ -123,8 +123,8 @@ loop:
 			}
 
 			return "", "", inherited, fmt.Errorf(
-				`line %d: unexpected character %q in variable name`,
-				p.line, string(rune))
+				`line %d: unexpected character %q in variable name %q`,
+				p.line, string(rune), strings.Split(src, "\n")[0])
 		}
 	}
 

--- a/dotenv/parser_test.go
+++ b/dotenv/parser_test.go
@@ -32,3 +32,9 @@ func TestParseBytes(t *testing.T) {
 		assert.Equal(t, value, out[key])
 	}
 }
+
+func TestParseVariable(t *testing.T) {
+	err := newParser().parse("%!(EXTRA string)=foo", map[string]string{}, nil)
+	assert.Error(t, err, "line 1: unexpected character \"%\" in variable name \"%!(EXTRA string)=foo\"")
+
+}

--- a/types/project.go
+++ b/types/project.go
@@ -507,7 +507,7 @@ func (p Project) ResolveServicesEnvironment(discardEnvFiles bool) error {
 
 			fileVars, err := dotenv.ParseWithLookup(bytes.NewBuffer(b), resolve)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "failed to read %s", envFile)
 			}
 			environment.OverrideBy(Mapping(fileVars).ToMappingWithEquals())
 		}


### PR DESCRIPTION
- print the variable name that failed to parse
- print the name of the file where the syntax error appeared