### PR TITLE
loader: restore implicit default of `.` for build context with a warning

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -261,6 +261,13 @@ func Load(configDetails types.ConfigDetails, options ...func(*Options)) (*types.
 		Extensions:  model.Extensions,
 	}
 
+	if !opts.SkipNormalization {
+		err = Normalize(project)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if opts.ResolvePaths {
 		err = ResolveRelativePaths(project)
 		if err != nil {
@@ -274,13 +281,6 @@ func Load(configDetails types.ConfigDetails, options ...func(*Options)) (*types.
 				service.Volumes[j] = convertVolumePath(volume)
 			}
 			project.Services[i] = service
-		}
-	}
-
-	if !opts.SkipNormalization {
-		err = Normalize(project)
-		if err != nil {
-			return nil, err
 		}
 	}
 

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1928,7 +1928,8 @@ func TestLoadWithExtends(t *testing.T) {
 
 	extendsDir := filepath.Join("testdata", "subdir")
 
-	expectedEnvFilePath := filepath.Join(extendsDir, "extra.env")
+	expectedEnvFilePath, err := filepath.Abs(filepath.Join(extendsDir, "extra.env"))
+	assert.NilError(t, err)
 
 	expServices := types.Services{
 		{


### PR DESCRIPTION
# This is an alternate version of #423 that includes a warning.

---

In the Compose spec, as well as Compose v1.x, the `build.context` field is mandatory in the object form of a `service.build` definition.

However, in compose-go (and thus Compose v2.x), this has never been enforced, and an empty `build.context` field was implicitly set to `.` aka the project directory.

Restore that behavior and emit a warning that future versions will reject this.

Note that the order of normalization and resolving paths has been switched so that normalization occurs first, and then paths can be resolved across all fields consistently. This resulted in a small test update where this was incorrect before - it was loading with path resolution enabled but then asserting it had a relative path for the env file.