### PR TITLE
introduce SkipResolveEnvironment loader option

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -328,6 +328,14 @@ func WithResourceLoader(r loader.ResourceLoader) ProjectOptionsFn {
 	}
 }
 
+// WithoutEnvironmentResolution disable environment resolution
+func WithoutEnvironmentResolution(o *ProjectOptions) error {
+	o.loadOptions = append(o.loadOptions, func(options *loader.Options) {
+		options.SkipResolveEnvironment = true
+	})
+	return nil
+}
+
 // DefaultFileNames defines the Compose file names for auto-discovery (in order of preference)
 var DefaultFileNames = []string{"compose.yaml", "compose.yml", "docker-compose.yml", "docker-compose.yaml"}
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -61,6 +61,8 @@ type Options struct {
 	SkipExtends bool
 	// SkipInclude will ignore `include` and only load model from file(s) set by ConfigDetails
 	SkipInclude bool
+	// SkipResolveEnvironment will ignore computing `environment` for services
+	SkipResolveEnvironment bool
 	// Interpolation options
 	Interpolate *interp.Options
 	// Discard 'env_file' entries after resolving to 'environment' section
@@ -387,9 +389,14 @@ func load(ctx context.Context, configDetails types.ConfigDetails, opts *Options,
 
 	project.ApplyProfiles(opts.Profiles)
 
-	err := project.ResolveServicesEnvironment(opts.discardEnvFiles)
+	if !opts.SkipResolveEnvironment {
+		err := project.ResolveServicesEnvironment(opts.discardEnvFiles)
+		if err != nil {
+			return nil, err
+		}
+	}
 
-	return project, err
+	return project, nil
 }
 
 func InvalidProjectNameErr(v string) error {


### PR DESCRIPTION
this allow to load a project without parsing `env_file`
see https://github.com/docker/compose/issues/10995