### PR TITLE
fix regression merging overrides

### DIFF
--- a/loader/override_test.go
+++ b/loader/override_test.go
@@ -1,0 +1,63 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package loader
+
+import (
+	"context"
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"gotest.tools/v3/assert"
+)
+
+func TestOverrideNetworks(t *testing.T) {
+	yaml := `
+name: test-override-networks
+services:
+  test:
+    image: test
+    networks:
+      - test_network
+
+networks:
+  test_network: {}
+`
+
+	override := `
+services:
+  test:
+    image: test
+    networks:
+      test_network: 
+        aliases:
+          - alias1
+          - alias2
+`
+	_, err := LoadWithContext(context.Background(), types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{
+			{
+				Filename: "base",
+				Content:  []byte(yaml),
+			},
+			{
+				Filename: "override",
+				Content:  []byte(override),
+			},
+		},
+	})
+	assert.NilError(t, err)
+}


### PR DESCRIPTION
`service.networks` can be defined as a sequence or mapping. Sequence syntax is equivalent to a mapping with value=null. Merge must operate on the mapping representation

includes test case

closes https://github.com/docker/compose/issues/11339