### PR TITLE
project name set by yaml must be identified by caller as opts.projectName

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -415,6 +415,7 @@ func load(ctx context.Context, configDetails types.ConfigDetails, opts *Options,
 		WorkingDir:  configDetails.WorkingDir,
 		Environment: configDetails.Environment,
 	}
+	delete(dict, "name") // project name set by yaml must be identified by caller as opts.projectName
 	err = Transform(dict, project)
 	if err != nil {
 		return nil, err

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -781,7 +781,6 @@ networks:
 	config, err := Load(buildConfigDetails(dict, env), func(options *Options) {
 		options.SkipNormalization = true
 		options.SkipConsistencyCheck = true
-		options.SetProjectName("test", true)
 	})
 	assert.NilError(t, err)
 

--- a/transform/external.go
+++ b/transform/external.go
@@ -37,14 +37,21 @@ func transformMaybeExternal(data any, p tree.Path) (any, error) {
 		if !ok {
 			return resource, nil
 		}
-		name := resource["name"]
-		if ename, ok := external["name"]; ok {
+		name, named := resource["name"]
+		extname, extNamed := external["name"]
+		if extNamed {
 			logrus.Warnf("%s: external.name is deprecated. Please set name and external: true", p)
-			if name != nil && ename != name {
+			if named && extname != name {
 				return nil, fmt.Errorf("%s: name and external.name conflict; only use name", p)
 			}
-			if name == nil {
-				resource["name"] = ename
+		}
+		if !named {
+			if extNamed {
+				// adopt (deprecated) external.name if set
+				resource["name"] = extname
+			} else {
+				// otherwise, just replicate the mapping key for convenience
+				resource["name"] = p
 			}
 		}
 		resource["external"] = true


### PR DESCRIPTION
as we map yaml dict to go struct, ignore `name` as an explicit name has precedence over yaml attribute and has to be managed by caller using `Options.projectName`
also fix `name` being set on external resources