### PR TITLE
unit bytes can be set as plain int

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2807,3 +2807,19 @@ networks:
 	})
 	assert.ErrorContains(t, err, "service redis declares mutually exclusive `network_mode` and `networks`")
 }
+
+func TestLoadUnitBytes(t *testing.T) {
+	project, err := loadYAML(`
+name: load-unit-bytes
+services:
+  test1:
+    image: test
+    memswap_limit: -1
+  test2:
+    image: test
+    memswap_limit: 640kb
+`)
+	assert.NilError(t, err)
+	assert.Equal(t, project.Services[0].MemSwapLimit, types.UnitBytes(-1))
+	assert.Equal(t, project.Services[1].MemSwapLimit, types.UnitBytes(640*1024))
+}

--- a/loader/paths_test.go
+++ b/loader/paths_test.go
@@ -100,7 +100,7 @@ services:
 			"image":    "docker-image://foo",
 			"oci":      "oci-layout://foo",
 			"abs_path": abs,
-			"github":   "github.com/compose-spec/compose-go/v2",
+			"github":   "github.com/compose-spec/compose-go",
 			"rel_path": filepath.Join(wd, "testdata"),
 		},
 	}

--- a/types/bytes.go
+++ b/types/bytes.go
@@ -36,7 +36,13 @@ func (u UnitBytes) MarshalJSON() ([]byte, error) {
 }
 
 func (u *UnitBytes) DecodeMapstructure(value interface{}) error {
-	v, err := units.RAMInBytes(fmt.Sprint(value))
-	*u = UnitBytes(v)
-	return err
+	switch v := value.(type) {
+	case int:
+		*u = UnitBytes(v)
+	case string:
+		b, err := units.RAMInBytes(fmt.Sprint(value))
+		*u = UnitBytes(b)
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
This fix a regression as mem limit can be set either as byte unit or plain integer

fix https://github.com/docker/compose/issues/11160