### PR TITLE
fix #512 revert err check

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -342,6 +342,9 @@ func loadYamlModel(ctx context.Context, config types.ConfigDetails, opts *Option
 				if err == io.EOF {
 					break
 				}
+				if err != nil {
+					return nil, err
+				}
 				if err := processRawYaml(raw, processor); err != nil {
 					return nil, err
 				}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -944,6 +944,14 @@ services:
 	assert.DeepEqual(t, configWithoutEnvFiles.Services["web"].Environment, expectedEnvironmentMap)
 }
 
+func TestDecodeErrors(t *testing.T) {
+	dict := "name: test\nservices:\n  web:\n    image: nginx\n\tbuild: ."
+
+	configDetails := buildConfigDetails(dict, nil)
+	_, err := Load(configDetails)
+	assert.Error(t, err, "yaml: line 4: found a tab character that violates indentation")
+}
+
 func TestBuildProperties(t *testing.T) {
 	dict := `
 name: test
@@ -2768,7 +2776,7 @@ services:
     image: example/proxy
     build: ./proxy
     develop:
-      watch: 
+      watch:
         # rebuild image and recreate service
         - path: ./proxy/proxy.conf
           action: sync+restart


### PR DESCRIPTION
Restore the `if err` that was likely unintentionally deleted in https://github.com/compose-spec/compose-go/commit/7e391a6500eeb366211891b2f6215412058de9a0