### PR TITLE
define Options type for (driver) options we pass as-is to runtime

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -613,7 +613,7 @@ func createTransformHook(additionalTransformers ...Transformer) mapstructure.Dec
 		reflect.TypeOf(types.HealthCheckTest{}):                  transformHealthCheckTest,
 		reflect.TypeOf(types.ShellCommand{}):                     transformShellCommand,
 		reflect.TypeOf(types.StringList{}):                       transformStringList,
-		reflect.TypeOf(map[string]string{}):                      transformMapStringString,
+		reflect.TypeOf(types.Options{}):                          transformMapStringString,
 		reflect.TypeOf(types.UlimitsConfig{}):                    transformUlimits,
 		reflect.TypeOf(types.UnitBytes(0)):                       transformSize,
 		reflect.TypeOf([]types.ServicePortConfig{}):              transformServicePort,

--- a/loader/merge.go
+++ b/loader/merge.go
@@ -320,8 +320,8 @@ func mergeLoggingConfig(dst, src reflect.Value) error {
 		if getLoggingDriver(dst.Elem()) == "" {
 			dst.Elem().FieldByName("Driver").SetString(getLoggingDriver(src.Elem()))
 		}
-		dstOptions := dst.Elem().FieldByName("Options").Interface().(map[string]string)
-		srcOptions := src.Elem().FieldByName("Options").Interface().(map[string]string)
+		dstOptions := dst.Elem().FieldByName("Options").Interface().(types.Options)
+		srcOptions := src.Elem().FieldByName("Options").Interface().(types.Options)
 		return mergo.Merge(&dstOptions, srcOptions, mergo.WithOverride)
 	}
 	// Different driver, override with src

--- a/types/types.go
+++ b/types/types.go
@@ -535,6 +535,9 @@ func (m Mapping) Merge(o Mapping) Mapping {
 	return m
 }
 
+// Options is a mapping type for options we pass as-is to container runtime
+type Options map[string]string
+
 // Labels is a mapping type for labels
 type Labels map[string]string
 
@@ -609,8 +612,8 @@ func (h HostsList) MarshalJSON() ([]byte, error) {
 
 // LoggingConfig the logging configuration for a service
 type LoggingConfig struct {
-	Driver  string            `yaml:"driver,omitempty" json:"driver,omitempty"`
-	Options map[string]string `yaml:"options,omitempty" json:"options,omitempty"`
+	Driver  string  `yaml:"driver,omitempty" json:"driver,omitempty"`
+	Options Options `yaml:"options,omitempty" json:"options,omitempty"`
 
 	Extensions Extensions `yaml:"#extensions,inline" json:"-"`
 }
@@ -955,16 +958,16 @@ func (u *UlimitsConfig) MarshalJSON() ([]byte, error) {
 
 // NetworkConfig for a network
 type NetworkConfig struct {
-	Name       string            `yaml:"name,omitempty" json:"name,omitempty"`
-	Driver     string            `yaml:"driver,omitempty" json:"driver,omitempty"`
-	DriverOpts map[string]string `yaml:"driver_opts,omitempty" json:"driver_opts,omitempty"`
-	Ipam       IPAMConfig        `yaml:"ipam,omitempty" json:"ipam,omitempty"`
-	External   External          `yaml:"external,omitempty" json:"external,omitempty"`
-	Internal   bool              `yaml:"internal,omitempty" json:"internal,omitempty"`
-	Attachable bool              `yaml:"attachable,omitempty" json:"attachable,omitempty"`
-	Labels     Labels            `yaml:"labels,omitempty" json:"labels,omitempty"`
-	EnableIPv6 bool              `yaml:"enable_ipv6,omitempty" json:"enable_ipv6,omitempty"`
-	Extensions Extensions        `yaml:"#extensions,inline" json:"-"`
+	Name       string     `yaml:"name,omitempty" json:"name,omitempty"`
+	Driver     string     `yaml:"driver,omitempty" json:"driver,omitempty"`
+	DriverOpts Options    `yaml:"driver_opts,omitempty" json:"driver_opts,omitempty"`
+	Ipam       IPAMConfig `yaml:"ipam,omitempty" json:"ipam,omitempty"`
+	External   External   `yaml:"external,omitempty" json:"external,omitempty"`
+	Internal   bool       `yaml:"internal,omitempty" json:"internal,omitempty"`
+	Attachable bool       `yaml:"attachable,omitempty" json:"attachable,omitempty"`
+	Labels     Labels     `yaml:"labels,omitempty" json:"labels,omitempty"`
+	EnableIPv6 bool       `yaml:"enable_ipv6,omitempty" json:"enable_ipv6,omitempty"`
+	Extensions Extensions `yaml:"#extensions,inline" json:"-"`
 }
 
 // IPAMConfig for a network
@@ -979,18 +982,18 @@ type IPAMPool struct {
 	Subnet             string                 `yaml:"subnet,omitempty" json:"subnet,omitempty"`
 	Gateway            string                 `yaml:"gateway,omitempty" json:"gateway,omitempty"`
 	IPRange            string                 `yaml:"ip_range,omitempty" json:"ip_range,omitempty"`
-	AuxiliaryAddresses map[string]string      `yaml:"aux_addresses,omitempty" json:"aux_addresses,omitempty"`
+	AuxiliaryAddresses Mapping                `yaml:"aux_addresses,omitempty" json:"aux_addresses,omitempty"`
 	Extensions         map[string]interface{} `yaml:",inline" json:"-"`
 }
 
 // VolumeConfig for a volume
 type VolumeConfig struct {
-	Name       string            `yaml:"name,omitempty" json:"name,omitempty"`
-	Driver     string            `yaml:"driver,omitempty" json:"driver,omitempty"`
-	DriverOpts map[string]string `yaml:"driver_opts,omitempty" json:"driver_opts,omitempty"`
-	External   External          `yaml:"external,omitempty" json:"external,omitempty"`
-	Labels     Labels            `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Extensions Extensions        `yaml:"#extensions,inline" json:"-"`
+	Name       string     `yaml:"name,omitempty" json:"name,omitempty"`
+	Driver     string     `yaml:"driver,omitempty" json:"driver,omitempty"`
+	DriverOpts Options    `yaml:"driver_opts,omitempty" json:"driver_opts,omitempty"`
+	External   External   `yaml:"external,omitempty" json:"external,omitempty"`
+	Labels     Labels     `yaml:"labels,omitempty" json:"labels,omitempty"`
+	Extensions Extensions `yaml:"#extensions,inline" json:"-"`
 }
 
 // External identifies a Volume or Network as a reference to a resource that is


### PR DESCRIPTION
introduce `Options` as an explicit type for `map[string]string` driver options we pass as-is to container runtime