### PR TITLE
validate watch.path is set to a valid path

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -373,9 +373,10 @@ func loadYamlModel(ctx context.Context, config types.ConfigDetails, opts *Option
 
 	dict = groupXFieldsIntoExtensions(dict, tree.NewPath())
 
-	// TODO(ndeloof) shall we implement this as a Validate func on types ?
-	if err := validation.Validate(dict); err != nil {
-		return nil, err
+	if !opts.SkipValidation {
+		if err := validation.Validate(dict); err != nil {
+			return nil, err
+		}
 	}
 
 	if opts.ResolvePaths {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2750,6 +2750,7 @@ services:
           action: sync+restart
 `, nil), func(options *Options) {
 		options.ResolvePaths = false
+		options.SkipValidation = true
 	})
 	assert.NilError(t, err)
 	frontend, err := project.GetService("frontend")

--- a/paths/resolve.go
+++ b/paths/resolve.go
@@ -96,7 +96,10 @@ func (r *relativePathsResolver) absPath(value any) (any, error) {
 		if filepath.IsAbs(v) {
 			return v, nil
 		}
-		return filepath.Join(r.workingDir, v), nil
+		if v != "" {
+			return filepath.Join(r.workingDir, v), nil
+		}
+		return v, nil
 	}
 	return nil, fmt.Errorf("unexpected type %T", value)
 }

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -461,6 +461,7 @@
               "target": {"type": "string"}
             }
           },
+          "required": ["path", "action"],
           "additionalProperties": false,
           "patternProperties": {"^x-": {}}
         }


### PR DESCRIPTION
this bump compose-spec schema (watch and path are required) + adds a validation step to check the configured path exists

closes https://github.com/docker/compose/issues/11182