### PR TITLE
keep depends_on config for services explicitly selected

### DIFF
--- a/types/project.go
+++ b/types/project.go
@@ -423,7 +423,14 @@ func (p *Project) ForServices(names []string, options ...DependencyOption) error
 		if _, ok := set[s.Name]; ok {
 			for _, option := range options {
 				if option == IgnoreDependencies {
-					s.DependsOn = nil
+					// remove all dependencies but those implied by explicitly selected services
+					dependencies := s.DependsOn
+					for d := range dependencies {
+						if _, ok := set[d]; !ok {
+							delete(dependencies, d)
+						}
+					}
+					s.DependsOn = dependencies
 				}
 			}
 			enabled = append(enabled, s)

--- a/types/project_test.go
+++ b/types/project_test.go
@@ -115,6 +115,28 @@ func Test_ForServices(t *testing.T) {
 	assert.Equal(t, p.DisabledServices[4].Name, "service_5")
 }
 
+func Test_ForServicesIgnoreDependencies(t *testing.T) {
+	p := makeProject()
+	err := p.ForServices([]string{"service_2"}, IgnoreDependencies)
+	assert.NilError(t, err)
+
+	assert.Equal(t, len(p.DisabledServices), 5)
+	service, err := p.GetService("service_2")
+	assert.NilError(t, err)
+	assert.Equal(t, len(service.DependsOn), 0)
+
+	p = makeProject()
+	err = p.ForServices([]string{"service_2", "service_3"}, IgnoreDependencies)
+	assert.NilError(t, err)
+
+	assert.Equal(t, len(p.DisabledServices), 4)
+	service, err = p.GetService("service_3")
+	assert.NilError(t, err)
+	assert.Equal(t, len(service.DependsOn), 1)
+	_, dependsOn := service.DependsOn["service_2"]
+	assert.Check(t, dependsOn)
+}
+
 func Test_ForServicesCycle(t *testing.T) {
 	p := makeProject()
 	p.Services[0].Links = []string{"service_2"}


### PR DESCRIPTION
As we select services A,B,C with dependencies declared, with `IgnoreDependencies` option, we should drop dependencies _but_ those between selected services
this fixes https://github.com/docker/compose/issues/10959