### PR TITLE
ability to convert a mapping (back) to KEY=VALUE strings

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -491,6 +491,16 @@ func NewMapping(values []string) Mapping {
 	return mapping
 }
 
+// convert values into a set of KEY=VALUE strings
+func (m Mapping) Values() []string {
+	values := make([]string, 0, len(m))
+	for k, v := range m {
+		values = append(values, fmt.Sprintf("%s=%s", k, v))
+	}
+	sort.Strings(values)
+	return values
+}
+
 // ToMappingWithEquals converts Mapping into a MappingWithEquals with pointer references
 func (m Mapping) ToMappingWithEquals() MappingWithEquals {
 	mapping := MappingWithEquals{}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -368,3 +368,14 @@ func equalTrimSpace(x interface{}, y interface{}) is.Comparison {
 	}
 	return is.DeepEqual(trim(x), trim(y))
 }
+
+func TestMappingValues(t *testing.T) {
+	values := []string{"BAR=QIX", "FOO=BAR", "QIX=ZOT"}
+	mapping := NewMapping(values)
+	assert.DeepEqual(t, mapping, Mapping{
+		"FOO": "BAR",
+		"BAR": "QIX",
+		"QIX": "ZOT",
+	})
+	assert.DeepEqual(t, mapping.Values(), values)
+}


### PR DESCRIPTION
this would allow to use Mapping from os.Environ and back as demonstrated on https://github.com/docker/compose/pull/10811/files#diff-5eb9d3607857efe53a0fb84cf97f6ef564834e72c264005796416bb7936471e2R176