### PR TITLE
don't absolutize empty build context

### DIFF
--- a/loader/paths.go
+++ b/loader/paths.go
@@ -88,7 +88,7 @@ func ResolveRelativePaths(project *types.Project) error {
 
 func ResolveServiceRelativePaths(workingDir string, s *types.ServiceConfig) {
 	if s.Build != nil {
-		if !isRemoteContext(s.Build.Context) {
+		if s.Build.Context != "" && !isRemoteContext(s.Build.Context) {
 			s.Build.Context = absPath(workingDir, s.Build.Context)
 		}
 		for name, path := range s.Build.AdditionalContexts {


### PR DESCRIPTION
keep build context unset when doing relative path resolution

fixes https://github.com/docker/compose/issues/10946