### PR TITLE
merge expose and keep order

### DIFF
--- a/loader/merge.go
+++ b/loader/merge.go
@@ -150,13 +150,12 @@ func unique(slice []string) []string {
 		return nil
 	}
 	uniqMap := make(map[string]struct{})
+	var uniqSlice []string
 	for _, v := range slice {
-		uniqMap[v] = struct{}{}
-	}
-
-	uniqSlice := make([]string, 0, len(uniqMap))
-	for v := range uniqMap {
-		uniqSlice = append(uniqSlice, v)
+		if _, ok := uniqMap[v]; !ok {
+			uniqSlice = append(uniqSlice, v)
+			uniqMap[v] = struct{}{}
+		}
 	}
 	return uniqSlice
 }

--- a/loader/merge_test.go
+++ b/loader/merge_test.go
@@ -1433,3 +1433,56 @@ services:
 		Environment: map[string]string{consts.ComposeProjectName: "test"},
 	}, config)
 }
+
+func TestMergeExpose(t *testing.T) {
+	base := `
+name: test
+services:
+  foo:
+    image: foo
+    expose:
+      - "8080"
+      - "8081"
+      - "8082"
+      - "8083"
+      - "8084"
+`
+	override := `
+services:
+  foo:
+    image: foo
+    expose:
+      - "8090"
+      - "8091"
+      - "8082"
+      - "8081"
+`
+	configDetails := types.ConfigDetails{
+		Environment: map[string]string{},
+		ConfigFiles: []types.ConfigFile{
+			{Filename: "base.yml", Content: []byte(base)},
+			{Filename: "override.yml", Content: []byte(override)},
+		},
+	}
+	config, err := loadTestProject(configDetails)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, &types.Project{
+		Name:       "test",
+		WorkingDir: "",
+		Services: []types.ServiceConfig{
+			{
+				Name:        "foo",
+				Image:       "foo",
+				Environment: types.MappingWithEquals{},
+				Expose:      types.StringOrNumberList{"8080", "8081", "8082", "8083", "8084", "8090", "8091"},
+				Scale:       1,
+			},
+		},
+		Networks:    types.Networks{},
+		Volumes:     types.Volumes{},
+		Secrets:     types.Secrets{},
+		Configs:     types.Configs{},
+		Extensions:  types.Extensions{},
+		Environment: map[string]string{consts.ComposeProjectName: "test"},
+	}, config)
+}


### PR DESCRIPTION
`Expose` entries must be unique and order MUST be preserved so that config hash is reproducible

closes https://github.com/docker/compose/issues/10765
https://docker.atlassian.net/browse/ENV-242