### PR TITLE
introduce compose-spec command line for compose file validation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,65 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/compose-spec/compose-go/v2/cli"
+)
+
+func main() {
+	if len(os.Args) == 1 {
+		fmt.Println(`
+Validates a compose file conforms to the Compose Specification
+
+Usage: compose-spec [OPTIONS] COMPOSE_FILE [COMPOSE_OVERRIDE_FILE]`)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		exitError("can't determine current directory", err)
+	}
+
+	options, err := cli.NewProjectOptions(os.Args[1:],
+		cli.WithWorkingDirectory(wd),
+		cli.WithOsEnv,
+		cli.WithDotEnv,
+		cli.WithConfigFileEnv,
+		cli.WithDefaultConfigPath,
+	)
+	if err != nil {
+		exitError("failed to configure project options", err)
+	}
+
+	project, err := cli.ProjectFromOptions(options)
+	if err != nil {
+		exitError("failed to load project", err)
+	}
+
+	yaml, err := project.MarshalYAML()
+	if err != nil {
+		exitError("failed to marshall project", err)
+	}
+	fmt.Println(string(yaml))
+}
+
+func exitError(message string, err error) {
+	_ = fmt.Errorf("%s: %w", message, err)
+	os.Exit(1)
+}

--- a/loader/paths_test.go
+++ b/loader/paths_test.go
@@ -100,7 +100,7 @@ services:
 			"image":    "docker-image://foo",
 			"oci":      "oci-layout://foo",
 			"abs_path": abs,
-			"github":   "github.com/compose-spec/compose-go/v2",
+			"github":   "github.com/compose-spec/compose-go",
 			"rel_path": filepath.Join(wd, "testdata"),
 		},
 	}


### PR DESCRIPTION
As part of compose-go v2, we consider introducing a command line to manage compose files and validate those, somehow comparable to `docker compose config` command but not tied to Docker implementation.