### PR TITLE
add support for multi-document yaml

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2737,3 +2737,19 @@ services:
 	})
 	assert.ErrorContains(t, err, "Circular reference")
 }
+
+func TestLoadMulmtiDocumentYaml(t *testing.T) {
+	project, err := loadYAML(`
+name: load-multi-docs
+services:
+  test:
+    image: nginx:latest
+--- 
+services:
+  test:
+    image: nginx:override
+
+`)
+	assert.NilError(t, err)
+	assert.Equal(t, project.Services[0].Image, "nginx:override")
+}


### PR DESCRIPTION
Allows a compose.yaml file to define a multi-document yaml content. Documents all get merged into a single compose model.
I don't expect this to be used by users directly, but to allow distribution of a set of compose files without the need to manage file paths, just as a single yaml stream with all documents inlined in expected order.