### PR TITLE
load: include details about included files on `Project`

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2545,6 +2545,15 @@ services:
 			},
 		},
 	})
+	assert.DeepEqual(t, p.IncludeReferences, map[string][]types.IncludeConfig{
+		filepath.Join(workingDir, "filename0.yml"): {
+			{
+				Path:             []string{filepath.Join(workingDir, "testdata", "subdir", "compose-test-extends-imported.yaml")},
+				ProjectDirectory: workingDir,
+				EnvFile:          []string{filepath.Join(workingDir, "testdata", "subdir", "extra.env")},
+			},
+		},
+	})
 	assert.NilError(t, err)
 }
 

--- a/types/project.go
+++ b/types/project.go
@@ -36,16 +36,22 @@ import (
 
 // Project is the result of loading a set of compose files
 type Project struct {
-	Name         string     `yaml:"name,omitempty" json:"name,omitempty"`
-	WorkingDir   string     `yaml:"-" json:"-"`
-	Services     Services   `yaml:"services" json:"services"`
-	Networks     Networks   `yaml:"networks,omitempty" json:"networks,omitempty"`
-	Volumes      Volumes    `yaml:"volumes,omitempty" json:"volumes,omitempty"`
-	Secrets      Secrets    `yaml:"secrets,omitempty" json:"secrets,omitempty"`
-	Configs      Configs    `yaml:"configs,omitempty" json:"configs,omitempty"`
-	Extensions   Extensions `yaml:"#extensions,inline" json:"-"` // https://github.com/golang/go/issues/6213
-	ComposeFiles []string   `yaml:"-" json:"-"`
-	Environment  Mapping    `yaml:"-" json:"-"`
+	Name       string     `yaml:"name,omitempty" json:"name,omitempty"`
+	WorkingDir string     `yaml:"-" json:"-"`
+	Services   Services   `yaml:"services" json:"services"`
+	Networks   Networks   `yaml:"networks,omitempty" json:"networks,omitempty"`
+	Volumes    Volumes    `yaml:"volumes,omitempty" json:"volumes,omitempty"`
+	Secrets    Secrets    `yaml:"secrets,omitempty" json:"secrets,omitempty"`
+	Configs    Configs    `yaml:"configs,omitempty" json:"configs,omitempty"`
+	Extensions Extensions `yaml:"#extensions,inline" json:"-"` // https://github.com/golang/go/issues/6213
+
+	// IncludeReferences is keyed by Compose YAML filename and contains config for
+	// other Compose YAML files it directly triggered a load of via `include`.
+	//
+	// Note: this is
+	IncludeReferences map[string][]IncludeConfig `yaml:"-" json:"-"`
+	ComposeFiles      []string                   `yaml:"-" json:"-"`
+	Environment       Mapping                    `yaml:"-" json:"-"`
 
 	// DisabledServices track services which have been disable as profile is not active
 	DisabledServices Services `yaml:"-" json:"-"`


### PR DESCRIPTION
Add a map to `Project` that has Compose YAML filename as key and any `IncludeConfig`s loaded from it.

This is populated as the project is recursively loaded.

For example:
```
proj/
  compose.yaml
  a/
    compose.yaml
  b/
    compose.yaml
```

If `project/compose.yaml` has:
```yaml
include: ['./a/compose.yaml']
```

And `project/a/compose.yaml` has:
```yaml
include: ['../b/compose.yaml']
```

The final result after load is conceptually:
```json
{
  "proj/compose.yaml": ["proj/a/compose.yaml"],
  "proj/a/compose.yaml": ["proj/b/compose.yaml"],
}
```
(Note: in reality, it's a list of `IncludeConfig`, which has multiple fields. Example is simplified.)

Relative path resolution is based on overall loader configuration, but note that disabling it does not work properly for `include` currently due to other issues.

This makes it possible for the caller to understand a bit more about the loaded project resources. We're really overdue for a bit of an overhaul/refactor of the loader - at that point, I think it might be better to have a `Loader` object type that can track stuff like this on the instance because it's weirdly both part of the project and NOT part of the project at the moment (similar to `Profiles`, project name, etc).