### PR TITLE
loader: report project structure

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -408,7 +408,6 @@ func ProjectFromOptions(options *ProjectOptions) (*types.Project, error) {
 		return nil, err
 	}
 
-	project.ComposeFiles = configPaths
 	return project, nil
 }
 

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -223,7 +223,7 @@ func TestProjectComposefilesFromSetOfFiles(t *testing.T) {
 	p, err := ProjectFromOptions(opts)
 	assert.NilError(t, err)
 	absPath, _ := filepath.Abs(filepath.Join("testdata", "simple", "compose.yaml"))
-	assert.DeepEqual(t, p.ComposeFiles, []string{absPath})
+	assert.DeepEqual(t, p.FileMeta.Path, absPath)
 }
 
 func TestProjectComposefilesFromWorkingDir(t *testing.T) {
@@ -235,8 +235,8 @@ func TestProjectComposefilesFromWorkingDir(t *testing.T) {
 	p, err := ProjectFromOptions(opts)
 	assert.NilError(t, err)
 	currentDir, _ := os.Getwd()
-	assert.DeepEqual(t, p.ComposeFiles, []string{
-		filepath.Join(currentDir, "testdata", "simple", "compose.yaml"),
+	assert.DeepEqual(t, p.FileMeta.Path, filepath.Join(currentDir, "testdata", "simple", "compose.yaml"))
+	assert.DeepEqual(t, p.FileMeta.OverrideFilePaths, []string{
 		filepath.Join(currentDir, "testdata", "simple", "compose-with-overrides.yaml"),
 	})
 }

--- a/loader/include.go
+++ b/loader/include.go
@@ -45,11 +45,9 @@ var transformIncludeConfig TransformerFunc = func(data interface{}) (interface{}
 	}
 }
 
-func loadInclude(ctx context.Context, filename string, configDetails types.ConfigDetails, model *types.Config, options *Options, loaded []string) (*types.Config, map[string][]types.IncludeConfig, error) {
-	included := make(map[string][]types.IncludeConfig)
+func loadInclude(ctx context.Context, configDetails types.ConfigDetails, model *types.Config, options *Options, loaded []string) (*types.Config, []types.FileMeta, error) {
+	var included []types.FileMeta
 	for _, r := range model.Include {
-		included[filename] = append(included[filename], r)
-
 		for i, p := range r.Path {
 			for _, loader := range options.ResourceLoaders {
 				if loader.Accept(p) {
@@ -92,9 +90,7 @@ func loadInclude(ctx context.Context, filename string, configDetails types.Confi
 		if err != nil {
 			return nil, nil, err
 		}
-		for k, v := range imported.IncludeReferences {
-			included[k] = append(included[k], v...)
-		}
+		included = append(included, imported.FileMeta)
 
 		err = importResources(model, imported, r.Path)
 		if err != nil {

--- a/loader/merge_test.go
+++ b/loader/merge_test.go
@@ -224,6 +224,12 @@ func TestLoadLogging(t *testing.T) {
 				Secrets:    types.Secrets{},
 				Configs:    types.Configs{},
 				Extensions: types.Extensions{},
+				FileMeta: types.FileMeta{
+					Path:              "base.yml",
+					OverrideFilePaths: []string{"override.yml"},
+					ProjectDirectory:  "",
+					Services:          []string{"foo"},
+				},
 			}, config)
 		})
 	}
@@ -379,6 +385,12 @@ func TestLoadMultipleServicePorts(t *testing.T) {
 				Secrets:    types.Secrets{},
 				Configs:    types.Configs{},
 				Extensions: types.Extensions{},
+				FileMeta: types.FileMeta{
+					Path:              "base.yml",
+					OverrideFilePaths: []string{"override.yml"},
+					ProjectDirectory:  "",
+					Services:          []string{"foo"},
+				},
 			}, config)
 		})
 	}
@@ -505,6 +517,12 @@ func TestLoadMultipleSecretsConfig(t *testing.T) {
 				Secrets:    types.Secrets{},
 				Configs:    types.Configs{},
 				Extensions: types.Extensions{},
+				FileMeta: types.FileMeta{
+					Path:              "base.yml",
+					OverrideFilePaths: []string{"override.yml"},
+					ProjectDirectory:  "",
+					Services:          []string{"foo"},
+				},
 			}, config)
 		})
 	}
@@ -631,6 +649,12 @@ func TestLoadMultipleConfigobjsConfig(t *testing.T) {
 				Secrets:    types.Secrets{},
 				Configs:    types.Configs{},
 				Extensions: types.Extensions{},
+				FileMeta: types.FileMeta{
+					Path:              "base.yml",
+					OverrideFilePaths: []string{"override.yml"},
+					ProjectDirectory:  "",
+					Services:          []string{"foo"},
+				},
 			}, config)
 		})
 	}
@@ -747,6 +771,12 @@ func TestLoadMultipleUlimits(t *testing.T) {
 				Secrets:    types.Secrets{},
 				Configs:    types.Configs{},
 				Extensions: types.Extensions{},
+				FileMeta: types.FileMeta{
+					Path:              "base.yml",
+					OverrideFilePaths: []string{"override.yml"},
+					ProjectDirectory:  "",
+					Services:          []string{"foo"},
+				},
 			}, config)
 		})
 	}
@@ -866,6 +896,12 @@ func TestLoadMultipleServiceNetworks(t *testing.T) {
 				Secrets:    types.Secrets{},
 				Configs:    types.Configs{},
 				Extensions: types.Extensions{},
+				FileMeta: types.FileMeta{
+					Path:              "base.yml",
+					OverrideFilePaths: []string{"override.yml"},
+					ProjectDirectory:  "",
+					Services:          []string{"foo"},
+				},
 			}, config)
 		})
 	}
@@ -1002,6 +1038,12 @@ func TestLoadMultipleConfigs(t *testing.T) {
 		Secrets:    types.Secrets{},
 		Configs:    types.Configs{},
 		Extensions: types.Extensions{},
+		FileMeta: types.FileMeta{
+			Path:              "base.yml",
+			OverrideFilePaths: []string{"override.yml"},
+			ProjectDirectory:  "",
+			Services:          []string{"bar", "foo"},
+		},
 	}, config)
 }
 
@@ -1073,6 +1115,12 @@ func TestLoadMultipleNetworks(t *testing.T) {
 		Secrets:    types.Secrets{},
 		Configs:    types.Configs{},
 		Extensions: types.Extensions{},
+		FileMeta: types.FileMeta{
+			Path:              "base.yml",
+			OverrideFilePaths: []string{"override.yml"},
+			ProjectDirectory:  "",
+			Services:          []string{"foo"},
+		},
 	}, config)
 }
 
@@ -1236,6 +1284,10 @@ func TestMergeTopLevelExtensions(t *testing.T) {
 				"base": "qix",
 			},
 			"x-zot": "zot",
+		},
+		FileMeta: types.FileMeta{
+			Path:              "base.yml",
+			OverrideFilePaths: []string{"override.yml"},
 		},
 	}, config)
 }
@@ -1432,6 +1484,12 @@ services:
 		Configs:     types.Configs{},
 		Extensions:  types.Extensions{},
 		Environment: map[string]string{consts.ComposeProjectName: "test"},
+		FileMeta: types.FileMeta{
+			Path:              "base.yml",
+			OverrideFilePaths: []string{"override.yml"},
+			ProjectDirectory:  "",
+			Services:          []string{"bar", "foo"},
+		},
 	}, config)
 }
 
@@ -1485,5 +1543,11 @@ services:
 		Configs:     types.Configs{},
 		Extensions:  types.Extensions{},
 		Environment: map[string]string{consts.ComposeProjectName: "test"},
+		FileMeta: types.FileMeta{
+			Path:              "base.yml",
+			OverrideFilePaths: []string{"override.yml"},
+			ProjectDirectory:  "",
+			Services:          []string{"foo"},
+		},
 	}, config)
 }

--- a/loader/paths.go
+++ b/loader/paths.go
@@ -32,12 +32,6 @@ func ResolveRelativePaths(project *types.Project) error {
 	}
 	project.WorkingDir = absWorkingDir
 
-	absComposeFiles, err := absComposeFiles(project.ComposeFiles)
-	if err != nil {
-		return err
-	}
-	project.ComposeFiles = absComposeFiles
-
 	for i, s := range project.Services {
 		ResolveServiceRelativePaths(project.WorkingDir, &s)
 		project.Services[i] = s
@@ -63,24 +57,6 @@ func ResolveRelativePaths(project *types.Project) error {
 			config.DriverOpts["device"] = resolveMaybeUnixPath(project.WorkingDir, config.DriverOpts["device"])
 			project.Volumes[name] = config
 		}
-	}
-
-	// don't coerce a nil map to an empty map
-	if project.IncludeReferences != nil {
-		absIncludes := make(map[string][]types.IncludeConfig, len(project.IncludeReferences))
-		for filename, config := range project.IncludeReferences {
-			filename = absPath(project.WorkingDir, filename)
-			absConfigs := make([]types.IncludeConfig, len(config))
-			for i, c := range config {
-				absConfigs[i] = types.IncludeConfig{
-					Path:             resolvePaths(project.WorkingDir, c.Path),
-					ProjectDirectory: absPath(project.WorkingDir, c.ProjectDirectory),
-					EnvFile:          resolvePaths(project.WorkingDir, c.EnvFile),
-				}
-			}
-			absIncludes[filename] = absConfigs
-		}
-		project.IncludeReferences = absIncludes
 	}
 
 	return nil

--- a/loader/paths_test.go
+++ b/loader/paths_test.go
@@ -25,21 +25,17 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestResolveComposeFilePaths(t *testing.T) {
+func TestResolveProjectDirectory(t *testing.T) {
 	absWorkingDir, _ := filepath.Abs("testdata")
-	absComposeFile, _ := filepath.Abs(filepath.Join("testdata", "simple", "compose.yaml"))
-	absOverrideFile, _ := filepath.Abs(filepath.Join("testdata", "simple", "compose-with-overrides.yaml"))
 
 	project := types.Project{
-		Name:         "myProject",
-		WorkingDir:   absWorkingDir,
-		ComposeFiles: []string{filepath.Join("testdata", "simple", "compose.yaml"), filepath.Join("testdata", "simple", "compose-with-overrides.yaml")},
+		Name:       "myProject",
+		WorkingDir: "testdata",
 	}
 
 	expected := types.Project{
-		Name:         "myProject",
-		WorkingDir:   absWorkingDir,
-		ComposeFiles: []string{absComposeFile, absOverrideFile},
+		Name:       "myProject",
+		WorkingDir: absWorkingDir,
 	}
 	err := ResolveRelativePaths(&project)
 	assert.NilError(t, err)

--- a/types/meta.go
+++ b/types/meta.go
@@ -1,0 +1,105 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package types
+
+import "golang.org/x/exp/maps"
+
+type ComposeFileType int
+
+const (
+	unknownComposeFileType ComposeFileType = iota << 1
+	MainComposeFileType
+	OverrideComposeFileType
+	IncludeComposeFileType
+	EnvComposeFileType
+)
+
+// FileMeta from loading a Compose file and might represent the whole project or a part
+// of it (in the case of `include`).
+//
+// This is not part of the Compose Spec; it is populated by compose-go itself during the
+// load.
+type FileMeta struct {
+	// Path to the Compose file that was loaded.
+	Path string
+
+	// OverrideFilePaths to any partial/override files used in the load.
+	//
+	// Because override files are not logical Compose (sub)projects on their own, they are only represented
+	// via this field and not FileMeta objects of their own.
+	OverrideFilePaths []string
+
+	EnvFilePaths []string
+
+	// ProjectDirectory is the working directory for the load of the Compose file at Path.
+	//
+	// If this is a sub-project, this might be different than the parent directory project.
+	// This can be used to correctly resolve relative paths for sub-projects.
+	ProjectDirectory string
+
+	// Services that were directly loaded by this Compose file or its overrides.
+	//
+	// Any services loaded via `include` in this Compose file will be included on the corresponding
+	// FileMeta object in Includes. This ensures each service only exists in a single FileMeta within
+	// the tree.
+	Services []string
+
+	// Includes are subprojects loaded via `include` by this Compose file or its overrides.
+	Includes []FileMeta
+}
+
+func (f FileMeta) AllFilePaths() []string {
+	paths := f.FilePaths(0)
+	return maps.Keys(paths)
+}
+
+// FilePaths returns a filtered result
+func (f FileMeta) FilePaths(filter ComposeFileType) map[string]ComposeFileType {
+	ret := make(map[string]ComposeFileType)
+	all := filter == 0
+	includeMain := all || filter&MainComposeFileType != 0
+	includeInclude := all || filter&IncludeComposeFileType != 0
+	includeOverride := all || filter&OverrideComposeFileType != 0
+	includeEnv := all || filter&EnvComposeFileType != 0
+	iterateFileMeta(f, func(meta FileMeta) {
+		if f.Path == meta.Path {
+			if includeMain {
+				ret[meta.Path] = MainComposeFileType
+			}
+		} else if includeInclude {
+			ret[meta.Path] = IncludeComposeFileType
+		}
+		if includeOverride {
+			for i := range meta.OverrideFilePaths {
+				ret[meta.OverrideFilePaths[i]] = OverrideComposeFileType
+			}
+		}
+		if includeEnv {
+			for i := range meta.EnvFilePaths {
+				ret[meta.EnvFilePaths[i]] = EnvComposeFileType
+			}
+		}
+	})
+	return ret
+}
+
+func iterateFileMeta(root FileMeta, fn func(meta FileMeta)) {
+	fn(root)
+	for i := range root.Includes {
+		iterateFileMeta(root.Includes[i], fn)
+	}
+}

--- a/types/project.go
+++ b/types/project.go
@@ -44,13 +44,8 @@ type Project struct {
 	Configs    Configs    `yaml:"configs,omitempty" json:"configs,omitempty"`
 	Extensions Extensions `yaml:"#extensions,inline" json:"-"` // https://github.com/golang/go/issues/6213
 
-	// IncludeReferences is keyed by Compose YAML filename and contains config for
-	// other Compose YAML files it directly triggered a load of via `include`.
-	//
-	// Note: this is
-	IncludeReferences map[string][]IncludeConfig `yaml:"-" json:"-"`
-	ComposeFiles      []string                   `yaml:"-" json:"-"`
-	Environment       Mapping                    `yaml:"-" json:"-"`
+	FileMeta    FileMeta `yaml:"-" json:"-"`
+	Environment Mapping  `yaml:"-" json:"-"`
 
 	// DisabledServices track services which have been disable as profile is not active
 	DisabledServices Services `yaml:"-" json:"-"`


### PR DESCRIPTION
With `include`'d Compose files, it's important to know the origin of each service to be able to properly resolve paths to them, for example.

A new `FileMeta` field on the `Project` type provides detailed access to the underlying file structure/hierarchy.

This replaces `IncludeReferences` and `ComposeFiles`, which were inconsistent and not comprehensive.

## What Problem Does This Solve
In Compose itself, when we use `x-` fields for non-stable features, the "load" logic lives in the `docker/compose` codebase until stabilized.

That means it needs to resolve in relative paths there -- `compose-go` can't help because it doesn't know about the fields to begin with. However, if they came from an included file, `IncludeReferences` has the `ProjectDirectory` BUT there's no way to know where a service came from! The `FileMeta` tree combines `ComposeFiles` + `IncludeReferences` and, critically, additionally populates service back-references.