### PR TITLE
Fix ulimit parsing

### DIFF
--- a/loader/extends_test.go
+++ b/loader/extends_test.go
@@ -90,3 +90,28 @@ services:
 	assert.NilError(t, err)
 	assert.Equal(t, p.Services["test"].Ports[0].Target, uint32(8000))
 }
+
+func TestExtendsUlimits(t *testing.T) {
+	yaml := `
+name: test-extends
+services:
+  test:
+    extends:
+      file: testdata/extends/base.yaml
+      service: withUlimits
+`
+	abs, err := filepath.Abs(".")
+	assert.NilError(t, err)
+
+	p, err := LoadWithContext(context.Background(), types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{
+			{
+				Content:  []byte(yaml),
+				Filename: "(inline)",
+			},
+		},
+		WorkingDir: abs,
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, p.Services["test"].Ulimits["nproc"].Single, 65535)
+}

--- a/loader/testdata/extends/base.yaml
+++ b/loader/testdata/extends/base.yaml
@@ -8,3 +8,12 @@ services:
   with-port:
     ports:
       - 8000:8000
+
+  withUlimits:
+    image: test
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000
+      

--- a/transform/ulimits.go
+++ b/transform/ulimits.go
@@ -26,9 +26,7 @@ func transformUlimits(data any, p tree.Path) (any, error) {
 	case map[string]any:
 		return v, nil
 	case int:
-		return map[string]any{
-			"single": v,
-		}, nil
+		return v, nil
 	default:
 		return data, errors.Errorf("%s: invalid type %T for external", p, v)
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -603,6 +603,31 @@ type UlimitsConfig struct {
 	Extensions Extensions `yaml:"#extensions,inline,omitempty" json:"-"`
 }
 
+func (u *UlimitsConfig) DecodeMapstructure(value interface{}) error {
+	switch v := value.(type) {
+	case *UlimitsConfig:
+		// this call to DecodeMapstructure is triggered after initial value conversion as we use a map[string]*UlimitsConfig
+		return nil
+	case int:
+		u.Single = v
+		u.Soft = 0
+		u.Hard = 0
+	case map[string]any:
+		u.Single = 0
+		soft, ok := v["soft"]
+		if ok {
+			u.Soft = soft.(int)
+		}
+		hard, ok := v["hard"]
+		if ok {
+			u.Hard = hard.(int)
+		}
+	default:
+		return fmt.Errorf("unexpected value type %T for ulimit", value)
+	}
+	return nil
+}
+
 // MarshalYAML makes UlimitsConfig implement yaml.Marshaller
 func (u *UlimitsConfig) MarshalYAML() (interface{}, error) {
 	if u.Single != 0 {


### PR DESCRIPTION
canonical transformation must keep `ulimit` as an int or struct to match json schema (validated after a merge)
converting `int` to internal `single` field must take place during the decode phase, as this is specific to go-structs design


fixes https://github.com/docker/compose/issues/11353#issuecomment-1899835614