### PR TITLE
COMPOSE_DISABLE_ENV_FILE allows to disable use of default .env file

### DIFF
--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -182,7 +182,7 @@ func TestProjectName(t *testing.T) {
 		assert.NilError(t, err)
 		defer os.Chdir(wd) //nolint:errcheck
 
-		opts, err := NewProjectOptions(nil, WithDotEnv, WithConfigFileEnv)
+		opts, err := NewProjectOptions(nil, WithEnvFiles(), WithDotEnv, WithConfigFileEnv)
 		assert.NilError(t, err)
 		p, err := ProjectFromOptions(opts)
 		assert.NilError(t, err)
@@ -250,7 +250,7 @@ func TestProjectWithDotEnv(t *testing.T) {
 
 	opts, err := NewProjectOptions([]string{
 		"compose-with-variables.yaml",
-	}, WithName("my_project"), WithDotEnv)
+	}, WithName("my_project"), WithEnvFiles(), WithDotEnv)
 	assert.NilError(t, err)
 	p, err := ProjectFromOptions(opts)
 	assert.NilError(t, err)
@@ -346,7 +346,7 @@ func TestEnvVariablePrecedence(t *testing.T) {
 				// First load os.Env variable, higher in precedence rule
 				WithEnv(test.osEnv),
 				// Then load dotEnv file
-				WithWorkingDirectory(wd), WithDotEnv)
+				WithWorkingDirectory(wd), WithEnvFiles(), WithDotEnv)
 			assert.NilError(t, err)
 			assert.DeepEqual(t, test.expected, options.Environment)
 		})

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -17,10 +17,11 @@
 package consts
 
 const (
-	ComposeProjectName   = "COMPOSE_PROJECT_NAME"
-	ComposePathSeparator = "COMPOSE_PATH_SEPARATOR"
-	ComposeFilePath      = "COMPOSE_FILE"
-	ComposeProfiles      = "COMPOSE_PROFILES"
+	ComposeProjectName           = "COMPOSE_PROJECT_NAME"
+	ComposePathSeparator         = "COMPOSE_PATH_SEPARATOR"
+	ComposeFilePath              = "COMPOSE_FILE"
+	ComposeDisableDefaultEnvFile = "COMPOSE_DISABLE_ENV_FILE"
+	ComposeProfiles              = "COMPOSE_PROFILES"
 )
 
 const Extensions = "#extensions" // Using # prefix, we prevent risk to conflict with an actual yaml key

--- a/dotenv/env.go
+++ b/dotenv/env.go
@@ -24,14 +24,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-func GetEnvFromFile(currentEnv map[string]string, workingDir string, filenames []string) (map[string]string, error) {
+func GetEnvFromFile(currentEnv map[string]string, filenames []string) (map[string]string, error) {
 	envMap := make(map[string]string)
 
-	dotEnvFiles := filenames
-	if len(dotEnvFiles) == 0 {
-		dotEnvFiles = append(dotEnvFiles, filepath.Join(workingDir, ".env"))
-	}
-	for _, dotEnvFile := range dotEnvFiles {
+	for _, dotEnvFile := range filenames {
 		abs, err := filepath.Abs(dotEnvFile)
 		if err != nil {
 			return envMap, err
@@ -40,9 +36,6 @@ func GetEnvFromFile(currentEnv map[string]string, workingDir string, filenames [
 
 		s, err := os.Stat(dotEnvFile)
 		if os.IsNotExist(err) {
-			if len(filenames) == 0 {
-				return envMap, nil
-			}
 			return envMap, errors.Errorf("Couldn't find env file: %s", dotEnvFile)
 		}
 		if err != nil {

--- a/dotenv/godotenv_test.go
+++ b/dotenv/godotenv_test.go
@@ -703,9 +703,6 @@ func TestGetEnvFromFile(t *testing.T) {
 	err := os.Mkdir(f, 0o700)
 	assert.NilError(t, err)
 
-	_, err = GetEnvFromFile(nil, wd, nil)
-	assert.NilError(t, err)
-
-	_, err = GetEnvFromFile(nil, wd, []string{f})
+	_, err = GetEnvFromFile(nil, []string{f})
 	assert.Check(t, strings.HasSuffix(err.Error(), ".env is a directory"))
 }

--- a/loader/include.go
+++ b/loader/include.go
@@ -19,6 +19,7 @@ package loader
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -76,7 +77,14 @@ func ApplyInclude(ctx context.Context, configDetails types.ConfigDetails, model 
 		loadOptions.SkipNormalization = true
 		loadOptions.SkipConsistencyCheck = true
 
-		envFromFile, err := dotenv.GetEnvFromFile(configDetails.Environment, r.ProjectDirectory, r.EnvFile)
+		if len(r.EnvFile) == 0 {
+			f := filepath.Join(r.ProjectDirectory, ".env")
+			if s, err := os.Stat(f); err == nil && !s.IsDir() {
+				r.EnvFile = types.StringList{f}
+			}
+		}
+
+		envFromFile, err := dotenv.GetEnvFromFile(configDetails.Environment, r.EnvFile)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
COMPOSE_DISABLE_ENV_FILE allows to disable use of default .env file
closes https://github.com/docker/compose/issues/6741

this also removes default value management from  `GetEnvFromFile` which makes it a more general-purpose function