### PR TITLE
loader: path resolution consistency

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1928,7 +1928,8 @@ func TestLoadWithExtends(t *testing.T) {
 
 	extendsDir := filepath.Join("testdata", "subdir")
 
-	expectedEnvFilePath := filepath.Join(extendsDir, "extra.env")
+	expectedEnvFilePath, err := filepath.Abs(filepath.Join(extendsDir, "extra.env"))
+	assert.NilError(t, err)
 
 	expServices := types.Services{
 		{

--- a/loader/merge_test.go
+++ b/loader/merge_test.go
@@ -233,6 +233,7 @@ func loadTestProject(configDetails types.ConfigDetails) (*types.Project, error) 
 	return Load(configDetails, func(options *Options) {
 		options.SkipNormalization = true
 		options.SkipConsistencyCheck = true
+		options.ResolvePaths = false
 	})
 }
 

--- a/loader/normalize.go
+++ b/loader/normalize.go
@@ -18,7 +18,6 @@ package loader
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/compose-spec/compose-go/errdefs"
@@ -29,12 +28,6 @@ import (
 
 // Normalize compose project by moving deprecated attributes to their canonical position and injecting implicit defaults
 func Normalize(project *types.Project) error {
-	absWorkingDir, err := filepath.Abs(project.WorkingDir)
-	if err != nil {
-		return err
-	}
-	project.WorkingDir = absWorkingDir
-
 	if project.Networks == nil {
 		project.Networks = make(map[string]types.NetworkConfig)
 	}
@@ -44,8 +37,7 @@ func Normalize(project *types.Project) error {
 		project.Networks["default"] = types.NetworkConfig{}
 	}
 
-	err = relocateExternalName(project)
-	if err != nil {
+	if err := relocateExternalName(project); err != nil {
 		return err
 	}
 
@@ -126,14 +118,6 @@ func Normalize(project *types.Project) error {
 		inferImplicitDependencies(&s)
 
 		project.Services[i] = s
-	}
-
-	for name, config := range project.Volumes {
-		if config.Driver == "local" && config.DriverOpts["o"] == "bind" {
-			// This is actually a bind mount
-			config.DriverOpts["device"] = absPath(project.WorkingDir, config.DriverOpts["device"])
-			project.Volumes[name] = config
-		}
 	}
 
 	setNameFromKey(project)

--- a/loader/normalize_test.go
+++ b/loader/normalize_test.go
@@ -18,7 +18,6 @@ package loader
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/compose-spec/compose-go/types"
@@ -103,7 +102,6 @@ func TestNormalizeVolumes(t *testing.T) {
 		},
 	}
 
-	absCwd, _ := filepath.Abs(".")
 	expected := types.Project{
 		Name:     "myProject",
 		Networks: types.Networks{"default": {Name: "myProject_default"}},
@@ -117,7 +115,6 @@ func TestNormalizeVolumes(t *testing.T) {
 				Name: "CustomName",
 			},
 		},
-		WorkingDir: absCwd,
 	}
 	err := Normalize(&project)
 	assert.NilError(t, err)

--- a/loader/paths.go
+++ b/loader/paths.go
@@ -26,6 +26,12 @@ import (
 
 // ResolveRelativePaths resolves relative paths based on project WorkingDirectory
 func ResolveRelativePaths(project *types.Project) error {
+	absWorkingDir, err := filepath.Abs(project.WorkingDir)
+	if err != nil {
+		return err
+	}
+	project.WorkingDir = absWorkingDir
+
 	absComposeFiles, err := absComposeFiles(project.ComposeFiles)
 	if err != nil {
 		return err


### PR DESCRIPTION
Move the project working directory absolute path resolution to `ResolveRelativePaths` and remove redundant local volume (a rarely used way of creating bind mounts) absolute path resolution from the normalization method.