### PR TITLE
apply reset on extended services

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -255,7 +255,6 @@ func load(ctx context.Context, configDetails types.ConfigDetails, opts *Options,
 	loaded = append(loaded, mainFile)
 
 	includeRefs := make(map[string][]types.IncludeConfig)
-	first := true
 	for _, file := range configDetails.ConfigFiles {
 		var postProcessor PostProcessor
 		configDict := file.Config
@@ -285,22 +284,21 @@ func load(ctx context.Context, configDetails types.ConfigDetails, opts *Options,
 				}
 			}
 
-			if first {
-				first = false
+			if model == nil {
 				model = cfg
-				return nil
-			}
-			merged, err := merge([]*types.Config{model, cfg})
-			if err != nil {
-				return err
+			} else {
+				merged, err := merge([]*types.Config{model, cfg})
+				if err != nil {
+					return err
+				}
+				model = merged
 			}
 			if postProcessor != nil {
-				err = postProcessor.Apply(merged)
+				err = postProcessor.Apply(model)
 				if err != nil {
 					return err
 				}
 			}
-			model = merged
 			return nil
 		}
 

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -422,6 +422,27 @@ services:
 	assert.Equal(t, svcB.Build.Context, bDir)
 }
 
+func TestLoadExtendsWihReset(t *testing.T) {
+	actual, err := loadYAML(`
+name: load-extends
+services:
+  foo:
+    extends:
+      service: bar
+    volumes: !reset []
+  bar:
+    image: alpine
+    command: echo
+    volumes:
+       - .:/src
+`)
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(actual.Services, 2))
+	foo, err := actual.GetService("foo")
+	assert.NilError(t, err)
+	assert.Check(t, len(foo.Volumes) == 0)
+}
+
 func TestLoadCredentialSpec(t *testing.T) {
 	actual, err := loadYAML(`
 name: load-credential-spec


### PR DESCRIPTION
postProcessor (used to collect `!reset` tags) need to be applied not just on 1+N config files after merge, but also on first compose.yaml file when this one uses `extends` to load another model and override service declaration.

closes https://github.com/docker/compose/issues/10962