### PR TITLE
Fix regression with additional_context short syntax

### DIFF
--- a/transform/canonical.go
+++ b/transform/canonical.go
@@ -27,6 +27,7 @@ var transformers = map[tree.Path]transformFunc{}
 func init() {
 	transformers["services.*"] = transformService
 	transformers["services.*.build.secrets.*"] = transformFileMount
+	transformers["services.*.build.additional_contexts"] = transformKeyValue
 	transformers["services.*.depends_on"] = transformDependsOn
 	transformers["services.*.env_file"] = transformEnvFile
 	transformers["services.*.extends"] = transformExtends

--- a/transform/mapping.go
+++ b/transform/mapping.go
@@ -1,0 +1,43 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package transform
+
+import (
+	"strings"
+
+	"github.com/compose-spec/compose-go/v2/tree"
+	"github.com/pkg/errors"
+)
+
+func transformKeyValue(data any, p tree.Path) (any, error) {
+	switch v := data.(type) {
+	case map[string]any:
+		return v, nil
+	case []any:
+		mapping := map[string]any{}
+		for _, e := range v {
+			before, after, found := strings.Cut(e.(string), "=")
+			if !found {
+				return nil, errors.Errorf("%s: invalid value %s, expected key=value", p, e)
+			}
+			mapping[before] = after
+		}
+		return mapping, nil
+	default:
+		return nil, errors.Errorf("%s: invalid type %T", p, v)
+	}
+}


### PR DESCRIPTION
need to convert additional_context to canonical (mapping) syntax before relative paths get resolved

closes https://github.com/docker/compose/issues/11351