### PR TITLE
avoid to fail if a duplicate resource is the same as a previous added ones

### DIFF
--- a/loader/include.go
+++ b/loader/include.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"reflect"
 
 	"github.com/compose-spec/compose-go/dotenv"
 	interp "github.com/compose-spec/compose-go/interpolation"
@@ -109,37 +110,55 @@ func loadInclude(ctx context.Context, filename string, configDetails types.Confi
 func importResources(model *types.Config, imported *types.Project, path []string) error {
 	services := mapByName(model.Services)
 	for _, service := range imported.Services {
-		if _, ok := services[service.Name]; ok {
+		if present, ok := services[service.Name]; ok {
+			if reflect.DeepEqual(present, service) {
+				continue
+			}
 			return fmt.Errorf("imported compose file %s defines conflicting service %s", path, service.Name)
 		}
 		model.Services = append(model.Services, service)
 	}
 	for _, service := range imported.DisabledServices {
-		if _, ok := services[service.Name]; ok {
+		if disabled, ok := services[service.Name]; ok {
+			if reflect.DeepEqual(disabled, service) {
+				continue
+			}
 			return fmt.Errorf("imported compose file %s defines conflicting service %s", path, service.Name)
 		}
 		model.Services = append(model.Services, service)
 	}
 	for n, network := range imported.Networks {
-		if _, ok := model.Networks[n]; ok {
+		if present, ok := model.Networks[n]; ok {
+			if reflect.DeepEqual(present, network) {
+				continue
+			}
 			return fmt.Errorf("imported compose file %s defines conflicting network %s", path, n)
 		}
 		model.Networks[n] = network
 	}
 	for n, volume := range imported.Volumes {
-		if _, ok := model.Volumes[n]; ok {
+		if present, ok := model.Volumes[n]; ok {
+			if reflect.DeepEqual(present, volume) {
+				continue
+			}
 			return fmt.Errorf("imported compose file %s defines conflicting volume %s", path, n)
 		}
 		model.Volumes[n] = volume
 	}
 	for n, secret := range imported.Secrets {
-		if _, ok := model.Secrets[n]; ok {
+		if present, ok := model.Secrets[n]; ok {
+			if reflect.DeepEqual(present, secret) {
+				continue
+			}
 			return fmt.Errorf("imported compose file %s defines conflicting secret %s", path, n)
 		}
 		model.Secrets[n] = secret
 	}
 	for n, config := range imported.Configs {
-		if _, ok := model.Configs[n]; ok {
+		if present, ok := model.Configs[n]; ok {
+			if reflect.DeepEqual(present, config) {
+				continue
+			}
 			return fmt.Errorf("imported compose file %s defines conflicting config %s", path, n)
 		}
 		model.Configs[n] = config

--- a/loader/testdata/compose-include-cycle.yaml
+++ b/loader/testdata/compose-include-cycle.yaml
@@ -1,0 +1,6 @@
+include:
+  - compose-include-cycle.yaml
+
+services:
+  foo:
+    image: foo

--- a/loader/testdata/compose-include.yaml
+++ b/loader/testdata/compose-include.yaml
@@ -1,6 +1,6 @@
 include:
-  - compose-include.yaml
+    - path: ./subdir/compose-test-extends-imported.yaml
 
 services:
-  foo:
-    image: foo
+  bar:
+    image: bar


### PR DESCRIPTION
If an exact same resource (service, network...) is included more than once via multiple `include` instructions we should not throw an error but skip it 