### PR TITLE
validate yaml dict _after_ path have been resolved

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -373,15 +373,15 @@ func loadYamlModel(ctx context.Context, config types.ConfigDetails, opts *Option
 
 	dict = groupXFieldsIntoExtensions(dict, tree.NewPath())
 
-	if !opts.SkipValidation {
-		if err := validation.Validate(dict); err != nil {
+	if opts.ResolvePaths {
+		err = paths.ResolveRelativePaths(dict, config.WorkingDir)
+		if err != nil {
 			return nil, err
 		}
 	}
 
-	if opts.ResolvePaths {
-		err = paths.ResolveRelativePaths(dict, config.WorkingDir)
-		if err != nil {
+	if !opts.SkipValidation {
+		if err := validation.Validate(dict); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
after https://github.com/compose-spec/compose-go/pull/490 `watch.path` is checked to be a valid path, so need to resolve relative paths _before_ such a validation
