### PR TITLE
don't assume attribute type to prevent int vs uint32 type mismatch

### DIFF
--- a/loader/extends_test.go
+++ b/loader/extends_test.go
@@ -64,3 +64,29 @@ services:
 	assert.Equal(t, p.Services["test2"].Hostname, "test2")
 	assert.Equal(t, p.Services["test3"].Hostname, "test3")
 }
+
+func TestExtendsPort(t *testing.T) {
+	yaml := `
+name: test-extends-port
+services:
+  test:
+    image: test
+    extends: 
+      file: testdata/extends/base.yaml
+      service: with-port
+`
+	abs, err := filepath.Abs(".")
+	assert.NilError(t, err)
+
+	p, err := LoadWithContext(context.Background(), types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{
+			{
+				Content:  []byte(yaml),
+				Filename: "(inline)",
+			},
+		},
+		WorkingDir: abs,
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, p.Services["test"].Ports[0].Target, uint32(8000))
+}

--- a/loader/testdata/extends/base.yaml
+++ b/loader/testdata/extends/base.yaml
@@ -5,3 +5,6 @@ services:
   another:
     extends: base
 
+  with-port:
+    ports:
+      - 8000:8000

--- a/override/uncity.go
+++ b/override/uncity.go
@@ -143,22 +143,22 @@ func portIndexer(y any, p tree.Path) (string, error) {
 	case int:
 		return strconv.Itoa(value), nil
 	case map[string]any:
-		target, ok := value["target"].(int)
+		target, ok := value["target"]
 		if !ok {
 			return "", fmt.Errorf("service ports %s is missing a target port", p)
 		}
-		published, ok := value["published"].(string)
+		published, ok := value["published"]
 		if !ok {
 			// try to parse it as an int
-			if pub, ok := value["published"].(int); ok {
+			if pub, ok := value["published"]; ok {
 				published = fmt.Sprintf("%d", pub)
 			}
 		}
-		host, ok := value["host_ip"].(string)
+		host, ok := value["host_ip"]
 		if !ok {
 			host = "0.0.0.0"
 		}
-		protocol, ok := value["protocol"].(string)
+		protocol, ok := value["protocol"]
 		if !ok {
 			protocol = "tcp"
 		}


### PR DESCRIPTION
when parsed from a "short syntax" string, target port is modeled as a `uint32` while it would be a plain `int` if defined with long yaml syntax.
By not using type cast, we can be more flexible with actual type being used to produce the port index string.

closes https://github.com/docker/compose/issues/11378