### PR TITLE
make scale a *int as default is 1 (not 0)

### DIFF
--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -100,7 +100,7 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 			},
 			Deploy: &types.DeployConfig{
 				Mode:     "replicated",
-				Replicas: uint64Ptr(6),
+				Replicas: intPtr(6),
 				Labels:   map[string]string{"FOO": "BAR"},
 				RollbackConfig: &types.UpdateConfig{
 					Parallelism:     uint64Ptr(3),
@@ -387,7 +387,6 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 			Privileged: true,
 			ReadOnly:   true,
 			Restart:    types.RestartPolicyAlways,
-			Scale:      1,
 			Secrets: []types.ServiceSecretConfig{
 				{
 					Source: "secret1",
@@ -444,7 +443,6 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 				DockerfileInline: "FROM alpine\nRUN echo \"hello\" > /world.txt\n",
 			},
 			Environment: types.MappingWithEquals{},
-			Scale:       1,
 		},
 	}
 }

--- a/loader/loader_yaml_test.go
+++ b/loader/loader_yaml_test.go
@@ -51,7 +51,6 @@ services:
 				"image":   "bar",
 				"command": "echo world",
 				"init":    false,
-				"scale":   1,
 			},
 		},
 	})

--- a/loader/normalize.go
+++ b/loader/normalize.go
@@ -116,11 +116,6 @@ func Normalize(project *types.Project) error {
 			return err
 		}
 
-		err = relocateScale(&s)
-		if err != nil {
-			return err
-		}
-
 		inferImplicitDependencies(&s)
 
 		project.Services[i] = s
@@ -196,21 +191,6 @@ func setIfMissing(d types.DependsOnConfig, service string, dep types.ServiceDepe
 		d[service] = dep
 	}
 	return d
-}
-
-func relocateScale(s *types.ServiceConfig) error {
-	scale := uint64(s.Scale)
-	if scale > 1 {
-		logrus.Warn("`scale` is deprecated. Use the `deploy.replicas` element")
-		if s.Deploy == nil {
-			s.Deploy = &types.DeployConfig{}
-		}
-		if s.Deploy.Replicas != nil && *s.Deploy.Replicas != scale {
-			return errors.Wrap(errdefs.ErrInvalid, "can't use both 'scale' (deprecated) and 'deploy.replicas'")
-		}
-		s.Deploy.Replicas = &scale
-	}
-	return nil
 }
 
 // Resources with no explicit name are actually named by their key in map

--- a/loader/normalize_test.go
+++ b/loader/normalize_test.go
@@ -52,7 +52,6 @@ func TestNormalizeNetworkNames(t *testing.T) {
 						"ZOT": nil,
 					},
 				},
-				Scale: 1,
 			},
 		},
 	}

--- a/loader/validate.go
+++ b/loader/validate.go
@@ -106,6 +106,14 @@ func checkConsistency(project *types.Project) error {
 				return errors.Wrap(errdefs.ErrInvalid, fmt.Sprintf("service %q refers to undefined secret %s", s.Name, secret.Source))
 			}
 		}
+
+		if s.Scale != nil && s.Deploy != nil {
+			if s.Deploy.Replicas != nil && *s.Scale != *s.Deploy.Replicas {
+				return errors.Wrap(errdefs.ErrInvalid, "can't set distinct values on 'scale' and 'deploy.replicas'")
+			}
+			s.Deploy.Replicas = s.Scale
+		}
+
 	}
 
 	for name, secret := range project.Secrets {

--- a/loader/with-version-struct_test.go
+++ b/loader/with-version-struct_test.go
@@ -45,7 +45,6 @@ func withVersionServices() []types.ServiceConfig {
 				"default": nil,
 			},
 			VolumesFrom: []string{"other"},
-			Scale:       1,
 		},
 		{
 			Name: "other",
@@ -56,7 +55,6 @@ func withVersionServices() []types.ServiceConfig {
 			Volumes: []types.ServiceVolumeConfig{
 				{Target: "/data", Type: "volume", Volume: &types.ServiceVolumeVolume{}},
 			},
-			Scale: 1,
 		},
 	}
 }

--- a/transform/services.go
+++ b/transform/services.go
@@ -22,9 +22,6 @@ import (
 
 func transformService(data any, p tree.Path) (any, error) {
 	value := data.(map[string]any)
-	if _, ok := value["scale"]; !ok {
-		value["scale"] = 1 // TODO(ndeloof) we should make scale a *int
-	}
 	return transformMapping(value, p)
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -112,7 +112,7 @@ type ServiceConfig struct {
 	ReadOnly        bool                             `yaml:"read_only,omitempty" json:"read_only,omitempty"`
 	Restart         string                           `yaml:"restart,omitempty" json:"restart,omitempty"`
 	Runtime         string                           `yaml:"runtime,omitempty" json:"runtime,omitempty"`
-	Scale           int                              `yaml:"scale,omitempty" json:"scale,omitempty"`
+	Scale           *int                             `yaml:"scale,omitempty" json:"scale,omitempty"`
 	Secrets         []ServiceSecretConfig            `yaml:"secrets,omitempty" json:"secrets,omitempty"`
 	SecurityOpt     []string                         `yaml:"security_opt,omitempty" json:"security_opt,omitempty"`
 	ShmSize         UnitBytes                        `yaml:"shm_size,omitempty" json:"shm_size,omitempty"`
@@ -138,17 +138,8 @@ type ServiceConfig struct {
 func (s ServiceConfig) MarshalYAML() (interface{}, error) {
 	type t ServiceConfig
 	value := t(s)
-	value.Scale = 0 // deprecated, but default value "1" doesn't match omitempty
 	value.Name = "" // set during map to slice conversion, not part of the yaml representation
 	return value, nil
-}
-
-// MarshalJSON makes ServiceConfig implement json.Marshaller
-func (s ServiceConfig) MarshalJSON() ([]byte, error) {
-	type t ServiceConfig
-	value := t(s)
-	value.Scale = 0 // deprecated, but default value "1" doesn't match omitempty
-	return json.Marshal(value)
 }
 
 // NetworksByPriority return the service networks IDs sorted according to Priority
@@ -323,7 +314,7 @@ type LoggingConfig struct {
 // DeployConfig the deployment configuration for a service
 type DeployConfig struct {
 	Mode           string         `yaml:"mode,omitempty" json:"mode,omitempty"`
-	Replicas       *uint64        `yaml:"replicas,omitempty" json:"replicas,omitempty"`
+	Replicas       *int           `yaml:"replicas,omitempty" json:"replicas,omitempty"`
 	Labels         Labels         `yaml:"labels,omitempty" json:"labels,omitempty"`
 	UpdateConfig   *UpdateConfig  `yaml:"update_config,omitempty" json:"update_config,omitempty"`
 	RollbackConfig *UpdateConfig  `yaml:"rollback_config,omitempty" json:"rollback_config,omitempty"`


### PR DESCRIPTION
as default is not 0, `omitempty` doesn't apply and this require code to manage this default value.
using an `*int` we can distinguish unset value (scale=1) vs service explicitly set to scale=0 (many users rely on this to disable service)