### PR TITLE
detect include cycle using compose-file stored in context

### DIFF
--- a/loader/extends.go
+++ b/loader/extends.go
@@ -71,7 +71,7 @@ func ApplyExtends(ctx context.Context, dict map[string]any, workingdir string, o
 					ConfigFiles: []types.ConfigFile{
 						{Filename: local},
 					},
-				}, extendsOpts, ct, nil)
+				}, extendsOpts, ct)
 				if err != nil {
 					return err
 				}

--- a/loader/loader_yaml_test.go
+++ b/loader/loader_yaml_test.go
@@ -43,7 +43,7 @@ services:
     image: bar
     command: echo world
     init: false
-`)}}}, &Options{}, &cycleTracker{}, nil)
+`)}}}, &Options{}, &cycleTracker{})
 	assert.NilError(t, err)
 	assert.DeepEqual(t, model, map[string]interface{}{
 		"services": map[string]interface{}{


### PR DESCRIPTION
to avoid passing around an `included` parameter, store the compose file chain in context and use it to detect cycles