### PR TITLE
[backport v1] Add a network-scoped mac_address field

### DIFF
--- a/loader/full-example.yml
+++ b/loader/full-example.yml
@@ -235,6 +235,7 @@ services:
       other-network:
         ipv4_address: 172.16.238.10
         ipv6_address: 2001:3984:3989::10
+        mac_address: 02:42:72:98:65:08
       other-other-network:
 
     pid: "host"

--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -233,6 +233,7 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 				"other-network": {
 					Ipv4Address: "172.16.238.10",
 					Ipv6Address: "2001:3984:3989::10",
+					MacAddress:  "02:42:72:98:65:08",
 				},
 				"other-other-network": nil,
 			},
@@ -775,6 +776,7 @@ services:
       other-network:
         ipv4_address: 172.16.238.10
         ipv6_address: 2001:3984:3989::10
+        mac_address: 02:42:72:98:65:08
       other-other-network: null
       some-network:
         aliases:
@@ -1392,7 +1394,8 @@ func fullExampleJSON(workingDir, homeDir string) string {
       "networks": {
         "other-network": {
           "ipv4_address": "172.16.238.10",
-          "ipv6_address": "2001:3984:3989::10"
+          "ipv6_address": "2001:3984:3989::10",
+          "mac_address": "02:42:72:98:65:08"
         },
         "other-other-network": null,
         "some-network": {

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -294,6 +294,7 @@
                         "ipv4_address": {"type": "string"},
                         "ipv6_address": {"type": "string"},
                         "link_local_ips": {"$ref": "#/definitions/list_of_strings"},
+                        "mac_address": {"type": "string"},
                         "priority": {"type": "number"}
                       },
                       "additionalProperties": false,

--- a/types/types.go
+++ b/types/types.go
@@ -611,6 +611,7 @@ type ServiceNetworkConfig struct {
 	Ipv4Address  string   `yaml:"ipv4_address,omitempty" json:"ipv4_address,omitempty"`
 	Ipv6Address  string   `yaml:"ipv6_address,omitempty" json:"ipv6_address,omitempty"`
 	LinkLocalIPs []string `yaml:"link_local_ips,omitempty" json:"link_local_ips,omitempty"`
+	MacAddress   string   `yaml:"mac_address,omitempty" json:"mac_address,omitempty"`
 
 	Extensions Extensions `yaml:"#extensions,inline" json:"-"`
 }


### PR DESCRIPTION
Related to:

- https://github.com/compose-spec/compose-spec/pull/435


(cherry picked from commit 0282c0c0958ae996d1c3079c25dde09093906426)