### PR TITLE
load: resolve symlinks and fix various path issues

### DIFF
--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -65,10 +65,13 @@ func TestProjectName(t *testing.T) {
 	})
 
 	t.Run("by name empty working dir", func(t *testing.T) {
+		tmpdir := t.TempDir()
+		wd := filepath.Join(tmpdir, "proj")
+		assert.NilError(t, os.Mkdir(wd, 0o700))
 		opts, err := NewProjectOptions(
 			[]string{"testdata/simple/compose.yaml"},
 			WithName(""),
-			WithWorkingDirectory("/path/to/proj"),
+			WithWorkingDirectory(wd),
 		)
 		assert.NilError(t, err)
 		p, err := ProjectFromOptions(opts)

--- a/cli/paths.go
+++ b/cli/paths.go
@@ -1,0 +1,44 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cli
+
+import (
+	"io/fs"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// RealAbsPath attempts to determine the true absolute path after symlink evaluation.
+func RealAbsPath(path string) (string, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	realPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// symlink resolution is done to ensure we use the canonical
+			// version of a path; if it does not exist, return the absolute
+			// path, allowing a failure to occur at the natural point when
+			// the path is attempted to be read.
+			return path, nil
+		}
+		return "", err
+	}
+	return filepath.Abs(realPath)
+}

--- a/cli/paths_test.go
+++ b/cli/paths_test.go
@@ -1,0 +1,90 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestRealAbsPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Test creates real files on disk")
+	}
+
+	tmpdir := temporaryWorkDir(t)
+
+	realDir := filepath.Join(tmpdir, "real")
+	assert.Equal(t, true, filepath.IsAbs(realDir))
+	assert.NilError(t, os.Mkdir(realDir, 0o700))
+	linkDir := filepath.Join(tmpdir, "symlink")
+	assert.NilError(t, os.Symlink(realDir, linkDir))
+
+	var p string
+	var err error
+
+	// reflexive
+	p, err = RealAbsPath(realDir)
+	assert.NilError(t, err)
+	assert.Equal(t, realDir, p)
+
+	// follow symlink
+	p, err = RealAbsPath(linkDir)
+	assert.NilError(t, err)
+	assert.Equal(t, realDir, p)
+
+	// reflexive (relative)
+	p, err = RealAbsPath("./real")
+	assert.NilError(t, err)
+	assert.Equal(t, realDir, p)
+
+	// follow symlink (relative)
+	p, err = RealAbsPath("./symlink")
+	assert.NilError(t, err)
+	assert.Equal(t, realDir, p)
+
+	// non-existent
+	p, err = RealAbsPath("./does-not-exist")
+	assert.NilError(t, err)
+	assert.Equal(t, filepath.Join(tmpdir, "does-not-exist"), p)
+}
+
+func temporaryWorkDir(t testing.TB) string {
+	t.Helper()
+
+	// the tmpdir might itself be a symlink (e.g. on macOS)
+	tmpdir, err := filepath.EvalSymlinks(t.TempDir())
+	assert.NilError(t, err)
+
+	wd, err := os.Getwd()
+	assert.NilError(t, err)
+	// NOTE: cleanup funcs are executed LIFO, so we need to restore
+	// the old dir before the `t.TempDir()` cleanup fires or it'll
+	// fail on Windows since the path will still be in use (by us)
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			panic(fmt.Errorf("restoring working directory: %v", err))
+		}
+	})
+
+	assert.NilError(t, os.Chdir(tmpdir))
+	return tmpdir
+}

--- a/loader/include.go
+++ b/loader/include.go
@@ -69,6 +69,7 @@ func loadInclude(configDetails types.ConfigDetails, model *types.Config, options
 			WorkingDir:  r.ProjectDirectory,
 			ConfigFiles: types.ToConfigFiles(r.Path),
 			Environment: env,
+			HomeDir:     configDetails.HomeDir,
 		}, loadOptions, loaded)
 		if err != nil {
 			return nil, err

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -52,6 +52,7 @@ func buildConfigDetailsMultipleFiles(env map[string]string, yamls ...string) typ
 		WorkingDir:  workingDir,
 		ConfigFiles: buildConfigFiles(yamls),
 		Environment: env,
+		HomeDir:     env["HOME"],
 	}
 }
 
@@ -1988,10 +1989,6 @@ func TestLoadWithExtends(t *testing.T) {
 	assert.NilError(t, err)
 
 	extendsDir := filepath.Join("testdata", "subdir")
-
-	expectedEnvFilePath, err := filepath.Abs(filepath.Join(extendsDir, "extra.env"))
-	assert.NilError(t, err)
-
 	expServices := types.Services{
 		{
 			Name:          "importer",
@@ -2000,7 +1997,7 @@ func TestLoadWithExtends(t *testing.T) {
 			Environment: types.MappingWithEquals{
 				"SOURCE": strPtr("extends"),
 			},
-			EnvFile:  []string{expectedEnvFilePath},
+			EnvFile:  []string{filepath.Join(extendsDir, "extra.env")},
 			Networks: map[string]*types.ServiceNetworkConfig{"default": nil},
 			Volumes: []types.ServiceVolumeConfig{{
 				Type:   "bind",

--- a/loader/paths_project.go
+++ b/loader/paths_project.go
@@ -1,0 +1,78 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package loader
+
+import (
+	paths "path"
+	"path/filepath"
+	"strings"
+)
+
+// ProjectPathResolver resolves file path references within a Compose file to suitable
+// paths for use.
+//
+// Relative paths are joined to the ProjectDir (note: this might still be a relative
+// path if ProjectDir is itself relative).
+//
+// Shell-style user-home relative paths such as `~/foo` are joined to the HomeDir
+// if specified. If HomeDir is empty, they will be left as-is.
+//
+// All returned paths are cleaned for consistency.
+type ProjectPathResolver struct {
+	// ProjectDir is the path to the project working directory.
+	//
+	// Any relative paths in a Compose file are based off this.
+	ProjectDir string
+
+	// HomeDir is the user's home directory path.
+	//
+	// If non-empty, any shell-style user-home relative paths (e.g. `~/foo`)
+	// are based off this.
+	//
+	// If empty, any shell-style user-home relative paths are returned as-is.
+	HomeDir string
+}
+
+// Resolve checks if the value is an absolute path for the OS loading the project.
+func (r ProjectPathResolver) Resolve(path string) string {
+	if strings.HasPrefix(path, "~") {
+		if r.HomeDir == "" {
+			// this is a user-home relative path no
+			// homedir was specified, so leave it as-is
+			return filepath.Clean(path)
+		}
+		path = filepath.Join(r.HomeDir, path[1:])
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(r.ProjectDir, path)
+	}
+	path = filepath.Clean(path)
+	return path
+}
+
+// ResolveMaybeUnix checks if the value is an absolute path (either Unix or Windows) to
+// handle a Windows client with a Unix daemon or vice-versa.
+//
+// Note that this is not required for Docker for Windows when specifying
+// a local Windows path, because Docker for Windows translates the Windows
+// path into a valid path within the VM.
+func (r ProjectPathResolver) ResolveMaybeUnix(path string) string {
+	if !paths.IsAbs(path) && !isAbs(path) {
+		return r.Resolve(path)
+	}
+	return path
+}

--- a/loader/paths_test.go
+++ b/loader/paths_test.go
@@ -25,27 +25,6 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestResolveComposeFilePaths(t *testing.T) {
-	absWorkingDir, _ := filepath.Abs("testdata")
-	absComposeFile, _ := filepath.Abs(filepath.Join("testdata", "simple", "compose.yaml"))
-	absOverrideFile, _ := filepath.Abs(filepath.Join("testdata", "simple", "compose-with-overrides.yaml"))
-
-	project := types.Project{
-		Name:         "myProject",
-		WorkingDir:   absWorkingDir,
-		ComposeFiles: []string{filepath.Join("testdata", "simple", "compose.yaml"), filepath.Join("testdata", "simple", "compose-with-overrides.yaml")},
-	}
-
-	expected := types.Project{
-		Name:         "myProject",
-		WorkingDir:   absWorkingDir,
-		ComposeFiles: []string{absComposeFile, absOverrideFile},
-	}
-	err := ResolveRelativePaths(&project)
-	assert.NilError(t, err)
-	assert.DeepEqual(t, expected, project)
-}
-
 func TestResolveBuildContextPaths(t *testing.T) {
 	wd, _ := os.Getwd()
 	project := types.Project{

--- a/types/config.go
+++ b/types/config.go
@@ -35,6 +35,7 @@ type ConfigDetails struct {
 	WorkingDir  string
 	ConfigFiles []ConfigFile
 	Environment map[string]string
+	HomeDir     string
 }
 
 // LookupEnv provides a lookup function for environment variables


### PR DESCRIPTION
The loader is very inconsistent with how it deals with relative
paths, and there have been various edge cases in which it does
not behave as expected (see #434).

At its core, this commit attempts to do the following:
  * Within the loader, do not perform real filesystem operations
    on paths (e.g. stat for existence)
  * Within the loader, use the root paths provided as-is, making
    other paths relative to them without trying to make the final
    result absolute
  * Perform real path lookup in the `ProjectOptions` helper in
    the `cli` package, including resolving symlinks and making the
    root paths absolute

Effectively, this is an attempt to make (the path-handling parts
of) the loader more "pure". It still does a lot of direct file
I/O (e.g. for `extends`, `env_file`) using `os.ReadFile` directly,
but this goes a long way towards making it practical to use the
loader for complex, multi-file projects without ever actually
touching the disk.

Pushing more of the "real system" concerns up to `ProjectOptions`
in the `cli` package means that the behavior should still be
consistent for high-level consumers.

There is a breaking behavioral change here for low-level consumers,
however, as shell-style user-home relative paths (e.g. `~/foo`)
were being resolved directly using system lookups deep within the
loader. Now, `ConfigDetails` includes a `HomeDir` field much like
`WorkingDir`, which is used to resolve these types of paths.

In the end, this should all provide greater flexibility and make
things slightly easier to test, since there's less system leakage.