### PR TITLE
don't check path is an actual file

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -294,6 +294,7 @@
                         "ipv4_address": {"type": "string"},
                         "ipv6_address": {"type": "string"},
                         "link_local_ips": {"$ref": "#/definitions/list_of_strings"},
+                        "mac_address": {"type": "string"},
                         "priority": {"type": "number"}
                       },
                       "additionalProperties": false,

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -18,7 +18,6 @@ package validation
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/tree"
@@ -93,9 +92,6 @@ func checkPath(value any, p tree.Path) error {
 	v := value.(string)
 	if v == "" {
 		return errors.Errorf("%s: value can't be blank", p)
-	}
-	if _, err := os.Stat(v); err != nil {
-		return errors.Wrapf(err, "%s: invalid path %s", p, value)
 	}
 	return nil
 }


### PR DESCRIPTION
after https://github.com/compose-spec/compose-go/pull/490 I changed my mind, considering this use-case:
as a team has a compose.yaml file, developers have `develop` section set, but ops only rely on published images, the latter won't be able to run `compose up` as they will get watch.path validation error, which isn't relevant for their usage.
So, better check valid path when actually used by some command.