### PR TITLE
Add Kurtosis to the list of compose-go users

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ Go reference library for parsing and loading Compose files as specified by the
 * [compose-cli](https://github.com/docker/compose-cli)
 * [tilt.dev](https://github.com/tilt-dev/tilt)
 * [kompose](https://github.com/kubernetes/kompose)
+* [kurtosis](https://github.com/kurtosis-tech/kurtosis/)


### PR DESCRIPTION
We've been using compose-go to [do Docker Compose file imports in Kurtosis](https://github.com/kurtosis-tech/kurtosis/blob/main/cli/cli/commands/import/import.go), so wanted to add ourselves to the list of happy users!