### PR TITLE
Add cluster volume type constant

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -815,6 +815,8 @@ const (
 	VolumeTypeTmpfs = "tmpfs"
 	// VolumeTypeNamedPipe is the type for mounting Windows named pipes
 	VolumeTypeNamedPipe = "npipe"
+	// VolumeTypeCluster is the type for mounting container storage interface (CSI) volumes
+	VolumeTypeCluster = "cluster"
 
 	// SElinuxShared share the volume content
 	SElinuxShared = "z"


### PR DESCRIPTION
[Cluster volumes](https://github.com/moby/moby/blob/master/docs/cluster_volumes.md) were added to docker SwarmKit in [23.0 of docker engine](https://github.com/docker/docs/blob/6dd952275680cf6f740058f1c0cf0b2e4e25f2ee/engine/release-notes/23.0.md?plain=1#L229). In short, cluster volumes enable use of container storage interface (CSI) volumes through docker's plugin system. This PR simply adds the `cluster` volume type constant. 


