### PR TITLE
docs: add testcontainers-go's Compose module to the list of compose-go users

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ Go reference library for parsing and loading Compose files as specified by the
 * [tilt.dev](https://github.com/tilt-dev/tilt)
 * [kompose](https://github.com/kubernetes/kompose)
 * [kurtosis](https://github.com/kurtosis-tech/kurtosis/)
+* [testcontainers-go's Compose module](https://github.com/testcontainers/testcontainers-go/tree/main/modules/compose)


### PR DESCRIPTION
This PR adds testcontainers-go as dependency of the compose-go lib.

We are using it for the compose module of testcontainers-go.