### PR TITLE
Fix merge between two numbers

### DIFF
--- a/override/merge.go
+++ b/override/merge.go
@@ -122,7 +122,7 @@ func convertIntoSequence(value any) []any {
 			if v == nil {
 				seq[i] = k
 			} else {
-				seq[i] = fmt.Sprintf("%s=%s", k, v)
+				seq[i] = fmt.Sprintf("%s=%v", k, v)
 			}
 			i++
 		}

--- a/override/merge_environment_test.go
+++ b/override/merge_environment_test.go
@@ -93,3 +93,22 @@ services:
       - QIX=ZOT
 `)
 }
+
+func Test_mergeYamlEnvironmentNumber(t *testing.T) {
+	assertMergeYaml(t, `
+services:
+  test:
+    environment:
+      FOO: 1
+`, `
+services:
+  test:
+    environment:
+      FOO: 3
+`, `
+services:
+  test:
+    environment:
+      - FOO=3
+`)
+}


### PR DESCRIPTION
when converting to environment string we were assuming it was always a string.

Fixes: https://github.com/docker/compose/issues/11353