### PR TITLE
include disabled services

### DIFF
--- a/loader/include.go
+++ b/loader/include.go
@@ -114,6 +114,12 @@ func importResources(model *types.Config, imported *types.Project, path []string
 		}
 		model.Services = append(model.Services, service)
 	}
+	for _, service := range imported.DisabledServices {
+		if _, ok := services[service.Name]; ok {
+			return fmt.Errorf("imported compose file %s defines conflicting service %s", path, service.Name)
+		}
+		model.Services = append(model.Services, service)
+	}
 	for n, network := range imported.Networks {
 		if _, ok := model.Networks[n]; ok {
 			return fmt.Errorf("imported compose file %s defines conflicting network %s", path, n)


### PR DESCRIPTION
as we import compose resources by `include`, also import disabled services so those can be enabled by profile activation

fixes https://github.com/docker/compose/issues/10921