### PR TITLE
loader: consistently resolve `build.context` path

### DIFF
--- a/loader/full-example.yml
+++ b/loader/full-example.yml
@@ -24,7 +24,7 @@ services:
         - bar
       labels: [FOO=BAR]
       additional_contexts:
-        foo: /bar
+        foo: ./bar
       secrets:
         - secret1
         - source: secret2

--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -53,7 +53,7 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 				"com.example.foo": "bar",
 			},
 			Build: &types.BuildConfig{
-				Context:            "./dir",
+				Context:            filepath.Join(workingDir, "dir"),
 				Dockerfile:         "Dockerfile",
 				Args:               map[string]*string{"foo": strPtr("bar")},
 				SSH:                []types.SSHKey{{ID: "default", Path: ""}},
@@ -438,6 +438,7 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 		{
 			Name: "bar",
 			Build: &types.BuildConfig{
+				Context:          workingDir,
 				DockerfileInline: "FROM alpine\nRUN echo \"hello\" > /world.txt\n",
 			},
 			Environment: types.MappingWithEquals{},
@@ -598,6 +599,7 @@ func fullExampleYAML(workingDir, homeDir string) string {
 services:
   bar:
     build:
+      context: %s
       dockerfile_inline: |
         FROM alpine
         RUN echo "hello" > /world.txt
@@ -605,7 +607,7 @@ services:
     annotations:
       com.example.foo: bar
     build:
-      context: ./dir
+      context: %s
       dockerfile: Dockerfile
       args:
         foo: bar
@@ -1037,6 +1039,8 @@ x-nested:
   bar: baz
   foo: bar
 `,
+		workingDir,
+		filepath.Join(workingDir, "dir"),
 		filepath.Join(workingDir, "example1.env"),
 		filepath.Join(workingDir, "example2.env"),
 		workingDir,
@@ -1148,6 +1152,7 @@ func fullExampleJSON(workingDir, homeDir string) string {
   "services": {
     "bar": {
       "build": {
+        "context": %q,
         "dockerfile_inline": "FROM alpine\nRUN echo \"hello\" \u003e /world.txt\n"
       },
       "command": null,
@@ -1158,7 +1163,7 @@ func fullExampleJSON(workingDir, homeDir string) string {
         "com.example.foo": "bar"
       },
       "build": {
-        "context": "./dir",
+        "context": %q,
         "dockerfile": "Dockerfile",
         "args": {
           "foo": "bar"
@@ -1683,6 +1688,8 @@ func fullExampleJSON(workingDir, homeDir string) string {
 		toPath(workingDir, "config_data"),
 		toPath(homeDir, "config_data"),
 		toPath(workingDir, "secret_data"),
+		toPath(workingDir),
+		toPath(workingDir, "dir"),
 		toPath(workingDir, "example1.env"),
 		toPath(workingDir, "example2.env"),
 		toPath(workingDir),

--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -60,7 +60,7 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 				Target:             "foo",
 				Network:            "foo",
 				CacheFrom:          []string{"foo", "bar"},
-				AdditionalContexts: types.Mapping{"foo": "/bar"},
+				AdditionalContexts: types.Mapping{"foo": filepath.Join(workingDir, "bar")},
 				Labels:             map[string]string{"FOO": "BAR"},
 				Secrets: []types.ServiceSecretConfig{
 					{
@@ -619,7 +619,7 @@ services:
         - foo
         - bar
       additional_contexts:
-        foo: /bar
+        foo: %s
       network: foo
       target: foo
       secrets:
@@ -1041,6 +1041,7 @@ x-nested:
 `,
 		workingDir,
 		filepath.Join(workingDir, "dir"),
+		filepath.Join(workingDir, "bar"),
 		filepath.Join(workingDir, "example1.env"),
 		filepath.Join(workingDir, "example2.env"),
 		workingDir,
@@ -1152,7 +1153,7 @@ func fullExampleJSON(workingDir, homeDir string) string {
   "services": {
     "bar": {
       "build": {
-        "context": %q,
+        "context": "%s",
         "dockerfile_inline": "FROM alpine\nRUN echo \"hello\" \u003e /world.txt\n"
       },
       "command": null,
@@ -1163,7 +1164,7 @@ func fullExampleJSON(workingDir, homeDir string) string {
         "com.example.foo": "bar"
       },
       "build": {
-        "context": %q,
+        "context": "%s",
         "dockerfile": "Dockerfile",
         "args": {
           "foo": "bar"
@@ -1179,7 +1180,7 @@ func fullExampleJSON(workingDir, homeDir string) string {
           "bar"
         ],
         "additional_contexts": {
-          "foo": "/bar"
+          "foo": "%s"
         },
         "network": "foo",
         "target": "foo",
@@ -1690,6 +1691,7 @@ func fullExampleJSON(workingDir, homeDir string) string {
 		toPath(workingDir, "secret_data"),
 		toPath(workingDir),
 		toPath(workingDir, "dir"),
+		toPath(workingDir, "bar"),
 		toPath(workingDir, "example1.env"),
 		toPath(workingDir, "example2.env"),
 		toPath(workingDir),

--- a/loader/paths_test.go
+++ b/loader/paths_test.go
@@ -84,6 +84,7 @@ func TestResolveBuildContextPaths(t *testing.T) {
 
 func TestResolveAdditionalContexts(t *testing.T) {
 	wd, _ := filepath.Abs(".")
+	absSubdir := filepath.Join(wd, "dir")
 	project := types.Project{
 		Name:       "myProject",
 		WorkingDir: wd,
@@ -96,7 +97,7 @@ func TestResolveAdditionalContexts(t *testing.T) {
 					AdditionalContexts: map[string]string{
 						"image":    "docker-image://foo",
 						"oci":      "oci-layout://foo",
-						"abs_path": "/tmp",
+						"abs_path": absSubdir,
 						"github":   "github.com/compose-spec/compose-go",
 						"rel_path": "./testdata",
 					},
@@ -117,7 +118,7 @@ func TestResolveAdditionalContexts(t *testing.T) {
 					AdditionalContexts: map[string]string{
 						"image":    "docker-image://foo",
 						"oci":      "oci-layout://foo",
-						"abs_path": "/tmp",
+						"abs_path": absSubdir,
 						"github":   "github.com/compose-spec/compose-go",
 						"rel_path": filepath.Join(wd, "testdata"),
 					},

--- a/loader/types_test.go
+++ b/loader/types_test.go
@@ -25,7 +25,7 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 )
 
-func TestMarshallProject(t *testing.T) {
+func TestMarshalProject(t *testing.T) {
 	workingDir, err := os.Getwd()
 	assert.NilError(t, err)
 	homeDir, err := os.UserHomeDir()
@@ -45,7 +45,7 @@ func TestMarshallProject(t *testing.T) {
 	assert.NilError(t, err)
 }
 
-func TestJSONMarshallProject(t *testing.T) {
+func TestJSONMarshalProject(t *testing.T) {
 	workingDir, err := os.Getwd()
 	assert.NilError(t, err)
 	homeDir, err := os.UserHomeDir()

--- a/loader/with-version-struct_test.go
+++ b/loader/with-version-struct_test.go
@@ -17,6 +17,8 @@
 package loader
 
 import (
+	"path/filepath"
+
 	"github.com/compose-spec/compose-go/types"
 )
 
@@ -29,12 +31,13 @@ func withVersionExampleConfig() *types.Config {
 }
 
 func withVersionServices() []types.ServiceConfig {
+	buildCtx, _ := filepath.Abs("./Dockerfile")
 	return []types.ServiceConfig{
 		{
 			Name: "web",
 
 			Build: &types.BuildConfig{
-				Context: "./Dockerfile",
+				Context: buildCtx,
 			},
 			Environment: types.MappingWithEquals{},
 			Networks: map[string]*types.ServiceNetworkConfig{


### PR DESCRIPTION
When using `extends.file` to load a service from another Compose file, if the `build.context` field wasn't explicitly set, it would get ignored by the path resolution.

As a result, the build context would end up as the working directory of the _root_ Compose file instead of the working directory of the _loaded_ Compose file.

This was because the relative path resolution logic ignored empty `build.context` values. Unfortunately, removing that restriction is itself not sufficient, as it then attempted to verify that the local path existed in an attempt to avoid unintentionally joining the working directory with a remote context value (e.g. `/foo/https://github.com/my/repo.git`).

This is problematic because the working directory itself might be relative (rooted to an unknown location that is != `.`), so it will be resolved relative to the current process working directory, and thus fail the existence check.

In practice, this happens when using `extends.file`, where we do resolve paths but intentionally pass a potentially relative value for the working dir, thus making it unsafe to be doing real filesystem operations here.

In fact, even if a context was specified, it was possible to break this by running Compose from a different directory than the _root_ Compose file while specifying the path to it.

As there's no formal specification for determining local path vs. remote build contexts (see discussion in #385), I'm simply eliminating the existence check. This COULD mean that Compose begins to erroneously consider remote context values as local paths if builders add new unsupported syntaxes, but I think it's fair for us to be more restrictive.

Additionally, I've ensured that when path resolution is happening, it _always_ resolves the `build.context` to an absolute path for consistency. In particular, this should help make it easier to use the output of `docker compose config` from arbitrary working directories.

There's a new test that covers the `extends.file` + `build.context` behavior, and everal existing test adjustments to account for the fact that Compose was emitting relative `build.context` paths from `docker compose config` despite everything else being absolute (such as volumes).

Fixes:
 * docker/for-mac#6912