### PR TITLE
make Services a map[string]ServiceConfig to reflect yaml structure

### DIFF
--- a/cli/options_windows_test.go
+++ b/cli/options_windows_test.go
@@ -34,8 +34,9 @@ func TestConvertWithEnvVar(t *testing.T) {
 	p, err := ProjectFromOptions(opts)
 
 	assert.NilError(t, err)
-	assert.Equal(t, len(p.Services[0].Volumes), 3)
-	assert.Equal(t, p.Services[0].Volumes[0].Source, "/c/docker/project")
-	assert.Equal(t, p.Services[0].Volumes[1].Source, "/c/project-dir/relative")
-	assert.Equal(t, p.Services[0].Volumes[2].Source, "/c/project-dir/relative2")
+	volumes := p.Services["test"].Volumes
+	assert.Equal(t, len(volumes), 3)
+	assert.Equal(t, volumes[0].Source, "/c/docker/project")
+	assert.Equal(t, volumes[1].Source, "/c/project-dir/relative")
+	assert.Equal(t, volumes[2].Source, "/c/project-dir/relative2")
 }

--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -44,9 +44,9 @@ func fullExampleProject(workingDir, homeDir string) *types.Project {
 	}
 }
 
-func services(workingDir, homeDir string) []types.ServiceConfig {
-	return []types.ServiceConfig{
-		{
+func services(workingDir, homeDir string) types.Services {
+	return types.Services{
+		"foo": {
 			Name: "foo",
 
 			Annotations: map[string]string{
@@ -436,7 +436,7 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 			},
 			WorkingDir: "/code",
 		},
-		{
+		"bar": {
 			Name: "bar",
 			Build: &types.BuildConfig{
 				Context:          workingDir,

--- a/loader/normalize.go
+++ b/loader/normalize.go
@@ -37,7 +37,7 @@ func Normalize(project *types.Project) error {
 		project.Networks["default"] = types.NetworkConfig{}
 	}
 
-	for i, s := range project.Services {
+	for name, s := range project.Services {
 		if len(s.Networks) == 0 && s.NetworkMode == "" {
 			// Service without explicit network attachment are implicitly exposed on default network
 			s.Networks = map[string]*types.ServiceNetworkConfig{"default": nil}
@@ -114,7 +114,7 @@ func Normalize(project *types.Project) error {
 
 		inferImplicitDependencies(&s)
 
-		project.Services[i] = s
+		project.Services[name] = s
 	}
 
 	setNameFromKey(project)

--- a/loader/normalize_test.go
+++ b/loader/normalize_test.go
@@ -42,8 +42,8 @@ func TestNormalizeNetworkNames(t *testing.T) {
 				Name: "CustomName",
 			},
 		},
-		Services: []types.ServiceConfig{
-			{
+		Services: types.Services{
+			"foo": {
 				Name: "foo",
 				Build: &types.BuildConfig{
 					Context: "./testdata",
@@ -125,8 +125,8 @@ func TestNormalizeDependsOn(t *testing.T) {
 		Name:     "myProject",
 		Networks: types.Networks{},
 		Volumes:  types.Volumes{},
-		Services: []types.ServiceConfig{
-			{
+		Services: types.Services{
+			"foo": {
 				Name: "foo",
 				DependsOn: map[string]types.ServiceDependency{
 					"bar": { // explicit depends_on never should be overridden
@@ -137,14 +137,14 @@ func TestNormalizeDependsOn(t *testing.T) {
 				},
 				NetworkMode: "service:zot",
 			},
-			{
+			"bar": {
 				Name: "bar",
 				VolumesFrom: []string{
 					"zot",
 					"container:xxx",
 				},
 			},
-			{
+			"zot": {
 				Name: "zot",
 			},
 		},
@@ -190,7 +190,7 @@ func TestNormalizeImplicitDependencies(t *testing.T) {
 	project := types.Project{
 		Name: "myProject",
 		Services: types.Services{
-			types.ServiceConfig{
+			"test": types.ServiceConfig{
 				Name:        "test",
 				Ipc:         "service:foo",
 				Cgroup:      "service:bar",
@@ -216,19 +216,19 @@ func TestNormalizeImplicitDependencies(t *testing.T) {
 	}
 	err := Normalize(&project)
 	assert.NilError(t, err)
-	assert.DeepEqual(t, expected, project.Services[0].DependsOn)
+	assert.DeepEqual(t, expected, project.Services["test"].DependsOn)
 }
 
 func TestImplicitContextPath(t *testing.T) {
 	project := &types.Project{
 		Name: "myProject",
 		Services: types.Services{
-			types.ServiceConfig{
+			"test": types.ServiceConfig{
 				Name:  "test",
 				Build: &types.BuildConfig{},
 			},
 		},
 	}
 	assert.NilError(t, Normalize(project))
-	assert.Equal(t, ".", project.Services[0].Build.Context)
+	assert.Equal(t, ".", project.Services["test"].Build.Context)
 }

--- a/loader/paths_test.go
+++ b/loader/paths_test.go
@@ -67,7 +67,7 @@ services:
 		Context:    filepath.Join(wd, "testdata"),
 		Dockerfile: "Dockerfile-sample",
 	}
-	assert.DeepEqual(t, expected, *project.Services[0].Build)
+	assert.DeepEqual(t, expected, *project.Services["foo"].Build)
 }
 
 func TestResolveAdditionalContexts(t *testing.T) {
@@ -104,5 +104,5 @@ services:
 			"rel_path": filepath.Join(wd, "testdata"),
 		},
 	}
-	assert.DeepEqual(t, expected, *project.Services[0].Build)
+	assert.DeepEqual(t, expected, *project.Services["test"].Build)
 }

--- a/loader/validate_test.go
+++ b/loader/validate_test.go
@@ -26,8 +26,8 @@ import (
 
 func TestValidateAnonymousVolume(t *testing.T) {
 	project := &types.Project{
-		Services: types.Services([]types.ServiceConfig{
-			{
+		Services: types.Services{
+			"myservice": {
 				Name:  "myservice",
 				Image: "my/service",
 				Volumes: []types.ServiceVolumeConfig{
@@ -37,7 +37,7 @@ func TestValidateAnonymousVolume(t *testing.T) {
 					},
 				},
 			},
-		}),
+		},
 	}
 	err := checkConsistency(project)
 	assert.NilError(t, err)
@@ -45,8 +45,8 @@ func TestValidateAnonymousVolume(t *testing.T) {
 
 func TestValidateNamedVolume(t *testing.T) {
 	project := &types.Project{
-		Services: types.Services([]types.ServiceConfig{
-			{
+		Services: types.Services{
+			"myservice": {
 				Name:  "myservice",
 				Image: "my/service",
 				Volumes: []types.ServiceVolumeConfig{
@@ -57,7 +57,7 @@ func TestValidateNamedVolume(t *testing.T) {
 					},
 				},
 			},
-		}),
+		},
 	}
 	err := checkConsistency(project)
 	assert.Error(t, err, `service "myservice" refers to undefined volume myVolume: invalid compose project`)
@@ -73,11 +73,11 @@ func TestValidateNamedVolume(t *testing.T) {
 
 func TestValidateNoBuildNoImage(t *testing.T) {
 	project := &types.Project{
-		Services: types.Services([]types.ServiceConfig{
-			{
+		Services: types.Services{
+			"myservice": {
 				Name: "myservice",
 			},
-		}),
+		},
 	}
 	err := checkConsistency(project)
 	assert.Error(t, err, `service "myservice" has neither an image nor a build context specified: invalid compose project`)
@@ -86,17 +86,17 @@ func TestValidateNoBuildNoImage(t *testing.T) {
 func TestValidateNetworkMode(t *testing.T) {
 	t.Run("network_mode service fail", func(t *testing.T) {
 		project := &types.Project{
-			Services: types.Services([]types.ServiceConfig{
-				{
+			Services: types.Services{
+				"myservice1": {
 					Name:  "myservice1",
 					Image: "scratch",
 				},
-				{
+				"myservice2": {
 					Name:        "myservice2",
 					Image:       "scratch",
 					NetworkMode: "service:myservice1",
 				},
-			}),
+			},
 		}
 		err := checkConsistency(project)
 		assert.NilError(t, err)
@@ -104,17 +104,17 @@ func TestValidateNetworkMode(t *testing.T) {
 
 	t.Run("network_mode service fail", func(t *testing.T) {
 		project := &types.Project{
-			Services: types.Services([]types.ServiceConfig{
-				{
+			Services: types.Services{
+				"myservice1": {
 					Name:  "myservice1",
 					Image: "scratch",
 				},
-				{
+				"myservice2": {
 					Name:        "myservice2",
 					Image:       "scratch",
 					NetworkMode: "service:nonexistentservice",
 				},
-			}),
+			},
 		}
 		err := checkConsistency(project)
 		assert.Error(t, err, `service "nonexistentservice" not found for network_mode 'service:nonexistentservice'`)
@@ -122,18 +122,18 @@ func TestValidateNetworkMode(t *testing.T) {
 
 	t.Run("network_mode container", func(t *testing.T) {
 		project := &types.Project{
-			Services: types.Services([]types.ServiceConfig{
-				{
+			Services: types.Services{
+				"myservice1": {
 					Name:          "myservice1",
 					ContainerName: "mycontainer_name",
 					Image:         "scratch",
 				},
-				{
+				"myservice2": {
 					Name:        "myservice2",
 					Image:       "scratch",
 					NetworkMode: "container:mycontainer_name",
 				},
-			}),
+			},
 		}
 		err := checkConsistency(project)
 		assert.NilError(t, err)
@@ -142,8 +142,8 @@ func TestValidateNetworkMode(t *testing.T) {
 	t.Run("network_mode & networks can't both be defined", func(t *testing.T) {
 		project := &types.Project{
 			Networks: types.Networks{"mynetwork": types.NetworkConfig{}},
-			Services: types.Services([]types.ServiceConfig{
-				{
+			Services: types.Services{
+				"myservice1": {
 					Name:        "myservice1",
 					Image:       "scratch",
 					NetworkMode: "host",
@@ -151,7 +151,7 @@ func TestValidateNetworkMode(t *testing.T) {
 						"mynetwork": {},
 					},
 				},
-			}),
+			},
 		}
 		err := checkConsistency(project)
 		assert.Error(t, err, "service myservice1 declares mutually exclusive `network_mode` and `networks`: invalid compose project")
@@ -209,8 +209,8 @@ func TestValidateSecret(t *testing.T) {
 					External: true,
 				},
 			},
-			Services: types.Services([]types.ServiceConfig{
-				{
+			Services: types.Services{
+				"myservice": {
 					Name:  "myservice",
 					Image: "scratch",
 					Secrets: []types.ServiceSecretConfig{
@@ -219,7 +219,7 @@ func TestValidateSecret(t *testing.T) {
 						},
 					},
 				},
-			}),
+			},
 		}
 		err := checkConsistency(project)
 		assert.NilError(t, err)
@@ -227,8 +227,8 @@ func TestValidateSecret(t *testing.T) {
 
 	t.Run("service secret undefined", func(t *testing.T) {
 		project := &types.Project{
-			Services: types.Services([]types.ServiceConfig{
-				{
+			Services: types.Services{
+				"myservice": {
 					Name:  "myservice",
 					Image: "scratch",
 					Secrets: []types.ServiceSecretConfig{
@@ -237,7 +237,7 @@ func TestValidateSecret(t *testing.T) {
 						},
 					},
 				},
-			}),
+			},
 		}
 		err := checkConsistency(project)
 		assert.Error(t, err, `service "myservice" refers to undefined secret foo: invalid compose project`)
@@ -246,15 +246,15 @@ func TestValidateSecret(t *testing.T) {
 
 func TestValidateDependsOn(t *testing.T) {
 	project := types.Project{
-		Services: types.Services([]types.ServiceConfig{
-			{
+		Services: types.Services{
+			"myservice": {
 				Name:  "myservice",
 				Image: "scratch",
 				DependsOn: map[string]types.ServiceDependency{
 					"missingservice": {},
 				},
 			},
-		}),
+		},
 	}
 	err := checkConsistency(&project)
 	assert.Error(t, err, `service "myservice" depends on undefined service missingservice: invalid compose project`)

--- a/loader/with-version-struct_test.go
+++ b/loader/with-version-struct_test.go
@@ -30,10 +30,10 @@ func withVersionExampleConfig() *types.Config {
 	}
 }
 
-func withVersionServices() []types.ServiceConfig {
+func withVersionServices() types.Services {
 	buildCtx, _ := filepath.Abs("./Dockerfile")
-	return []types.ServiceConfig{
-		{
+	return types.Services{
+		"web": {
 			Name: "web",
 
 			Build: &types.BuildConfig{
@@ -46,7 +46,7 @@ func withVersionServices() []types.ServiceConfig {
 			},
 			VolumesFrom: []string{"other"},
 		},
-		{
+		"other": {
 			Name: "other",
 
 			Image:       "busybox:1.31.0-uclibc",

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -24,8 +24,8 @@ import (
 
 func Test_WithServices(t *testing.T) {
 	p := Project{
-		Services: append(Services{},
-			ServiceConfig{
+		Services: Services{
+			"service_1": ServiceConfig{
 				Name: "service_1",
 				DependsOn: map[string]ServiceDependency{
 					"service_3": {
@@ -33,9 +33,11 @@ func Test_WithServices(t *testing.T) {
 						Required:  true,
 					},
 				},
-			}, ServiceConfig{
+			},
+			"service_2": ServiceConfig{
 				Name: "service_2",
-			}, ServiceConfig{
+			},
+			"service_3": ServiceConfig{
 				Name: "service_3",
 				DependsOn: map[string]ServiceDependency{
 					"service_2": {
@@ -43,7 +45,8 @@ func Test_WithServices(t *testing.T) {
 						Required:  true,
 					},
 				},
-			}),
+			},
+		},
 	}
 	order := []string{}
 	fn := func(service ServiceConfig) error {

--- a/types/services.go
+++ b/types/services.go
@@ -16,25 +16,20 @@
 
 package types
 
-import "encoding/json"
+// Services is a map of ServiceConfig
+type Services map[string]ServiceConfig
 
-// Services is a list of ServiceConfig
-type Services []ServiceConfig
-
-// MarshalYAML makes Services implement yaml.Marshaller
-func (s Services) MarshalYAML() (interface{}, error) {
-	services := map[string]ServiceConfig{}
+// GetProfiles retrieve the profiles implicitly enabled by explicitly targeting selected services
+func (s Services) GetProfiles() []string {
+	set := map[string]struct{}{}
 	for _, service := range s {
-		services[service.Name] = service
+		for _, p := range service.Profiles {
+			set[p] = struct{}{}
+		}
 	}
-	return services, nil
-}
-
-// MarshalJSON makes Services implement json.Marshaler
-func (s Services) MarshalJSON() ([]byte, error) {
-	data, err := s.MarshalYAML()
-	if err != nil {
-		return nil, err
+	var profiles []string
+	for k := range set {
+		profiles = append(profiles, k)
 	}
-	return json.MarshalIndent(data, "", "  ")
+	return profiles
 }


### PR DESCRIPTION
the docker/cli compose parser we inherited as compose-go used a `[]ServiceConfig` to map to yaml `services`. I'm not sure what was the reason for this design decision, and propose we adopt a natural `map[string]ServiceConfig` type.
For convenience, `ServiceConfig.Name` is set to map key