### PR TITLE
merge yaml files as plain map[string]interface trees

### DIFF
--- a/loader/include.go
+++ b/loader/include.go
@@ -24,7 +24,6 @@ import (
 	"github.com/compose-spec/compose-go/dotenv"
 	interp "github.com/compose-spec/compose-go/interpolation"
 	"github.com/compose-spec/compose-go/types"
-	"github.com/pkg/errors"
 )
 
 // LoadIncludeConfig parse the require config from raw yaml
@@ -32,17 +31,6 @@ func LoadIncludeConfig(source []interface{}) ([]types.IncludeConfig, error) {
 	var requires []types.IncludeConfig
 	err := Transform(source, &requires)
 	return requires, err
-}
-
-var transformIncludeConfig TransformerFunc = func(data interface{}) (interface{}, error) {
-	switch value := data.(type) {
-	case string:
-		return map[string]interface{}{"path": value}, nil
-	case map[string]interface{}:
-		return value, nil
-	default:
-		return data, errors.Errorf("invalid type %T for `include` configuration", value)
-	}
 }
 
 func loadInclude(ctx context.Context, filename string, configDetails types.ConfigDetails, model *types.Config, options *Options, loaded []string) (*types.Config, map[string][]types.IncludeConfig, error) {

--- a/loader/interpolate.go
+++ b/loader/interpolate.go
@@ -22,6 +22,7 @@ import (
 
 	interp "github.com/compose-spec/compose-go/interpolation"
 	"github.com/compose-spec/compose-go/tree"
+	"github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -60,7 +61,6 @@ var interpolateTypeCastMapping = map[tree.Path]interp.Cast{
 	servicePath("secrets", tree.PathMatchList, "mode"):             toInt,
 	servicePath("shm_size"):                                        toUnitBytes,
 	servicePath("stdin_open"):                                      toBoolean,
-	servicePath("stop_grace_period"):                               toDuration,
 	servicePath("tty"):                                             toBoolean,
 	servicePath("ulimits", tree.PathMatchAll):                      toInt,
 	servicePath("ulimits", tree.PathMatchAll, "hard"):              toInt,
@@ -94,11 +94,7 @@ func toInt64(value string) (interface{}, error) {
 }
 
 func toUnitBytes(value string) (interface{}, error) {
-	return transformSize(value)
-}
-
-func toDuration(value string) (interface{}, error) {
-	return transformStringToDuration(value)
+	return units.RAMInBytes(value)
 }
 
 func toFloat(value string) (interface{}, error) {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1448,7 +1448,8 @@ func TestLoadVolumesWarnOnDeprecatedExternalNameVersion34(t *testing.T) {
 	source := map[string]interface{}{
 		"foo": map[string]interface{}{
 			"external": map[string]interface{}{
-				"name": "oops",
+				"external": true,
+				"name":     "oops",
 			},
 		},
 	}
@@ -1462,7 +1463,6 @@ func TestLoadVolumesWarnOnDeprecatedExternalNameVersion34(t *testing.T) {
 	}
 	assert.Check(t, is.DeepEqual(expected, volumes))
 	assert.Check(t, is.Contains(buf.String(), "volume.external.name is deprecated"))
-
 }
 
 func patchLogrus() (*bytes.Buffer, func()) {
@@ -1479,7 +1479,8 @@ func TestLoadVolumesWarnOnDeprecatedExternalName(t *testing.T) {
 	source := map[string]interface{}{
 		"foo": map[string]interface{}{
 			"external": map[string]interface{}{
-				"name": "oops",
+				"external": true,
+				"name":     "oops",
 			},
 		},
 	}
@@ -1533,7 +1534,8 @@ func TestLoadSecretsWarnOnDeprecatedExternalNameVersion35(t *testing.T) {
 	source := map[string]interface{}{
 		"foo": map[string]interface{}{
 			"external": map[string]interface{}{
-				"name": "oops",
+				"name":     "oops",
+				"external": true,
 			},
 		},
 	}
@@ -1556,7 +1558,8 @@ func TestLoadNetworksWarnOnDeprecatedExternalNameVersion35(t *testing.T) {
 	source := map[string]interface{}{
 		"foo": map[string]interface{}{
 			"external": map[string]interface{}{
-				"name": "oops",
+				"name":     "oops",
+				"external": true,
 			},
 		},
 	}
@@ -1580,7 +1583,8 @@ func TestLoadNetworksWarnOnDeprecatedExternalName(t *testing.T) {
 	source := map[string]interface{}{
 		"foo": map[string]interface{}{
 			"external": map[string]interface{}{
-				"name": "oops",
+				"name":     "oops",
+				"external": true,
 			},
 		},
 	}
@@ -1807,30 +1811,6 @@ services:
 
 	assert.Assert(t, is.Len(config.Services, 1))
 	assert.Check(t, is.DeepEqual(expected, config.Services[0].Sysctls))
-}
-
-func TestTransform(t *testing.T) {
-	var source = []interface{}{
-		"80-82:8080-8082",
-		"90-92:8090-8092/udp",
-		"85:8500",
-		8600,
-		map[string]interface{}{
-			"protocol":  "udp",
-			"target":    53,
-			"published": 10053,
-		},
-		map[string]interface{}{
-			"mode":      "host",
-			"target":    22,
-			"published": 10022,
-		},
-	}
-	var ports []types.ServicePortConfig
-	err := Transform(source, &ports)
-	assert.NilError(t, err)
-
-	assert.Check(t, is.DeepEqual(samplePortsConfig, ports))
 }
 
 func TestLoadTemplateDriver(t *testing.T) {
@@ -2129,7 +2109,7 @@ services:
           devices:
             - driver: nvidia
               capabilities: [gpu]
-              count: somestring
+              count: some_string
 `)
 	assert.ErrorContains(t, err, "invalid string value for 'count' (the only value allowed is 'all' or a number)")
 }
@@ -2183,36 +2163,6 @@ func TestLoadServiceWithEnvFile(t *testing.T) {
 	service, err := p.GetService("Test")
 	assert.NilError(t, err)
 	assert.Equal(t, "YES", *service.Environment["HALLO"])
-}
-
-func TestLoadServiceWithVolumes(t *testing.T) {
-	m := map[string]interface{}{
-		"volumes": []interface{}{
-			"source:/path 1/",
-			map[string]interface{}{
-				"target": "/path 2/",
-			},
-		},
-		"configs": []interface{}{
-			map[string]interface{}{
-				"target": "/path 3/",
-			},
-		},
-		"secrets": []interface{}{
-			map[string]interface{}{
-				"target": "/path 4/",
-			},
-		},
-	}
-	s, err := LoadService("Test Name", m)
-	assert.NilError(t, err)
-	assert.Equal(t, len(s.Volumes), 2)
-	assert.Equal(t, "/path 1", s.Volumes[0].Target)
-	assert.Equal(t, "/path 2", s.Volumes[1].Target)
-	assert.Equal(t, len(s.Configs), 1)
-	assert.Equal(t, "/path 3", s.Configs[0].Target)
-	assert.Equal(t, len(s.Secrets), 1)
-	assert.Equal(t, "/path 4", s.Secrets[0].Target)
 }
 
 func TestLoadNoSSHInBuildConfig(t *testing.T) {

--- a/override/mergeYaml.go
+++ b/override/mergeYaml.go
@@ -1,0 +1,141 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package override
+
+import (
+	"fmt"
+
+	"github.com/compose-spec/compose-go/tree"
+)
+
+type merger func(interface{}, interface{}, tree.Path) (interface{}, error)
+
+// mergeSpecials defines the custom rules applied by compose when merging yaml trees
+var mergeSpecials = map[tree.Path]merger{}
+
+func init() {
+	mergeSpecials["services.*.logging"] = mergeLogging
+	mergeSpecials["services.*.volumes"] = mergeVolumes
+	mergeSpecials["services.*.ports"] = mergePorts
+}
+
+// MergeYaml merges map[string]interface{} yaml trees handling special rules
+func MergeYaml(e interface{}, o interface{}, p tree.Path) (interface{}, error) {
+	for pattern, merger := range mergeSpecials {
+		if p.Matches(pattern) {
+			merged, err := merger(e, o, p)
+			if err != nil {
+				return nil, err
+			}
+			return merged, nil
+		}
+	}
+	switch value := e.(type) {
+	case map[string]interface{}:
+		other, ok := o.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("cannont override %s", p)
+		}
+		return mergeMappings(value, other, p)
+	case []interface{}:
+		other, ok := o.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("cannont override %s", p)
+		}
+		return append(value, other...), nil
+	default:
+		return o, nil
+	}
+}
+
+func mergeSlices(c []interface{}, o []interface{}, keyFn func(interface{}) interface{}, path tree.Path) (interface{}, error) {
+	merged := map[interface{}]interface{}{}
+	for _, v := range c {
+		merged[keyFn(v)] = v
+	}
+	for _, v := range o {
+		key := keyFn(v)
+		e, ok := merged[key]
+		if !ok {
+			merged[key] = v
+			continue
+		}
+		MergeYaml(e, v, path.Next("[]"))
+	}
+	sequence := make([]interface{}, 0, len(merged))
+	for _, v := range merged {
+		sequence = append(sequence, v)
+	}
+	return sequence, nil
+}
+
+func mergeMappings(mapping map[string]interface{}, other map[string]interface{}, p tree.Path) (map[string]interface{}, error) {
+	for k, v := range other {
+		next := p.Next(k)
+		e, ok := mapping[k]
+		if !ok {
+			mapping[k] = v
+			continue
+		}
+		merged, err := MergeYaml(e, v, next)
+		if err != nil {
+			return nil, err
+		}
+		mapping[k] = merged
+	}
+	return mapping, nil
+}
+
+// ports is actually a map, indexed by ip:port:target/protocol
+func mergePorts(v interface{}, o interface{}, path tree.Path) (interface{}, error) {
+	type port struct {
+		target    interface{}
+		published interface{}
+		ip        interface{}
+		protocol  interface{}
+	}
+	return mergeSlices(v.([]interface{}), o.([]interface{}), func(i interface{}) interface{} {
+		m := i.(map[string]interface{})
+		return port{
+			target:    m["target"],
+			published: m["published"],
+			ip:        m["ip"],
+			protocol:  m["protocol"],
+		}
+	}, path)
+}
+
+// volumes is actually a map, indexed by mount path in container
+func mergeVolumes(v interface{}, o interface{}, path tree.Path) (interface{}, error) {
+	return mergeSlices(v.([]interface{}), o.([]interface{}), func(i interface{}) interface{} {
+		m := i.(map[string]interface{})
+		return m["target"]
+	}, path)
+}
+
+// logging driver options are merged only when both compose file define the same driver
+func mergeLogging(c interface{}, o interface{}, p tree.Path) (interface{}, error) {
+	config := c.(map[string]interface{})
+	other := o.(map[string]interface{})
+	// we override logging config if source and override have the same driver set, or none
+	d, ok1 := other["driver"]
+	o, ok2 := config["driver"]
+	if d == o || !ok1 || !ok2 {
+		return mergeMappings(config, other, p)
+	}
+	return other, nil
+}

--- a/override/mergeYaml_logging_test.go
+++ b/override/mergeYaml_logging_test.go
@@ -1,0 +1,103 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package override
+
+import (
+	"testing"
+)
+
+// override using the same logging driver will override driver options
+func Test_mergeYamlLoggingSameDriver(t *testing.T) {
+	assertMergeYaml(t, `
+services:
+  test:
+    image: foo
+    logging:
+      driver: syslog
+      options:
+        syslog-address: "tcp://192.168.0.42:123"
+`, `
+services:
+  test:
+    logging:
+      driver: syslog
+      options:
+        syslog-address: "tcp://127.0.0.1:123"
+`, `
+services:
+  test:
+    image: foo
+    logging:
+      driver: syslog
+      options:
+        syslog-address: "tcp://127.0.0.1:123"
+`)
+}
+
+// check override with a distinct logging driver fully overrides driver options
+func Test_mergeYamlLoggingDistinctDriver(t *testing.T) {
+	assertMergeYaml(t, `
+services:
+  test:
+    image: foo
+    logging:
+      driver: local
+      options:
+        max-size: "10m"
+`, `
+services:
+  test:
+    logging:
+      driver: syslog
+      options:
+        syslog-address: "tcp://127.0.0.1:123"
+`, `
+services:
+  test:
+    image: foo
+    logging:
+      driver: syslog
+      options:
+        syslog-address: "tcp://127.0.0.1:123"
+`)
+}
+
+// check override without an explicit driver set (defaults to local driver)
+func Test_mergeYamlLoggingImplicitDriver(t *testing.T) {
+	assertMergeYaml(t, `
+services:
+  test:
+    image: foo
+    logging:
+      options:
+        max-size: "10m"
+`, `
+services:
+  test:
+    logging:
+      options:
+        max-file: 3
+`, `
+services:
+  test:
+    image: foo
+    logging:
+      options:
+        max-size: "10m"
+        max-file: 3
+`)
+}

--- a/override/mergeYaml_ports_test.go
+++ b/override/mergeYaml_ports_test.go
@@ -1,0 +1,54 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package override
+
+import (
+	"testing"
+)
+
+func Test_mergeYamlPortsLongSyntax(t *testing.T) {
+	assertMergeYaml(t, `
+services:
+  test:
+    image: foo
+    ports:
+      - target: 8080
+        published: "80"
+        protocol: tcp
+`, `
+services:
+  test:
+    ports:
+      - target: 8080
+        published: "80"
+        protocol: tcp
+      - target: 8443
+        published: "443"
+        protocol: tcp
+`, `
+services:
+  test:
+    image: foo
+    ports:
+      - target: 8080
+        published: "80"
+        protocol: tcp
+      - target: 8443
+        published: "443"
+        protocol: tcp
+`)
+}

--- a/override/mergeYaml_test.go
+++ b/override/mergeYaml_test.go
@@ -1,0 +1,59 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package override
+
+import (
+	"testing"
+
+	"github.com/compose-spec/compose-go/tree"
+	"gopkg.in/yaml.v3"
+	"gotest.tools/v3/assert"
+)
+
+func Test_mergeYamlBase(t *testing.T) {
+	assertMergeYaml(t, `
+services:
+  test:
+    image: foo
+    container_name: foo
+    init:  true 
+`, `
+services:
+  test:
+    image: bar
+    init:  false 
+`, `
+services:
+  test:
+    container_name: foo
+    image: bar
+    init: false
+`)
+}
+
+func assertMergeYaml(t *testing.T, right string, left string, want string) {
+	got, err := MergeYaml(unmarshall(t, right), unmarshall(t, left), tree.NewPath())
+	assert.NilError(t, err)
+	assert.DeepEqual(t, got, unmarshall(t, want))
+}
+
+func unmarshall(t *testing.T, s string) map[string]interface{} {
+	var val map[string]interface{}
+	err := yaml.Unmarshal([]byte(s), &val)
+	assert.NilError(t, err)
+	return val
+}

--- a/override/mergeYaml_volumes_test.go
+++ b/override/mergeYaml_volumes_test.go
@@ -1,0 +1,67 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package override
+
+import (
+	"testing"
+)
+
+func Test_mergeYamlVolumesLongSyntax(t *testing.T) {
+	assertMergeYaml(t, `
+services:
+  test:
+    image: foo
+    volumes: 
+      # /src:/target
+      - type: bind
+        source: /src
+        target: /target
+      # /foo:/bar
+      - type: bind
+        source: /foo
+        target: /bar
+`, `
+services:
+  test:
+    volumes:
+      # /src:/target
+      - type: bind
+        source: /src
+        target: /target
+      # /zot:/qix
+      - type: bind
+        source: /zot
+        target: /qix
+`, `
+services:
+  test:
+    image: foo
+    volumes:
+      # /src:/target
+      - type: bind
+        source: /src
+        target: /target
+      # /foo:/bar
+      - type: bind
+        source: /foo
+        target: /bar
+      # /zot:/qix
+      - type: bind
+        source: /zot
+        target: /qix
+`)
+}

--- a/transform/devices_test.go
+++ b/transform/devices_test.go
@@ -1,0 +1,84 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package transform
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestExpandDevicesAll(t *testing.T) {
+	assertExpand(t, `
+services:
+  test:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+`, `
+services:
+  test:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: -1
+
+`)
+}
+
+func TestExpandDevicesCountAsString(t *testing.T) {
+	assertExpand(t, `
+services:
+  test:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: "1"
+`, `
+services:
+  test:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+
+`)
+}
+
+func TestExpandDevicesCountInvalidString(t *testing.T) {
+	_, err := ExpandShortSyntax(unmarshall(t, `
+services:
+  test:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: some_string
+`))
+	assert.Error(t, err, "invalid string value for 'count' (the only value allowed is 'all' or a number)")
+
+}

--- a/transform/expand.go
+++ b/transform/expand.go
@@ -1,0 +1,516 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package transform
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/compose-spec/compose-go/tree"
+	"github.com/compose-spec/compose-go/types"
+	"github.com/docker/go-units"
+	"github.com/mattn/go-shellwords"
+	"github.com/pkg/errors"
+)
+
+type transformFunc func(data interface{}) (interface{}, error)
+
+var (
+	// TODO(ndeloof) Labels, Mapping, MappingWithEqual and HostsList could implement yaml.Unmarhsaller
+	transformLabels           = transformMappingOrListFunc("=", false)
+	transformHostList         = transformMappingOrListFunc(":", false)
+	transformMapping          = transformMappingOrListFunc("=", false)
+	transformMappingWithEqual = transformMappingOrListFunc("=", true)
+)
+
+// transformers list the places compose spec allows a short syntax we have to expand
+var transformers = map[tree.Path]transformFunc{
+	"services.*.annotations":                                   transformMapping,
+	"services.*.blkio_config.device_read_bps.*.rate":           transformSize,
+	"services.*.blkio_config.device_read_iops.*.rate":          transformSize,
+	"services.*.blkio_config.device_write_bps.*.rate":          transformSize,
+	"services.*.blkio_config.device_write_iops.*.rate":         transformSize,
+	"services.*.build":                                         transformBuildConfig,
+	"services.*.build.additional_contexts":                     transformMapping,
+	"services.*.build.args":                                    transformMappingWithEqual,
+	"services.*.build.cache_from":                              transformStringList,
+	"services.*.build.cache_to":                                transformStringList,
+	"services.*.build.extra_hosts":                             transformHostList,
+	"services.*.build.labels":                                  transformLabels,
+	"services.*.build.tags":                                    transformStringList,
+	"services.*.build.platforms":                               transformStringList,
+	"services.*.build.secrets.*":                               transformFileReferenceConfig,
+	"services.*.build.ssh":                                     transformSSHConfig,
+	"services.*.command":                                       transformShellCommand,
+	"services.*.configs.*":                                     transformFileReferenceConfig,
+	"services.*.depends_on":                                    transformDependsOnConfig,
+	"services.*.deploy.labels":                                 transformLabels,
+	"services.*.deploy.resources.limits.memory":                transformSize,
+	"services.*.deploy.resources.reservations.memory":          transformSize,
+	"services.*.deploy.resources.reservations.devices.*.count": transformServiceDeviceRequestCount,
+	"services.*.dns":                                           transformStringList,
+	"services.*.dns_search":                                    transformStringList,
+	"services.*.entrypoint":                                    transformShellCommand,
+	"services.*.env_file":                                      transformStringList,
+	"services.*.environment":                                   transformMappingWithEqual,
+	"services.*.expose":                                        transformStringOrNumberList,
+	"services.*.extends":                                       transformExtends,
+	"services.*.extra_hosts":                                   transformHostList,
+	"services.*.healthcheck.test":                              transformHealthCheckTest,
+	"services.*.labels":                                        transformLabels,
+	"services.*.mem_limit":                                     transformSize,
+	"services.*.mem_reservation":                               transformSize,
+	"services.*.mem_swap_limit":                                transformSize,
+	"services.*.mem_swapiness":                                 transformSize,
+	"services.*.networks":                                      transformServiceNetworks,
+	"services.*.ports":                                         transformServicePorts,
+	"services.*.secrets.*":                                     transformFileReferenceConfig,
+	"services.*.shm_size":                                      transformSize,
+	"services.*.sysctls":                                       transformMapping,
+	"services.*.tmpfs":                                         transformStringList,
+	"services.*.ulimits.*":                                     transformUlimits,
+	"services.*.volumes.*":                                     transformServiceVolume,
+	"services.*.volumes.*.tmpfs.size":                          transformSize,
+	"include.*":                                                transformIncludeConfig,
+	"include.*.path":                                           transformStringList,
+	"include.*.env_file":                                       transformStringList,
+	"configs.*.external":                                       transformExternal,
+	"configs.*.labels":                                         transformLabels,
+	"networks.*.driver_opts.*":                                 transformDriverOpt,
+	"networks.*.external":                                      transformExternal,
+	"networks.*.labels":                                        transformLabels,
+	"volumes.*.driver_opts.*":                                  transformDriverOpt,
+	"volumes.*.external":                                       transformExternal,
+	"volumes.*.labels":                                         transformLabels,
+	"secrets.*.external":                                       transformExternal,
+	"secrets.*.labels":                                         transformLabels,
+}
+
+func ExpandShortSyntax(composefile map[string]interface{}) (map[string]interface{}, error) {
+	m, err := transform(composefile, tree.NewPath())
+	if err != nil {
+		return nil, err
+	}
+	return m.(map[string]interface{}), nil
+}
+
+func transform(e interface{}, p tree.Path) (interface{}, error) {
+	for pattern, transformer := range transformers {
+		if p.Matches(pattern) {
+			t, err := transformer(e)
+			if err != nil {
+				return nil, err
+			}
+			e = t
+		}
+	}
+	switch value := e.(type) {
+	case map[string]interface{}:
+		for k, v := range value {
+			t, err := transform(v, p.Next(k))
+			if err != nil {
+				return nil, err
+			}
+			value[k] = t
+		}
+		return value, nil
+	case []interface{}:
+		for i, e := range value {
+			t, err := transform(e, p.Next("[]"))
+			if err != nil {
+				return nil, err
+			}
+			value[i] = t
+		}
+		return value, nil
+	default:
+		return e, nil
+	}
+}
+
+func transformServiceVolume(data interface{}) (interface{}, error) {
+	if value, ok := data.(string); ok {
+		volume, err := parseVolume(value)
+		if err != nil {
+			return nil, err
+		}
+		vol := map[string]interface{}{
+			"type":      volume.Type,
+			"source":    volume.Source,
+			"target":    volume.Target,
+			"read_only": volume.ReadOnly,
+		}
+		if volume.Volume != nil {
+			vol["volume"] = map[string]interface{}{
+				"nocopy": volume.Volume.NoCopy,
+			}
+		}
+		if volume.Bind != nil {
+			vol["bind"] = map[string]interface{}{
+				"create_host_path": volume.Bind.CreateHostPath,
+				"propagation":      volume.Bind.Propagation,
+				"selinux":          volume.Bind.SELinux,
+			}
+		}
+		return omitEmpty(vol), nil
+	}
+	return data, nil
+}
+
+// transformServicePorts process the list instead of individual ports as a port-range definition will result in multiple
+// items, so we flatten this into a single sequence
+func transformServicePorts(data interface{}) (interface{}, error) {
+	switch entries := data.(type) {
+	case []interface{}:
+		var ports []interface{}
+		for _, entry := range entries {
+			switch value := entry.(type) {
+			case int, string:
+				parsed, err := types.ParsePortConfig(fmt.Sprint(value))
+				if err != nil {
+					return data, err
+				}
+				for _, v := range parsed {
+					ports = append(ports, map[string]interface{}{
+						"mode":      v.Mode,
+						"host_ip":   v.HostIP,
+						"target":    int(v.Target),
+						"published": v.Published,
+						"protocol":  v.Protocol,
+					})
+				}
+			case map[string]interface{}:
+				published := value["published"]
+				if v, ok := published.(int); ok {
+					value["published"] = strconv.Itoa(v)
+				}
+				ports = append(ports, value)
+			default:
+				return data, errors.Errorf("invalid type %T for port", value)
+			}
+		}
+		return ports, nil
+	default:
+		return data, errors.Errorf("invalid type %T for port", entries)
+	}
+}
+
+func transformServiceNetworks(data interface{}) (interface{}, error) {
+	if list, ok := data.([]interface{}); ok {
+		mapValue := map[interface{}]interface{}{}
+		for _, name := range list {
+			mapValue[name] = nil
+		}
+		return mapValue, nil
+	}
+	return data, nil
+}
+
+func transformExternal(data interface{}) (interface{}, error) {
+	switch value := data.(type) {
+	case bool:
+		return map[string]interface{}{"external": value}, nil
+	case map[string]interface{}:
+		return map[string]interface{}{"external": true, "name": value["name"]}, nil
+	default:
+		return data, errors.Errorf("invalid type %T for external", value)
+	}
+}
+
+func transformHealthCheckTest(data interface{}) (interface{}, error) {
+	switch value := data.(type) {
+	case string:
+		return append([]string{"CMD-SHELL"}, value), nil
+	case []interface{}:
+		return value, nil
+	default:
+		return value, errors.Errorf("invalid type %T for healthcheck.test", value)
+	}
+}
+
+func transformShellCommand(data interface{}) (interface{}, error) {
+	switch value := data.(type) {
+	case string:
+		args, err := shellwords.Parse(value)
+		res := make([]interface{}, len(args))
+		for i, arg := range args {
+			res[i] = arg
+		}
+		return res, err
+	case []interface{}:
+		return value, nil
+	default:
+		// ShellCommand do NOT have omitempty tag, to distinguish unset vs empty
+		if data == nil {
+			return nil, nil
+		}
+		return data, errors.Errorf("invalid type %T for shell command", value)
+	}
+}
+
+func transformDependsOnConfig(data interface{}) (interface{}, error) {
+	switch value := data.(type) {
+	case []interface{}:
+		transformed := map[string]interface{}{}
+		for _, serviceIntf := range value {
+			service, ok := serviceIntf.(string)
+			if !ok {
+				return data, errors.Errorf("invalid type %T for service depends_on element, expected string", value)
+			}
+			transformed[service] = map[string]interface{}{
+				"condition": types.ServiceConditionStarted,
+				"required":  true,
+			}
+		}
+		return transformed, nil
+	case map[string]interface{}:
+		transformed := map[string]interface{}{}
+		for service, val := range value {
+			dependsConfigIntf, ok := val.(map[string]interface{})
+			if !ok {
+				return data, errors.Errorf("invalid type %T for service depends_on element", value)
+			}
+			if _, ok := dependsConfigIntf["required"]; !ok {
+				dependsConfigIntf["required"] = true
+			}
+			transformed[service] = dependsConfigIntf
+		}
+		return transformed, nil
+	default:
+		return data, errors.Errorf("invalid type %T for service depends_on", value)
+	}
+}
+
+func transformFileReferenceConfig(data interface{}) (interface{}, error) {
+	switch value := data.(type) {
+	case string:
+		return map[string]interface{}{"source": value}, nil
+	case map[string]interface{}:
+		return value, nil
+	default:
+		return data, errors.Errorf("invalid type %T for secret", value)
+	}
+}
+
+func transformBuildConfig(data interface{}) (interface{}, error) {
+	switch value := data.(type) {
+	case string:
+		return map[string]interface{}{"context": value}, nil
+	case map[string]interface{}:
+		return data, nil
+	default:
+		return data, errors.Errorf("invalid type %T for service build", value)
+	}
+}
+
+func transformExtends(data interface{}) (interface{}, error) {
+	switch data.(type) {
+	case string:
+		return map[string]interface{}{"service": data}, nil
+	case map[string]interface{}:
+		return data, nil
+	default:
+		return data, errors.Errorf("invalid type %T for extends", data)
+	}
+}
+
+func transformStringList(data interface{}) (interface{}, error) {
+	switch value := data.(type) {
+	case string:
+		return []string{value}, nil
+	case []interface{}:
+		return value, nil
+	default:
+		return data, errors.Errorf("invalid type %T for string list", value)
+	}
+}
+
+// TODO(ndeloof) StringOrNumberList could implement yaml.Unmarhsaler
+func transformStringOrNumberList(data interface{}) (interface{}, error) {
+	list := data.([]interface{})
+	result := make([]string, len(list))
+	for i, item := range list {
+		result[i] = fmt.Sprint(item)
+	}
+	return result, nil
+}
+
+// TODO(ndeloof) UlimitsConfig could implement yaml.Unmarhsaler
+func transformUlimits(data interface{}) (interface{}, error) {
+	switch value := data.(type) {
+	case int:
+		return map[string]interface{}{"single": value}, nil
+	case map[string]interface{}:
+		return data, nil
+	default:
+		return data, errors.Errorf("invalid type %T for ulimits", value)
+	}
+}
+
+// TODO(ndeloof) UnitBytes could implement yaml.Unmarhsaler
+func transformSize(data interface{}) (interface{}, error) {
+	switch value := data.(type) {
+	case int:
+		return value, nil
+	case int64, types.UnitBytes:
+		return value, nil
+	case string:
+		return units.RAMInBytes(value)
+	default:
+		return value, errors.Errorf("invalid type for size %T", value)
+	}
+}
+
+// TODO(ndeloof) create a DriverOpts type and implement yaml.Unmarshaler
+func transformDriverOpt(data interface{}) (interface{}, error) {
+	switch value := data.(type) {
+	case int:
+		return strconv.Itoa(value), nil
+	case string:
+		return value, nil
+	default:
+		return data, errors.Errorf("invalid type %T for driver_opts value", value)
+	}
+}
+
+func transformServiceDeviceRequestCount(data interface{}) (interface{}, error) {
+	switch value := data.(type) {
+	case int:
+		return value, nil
+	case string:
+		if strings.ToLower(value) == "all" {
+			return -1, nil
+		}
+		i, err := strconv.Atoi(value)
+		if err == nil {
+			return i, nil
+		}
+		return data, errors.Errorf("invalid string value for 'count' (the only value allowed is 'all' or a number)")
+	default:
+		return data, errors.Errorf("invalid type %T for device count", value)
+	}
+}
+
+// TODO(ndeloof) SSHConfig could implement yaml.Unmarshal
+func transformSSHConfig(data interface{}) (interface{}, error) {
+	switch value := data.(type) {
+	case map[string]interface{}:
+		var result []interface{}
+		for key, val := range value {
+			if val == nil {
+				val = ""
+			}
+			result = append(result, map[string]interface{}{"id": key, "path": val.(string)})
+		}
+		return result, nil
+	case []interface{}:
+		var result []interface{}
+		for _, v := range value {
+			key, val := transformValueToMapEntry(v.(string), "=", false)
+			result = append(result, map[string]interface{}{"id": key, "path": val.(string)})
+		}
+		return result, nil
+	case string:
+		return ParseShortSSHSyntax(value)
+	}
+	return nil, errors.Errorf("expected a sting, map or a list, got %T: %#v", data, data)
+}
+
+// ParseShortSSHSyntax parse short syntax for SSH authentications
+func ParseShortSSHSyntax(value string) ([]types.SSHKey, error) {
+	if value == "" {
+		value = "default"
+	}
+	key, val := transformValueToMapEntry(value, "=", false)
+	result := []types.SSHKey{{ID: key, Path: val.(string)}}
+	return result, nil
+}
+
+func transformValueToMapEntry(value string, separator string, allowNil bool) (string, interface{}) {
+	parts := strings.SplitN(value, separator, 2)
+	key := parts[0]
+	switch {
+	case len(parts) == 1 && allowNil:
+		return key, nil
+	case len(parts) == 1 && !allowNil:
+		return key, ""
+	default:
+		return key, parts[1]
+	}
+}
+
+func transformIncludeConfig(data interface{}) (interface{}, error) {
+	switch value := data.(type) {
+	case string:
+		return map[string]interface{}{"path": value}, nil
+	case map[string]interface{}:
+		return value, nil
+	default:
+		return data, errors.Errorf("invalid type %T for `include` configuration", value)
+	}
+}
+
+func transformMappingOrListFunc(sep string, allowNil bool) transformFunc {
+	return func(data interface{}) (interface{}, error) {
+		switch value := data.(type) {
+		case map[string]interface{}:
+			result := make(map[string]interface{})
+			for key, v := range value {
+				result[key] = toString(v, allowNil)
+			}
+			return result, nil
+		case []interface{}:
+			result := make(map[string]interface{})
+			for _, v := range value {
+				key, val := transformValueToMapEntry(v.(string), sep, allowNil)
+				result[key] = val
+			}
+			return result, nil
+		}
+		return nil, errors.Errorf("expected a map or a list, got %T: %#v", data, data)
+	}
+}
+
+func toString(value interface{}, allowNil bool) interface{} {
+	switch {
+	case value != nil:
+		return fmt.Sprint(value)
+	case allowNil:
+		return nil
+	default:
+		return ""
+	}
+}
+
+func omitEmpty(m map[string]interface{}) interface{} {
+	for k, v := range m {
+		switch e := v.(type) {
+		case string:
+			if e == "" {
+				delete(m, k)
+			}
+		case int, int32, int64:
+			if e == 0 {
+				delete(m, k)
+			}
+		case map[string]interface{}:
+			m[k] = omitEmpty(e)
+		}
+	}
+	return m
+}

--- a/transform/expand_test.go
+++ b/transform/expand_test.go
@@ -1,0 +1,38 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package transform
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+	"gotest.tools/v3/assert"
+)
+
+func assertExpand(t *testing.T, input string, want string) {
+	got, err := ExpandShortSyntax(unmarshall(t, input))
+	assert.NilError(t, err)
+
+	assert.DeepEqual(t, unmarshall(t, want), got)
+}
+
+func unmarshall(t *testing.T, s string) map[string]interface{} {
+	var val map[string]interface{}
+	err := yaml.Unmarshal([]byte(s), &val)
+	assert.NilError(t, err)
+	return val
+}

--- a/transform/external_test.go
+++ b/transform/external_test.go
@@ -1,0 +1,53 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package transform
+
+import "testing"
+
+func TestExpandExternal(t *testing.T) {
+	assertExpand(t, `
+volumes:
+  foo:
+    external: true
+secrets:
+  foo:
+    external: true
+configs:
+  foo:
+    external: true
+networks:
+  foo:
+    external: true
+`, `
+volumes:
+  foo:
+    external: 
+      external: true
+secrets:
+  foo:
+    external: 
+      external: true
+configs:
+  foo:
+    external: 
+      external: true
+networks:
+  foo:
+    external: 
+      external: true
+`)
+}

--- a/transform/extra_hosts_test.go
+++ b/transform/extra_hosts_test.go
@@ -1,0 +1,35 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package transform
+
+import "testing"
+
+func TestExpandExtraHosts(t *testing.T) {
+	assertExpand(t, `
+services:
+  test:
+    extra_hosts:
+      - "alpha:50.31.209.229"
+      - "zulu:ff02::1"
+`, `
+services:
+  test:
+    extra_hosts:
+      alpha: "50.31.209.229"
+      zulu:  "ff02::1"
+`)
+}

--- a/transform/ports_test.go
+++ b/transform/ports_test.go
@@ -1,0 +1,85 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package transform
+
+import "testing"
+
+func TestExpandServicePorts(t *testing.T) {
+	t.Parallel()
+	t.Run("simple int", func(t *testing.T) {
+		assertExpand(t, `
+services:
+  test:
+    ports:
+      - 9090
+`, `
+services:
+  test:
+    ports:
+      - mode: ingress
+        host_ip: "" 
+        published: ""
+        target: 9090
+        protocol: tcp
+`)
+	})
+	t.Run("simple port binding", func(t *testing.T) {
+		assertExpand(t, `
+services:
+  test:
+    ports:
+      - 127.0.0.1:8080:80/tcp
+`, `
+services:
+  test:
+    ports:
+      - mode: ingress
+        host_ip: 127.0.0.1
+        published: "8080"
+        target: 80
+        protocol: tcp
+`)
+	})
+	t.Run("port range", func(t *testing.T) {
+		assertExpand(t, `
+services:
+  test:
+    ports:
+      - 127.0.0.1:8080-8082:80-82/tcp
+`, `
+services:
+  test:
+    ports:
+      - mode: ingress
+        host_ip: 127.0.0.1
+        published: "8080"
+        target: 80
+        protocol: tcp
+      - mode: ingress
+        host_ip: 127.0.0.1
+        published: "8081"
+        target: 81
+        protocol: tcp
+      - mode: ingress
+        host_ip: 127.0.0.1
+        published: "8082"
+        target: 82
+        protocol: tcp
+`)
+	})
+
+}

--- a/transform/shellCommands_test.go
+++ b/transform/shellCommands_test.go
@@ -1,0 +1,35 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package transform
+
+import (
+	"testing"
+)
+
+func TestExpandShellCommands(t *testing.T) {
+	assertExpand(t, `
+services:
+  test:
+    command: hello world
+    entrypoint: /bin/sh -c echo
+`, `
+services:
+  test:
+    command: ["hello", "world"]
+    entrypoint: ["/bin/sh", "-c", "echo"]
+`)
+}

--- a/transform/ulimits_test.go
+++ b/transform/ulimits_test.go
@@ -1,0 +1,41 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package transform
+
+import (
+	"testing"
+)
+
+func TestUlimits(t *testing.T) {
+	assertExpand(t, `
+services:
+  test:
+    ulimits:
+      noproc: 65535
+      nofile:
+        soft: 11111
+        hard: 99999
+`, `
+services:
+  test:
+    ulimits:
+      noproc: 
+        single: 65535
+      nofile:
+        soft: 11111
+        hard: 99999`)
+}

--- a/transform/volume.go
+++ b/transform/volume.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package loader
+package transform
 
 import (
 	"strings"
@@ -27,8 +27,8 @@ import (
 
 const endOfSpec = rune(0)
 
-// ParseVolume parses a volume spec without any knowledge of the target platform
-func ParseVolume(spec string) (types.ServiceVolumeConfig, error) {
+// parseVolume parses a volume spec without interface{} knowledge of the target platform
+func parseVolume(spec string) (types.ServiceVolumeConfig, error) {
 	volume := types.ServiceVolumeConfig{}
 
 	switch len(spec) {
@@ -80,7 +80,7 @@ func populateFieldFromBuffer(char rune, buffer []rune, volume *types.ServiceVolu
 		volume.Target = strBuffer
 		return nil
 	case char == ':':
-		return errors.New("too many colons")
+		return errors.New("too minterface{} colons")
 	}
 	for _, option := range strings.Split(strBuffer, ",") {
 		switch option {

--- a/transform/volumes_test.go
+++ b/transform/volumes_test.go
@@ -1,0 +1,38 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package transform
+
+import "testing"
+
+func TestExpandServiceVolume(t *testing.T) {
+	assertExpand(t, `
+services:
+  test:
+    volumes:
+      - .:/src:ro
+`, `
+services:
+  test:
+    volumes:
+      - type: bind
+        source: .
+        target: /src
+        read_only: true
+        bind:
+            create_host_path: true
+`)
+}

--- a/types/project.go
+++ b/types/project.go
@@ -504,6 +504,10 @@ func (p *Project) MarshalYAML() ([]byte, error) {
 
 // MarshalJSON makes Config implement json.Marshaler
 func (p *Project) MarshalJSON() ([]byte, error) {
+	return p.MarshalJSONIndent("", "")
+}
+
+func (p *Project) MarshalJSONIndent(prefix, indent string) ([]byte, error) {
 	m := map[string]interface{}{
 		"name":     p.Name,
 		"services": p.Services,
@@ -524,7 +528,7 @@ func (p *Project) MarshalJSON() ([]byte, error) {
 	for k, v := range p.Extensions {
 		m[k] = v
 	}
-	return json.Marshal(m)
+	return json.MarshalIndent(m, prefix, indent)
 }
 
 // ResolveServicesEnvironment parse env_files set for services to resolve the actual environment map for services


### PR DESCRIPTION
Implement the Compose file merge (aka "override") logic on a plain `map[string]interface{}` trees so that we can process compose files before those are unmarshalled into go structs