### PR TITLE
Read config file content if missing

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -484,7 +484,17 @@ func projectName(details types.ConfigDetails, opts *Options) (string, error) {
 	if !projectNameImperativelySet {
 		var pjNameFromConfigFile string
 		for _, configFile := range details.ConfigFiles {
-			yml, err := ParseYAML(configFile.Content)
+			content := configFile.Content
+			if content == nil {
+				// This can be hit when Filename is set but Content is not. One
+				// example is when using ToConfigFiles().
+				d, err := os.ReadFile(configFile.Filename)
+				if err != nil {
+					return "", fmt.Errorf("failed to read file %q: %w", configFile.Filename, err)
+				}
+				content = d
+			}
+			yml, err := ParseYAML(content)
 			if err != nil {
 				// HACK: the way that loading is currently structured, this is
 				// a duplicative parse just for the `name`. if it fails, we

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -405,6 +405,7 @@ services:
 	}, func(options *Options) {
 		options.SkipNormalization = true
 		options.SkipConsistencyCheck = true
+		options.SetProjectName("project", true)
 	})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Len(actual.Services, 2))
@@ -2852,6 +2853,46 @@ networks:
 		},
 	})
 	assert.ErrorContains(t, err, "service redis declares mutually exclusive `network_mode` and `networks`")
+}
+
+func TestLoadEmptyContent(t *testing.T) {
+	yaml := `name: load-multi-docs
+services:
+  test:
+    image: nginx:latest`
+	tmpPath := filepath.Join(t.TempDir(), "docker-compose.yaml")
+	if err := os.WriteFile(tmpPath, []byte(yaml), 0o644); err != nil {
+		t.Fatalf("failed to write temporary file: %s", err)
+	}
+	_, err := Load(types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{
+			{
+				Filename: tmpPath,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadEmptyContent_MissingProject(t *testing.T) {
+	yaml := `
+services:
+  test:
+    image: nginx:latest`
+	tmpPath := filepath.Join(t.TempDir(), "docker-compose.yaml")
+	if err := os.WriteFile(tmpPath, []byte(yaml), 0o644); err != nil {
+		t.Fatalf("failed to write temporary file: %s", err)
+	}
+	_, err := Load(types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{
+			{
+				Filename: tmpPath,
+			},
+		},
+	})
+	assert.ErrorContains(t, err, "project name must not be empty")
 }
 
 func TestLoadUnitBytes(t *testing.T) {

--- a/loader/testdata/compose-include-cycle.yaml
+++ b/loader/testdata/compose-include-cycle.yaml
@@ -1,6 +1,7 @@
 include:
   - compose-include-cycle.yaml
 
+name: project
 services:
   foo:
     image: foo


### PR DESCRIPTION
This ensures that project name validation occurs in cases where the content is missing (e.g., when constructed via `ToConfigFiles`).

I opted to do the read during project name parsing for two reasons:

1. It addresses all cases where `Content` is not set (not just `ToConfigFiles`).
2. It does not require a (breaking?) change to the `ToConfigFiles` function.

I also had to fix a few tests that were not setting the project correctly. 

Fixes #489.