### PR TITLE
load: ignore dependency fields with `extends`

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -777,6 +777,21 @@ func loadServiceWithExtends(ctx context.Context, filename, name string, services
 			ResolveServiceRelativePaths(baseFileParent, baseService)
 		}
 
+		baseService.VolumesFrom = nil
+		baseService.DependsOn = nil
+		maybeReferences := []*string{
+			&baseService.NetworkMode,
+			&baseService.Ipc,
+			&baseService.Pid,
+			&baseService.Uts,
+			&baseService.Cgroup,
+		}
+		for _, ref := range maybeReferences {
+			if _, ok := IsServiceDependency(*ref); ok {
+				*ref = ""
+			}
+		}
+
 		serviceConfig, err = _merge(baseService, serviceConfig)
 		if err != nil {
 			return nil, err

--- a/loader/testdata/subdir/compose-test-includes-imported.yaml
+++ b/loader/testdata/subdir/compose-test-includes-imported.yaml
@@ -7,4 +7,7 @@ services:
     volumes:
       - /opt/data:/var/lib/mysql
     depends_on:
-      - should-be-ignored
+      imported-dep:
+        condition: service_healthy
+  imported-dep:
+    build: .


### PR DESCRIPTION
When using `extends`, clear any dependency fields on the base service before merging.

See:
 * docker/compose#10905

Draft until we determine what behavior is actually desirable.

