### PR TITLE
label can be set with empty value

### DIFF
--- a/types/labels.go
+++ b/types/labels.go
@@ -66,10 +66,7 @@ func (l *Labels) DecodeMapstructure(value interface{}) error {
 	case []interface{}:
 		labels := make(map[string]string, len(v))
 		for _, s := range v {
-			k, e, ok := strings.Cut(fmt.Sprint(s), "=")
-			if !ok {
-				return fmt.Errorf("invalid label %q", v)
-			}
+			k, e, _ := strings.Cut(fmt.Sprint(s), "=")
 			labels[k] = labelValue(e)
 		}
 		*l = labels

--- a/types/labels_test.go
+++ b/types/labels_test.go
@@ -1,0 +1,34 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestDecodeLabel(t *testing.T) {
+	l := Labels{}
+	err := l.DecodeMapstructure([]any{
+		"a=b",
+		"c",
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, l["a"], "b")
+	assert.Equal(t, l["c"], "")
+}


### PR DESCRIPTION
credit to ndeloof
previously fixed in PR #475 but it seems the respective branch is gone

Fixes https://github.com/compose-spec/compose-go/issues/534
and https://github.com/docker/compose/issues/11133