### PR TITLE
always resolve paths relative to extending file's working dir

### DIFF
--- a/loader/extends_test.go
+++ b/loader/extends_test.go
@@ -115,3 +115,30 @@ services:
 	assert.NilError(t, err)
 	assert.Equal(t, p.Services["test"].Ulimits["nproc"].Single, 65535)
 }
+
+func TestExtendsRelativePath(t *testing.T) {
+	yaml := `
+name: test-extends-port
+services:
+  test:
+    extends: 
+      file: testdata/extends/base.yaml
+      service: with-build
+`
+	abs, err := filepath.Abs(".")
+	assert.NilError(t, err)
+
+	p, err := LoadWithContext(context.Background(), types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{
+			{
+				Content:  []byte(yaml),
+				Filename: "(inline)",
+			},
+		},
+		WorkingDir: abs,
+	}, func(options *Options) {
+		options.ResolvePaths = false
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, p.Services["test"].Build.Context, filepath.Join("testdata", "extends"))
+}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2636,13 +2636,21 @@ func (c customLoader) Accept(s string) bool {
 	return strings.HasPrefix(s, c.prefix+":")
 }
 
+func (c customLoader) path(s string) string {
+	return filepath.Join("testdata", c.prefix, s[len(c.prefix)+1:])
+}
+
 func (c customLoader) Load(_ context.Context, s string) (string, error) {
-	path := filepath.Join("testdata", c.prefix, s[len(c.prefix)+1:])
+	path := c.path(s)
 	_, err := os.Stat(path)
 	if err != nil {
 		return "", err
 	}
 	return filepath.Abs(path)
+}
+
+func (c customLoader) Dir(s string) string {
+	return filepath.Dir(c.path(s))
 }
 
 func TestLoadWithRemoteResources(t *testing.T) {

--- a/loader/testdata/extends/base.yaml
+++ b/loader/testdata/extends/base.yaml
@@ -16,4 +16,9 @@ services:
       nofile:
         soft: 20000
         hard: 40000
-      
+
+  with-build:
+    extends:
+      file: sibling.yaml
+      service: test
+

--- a/loader/testdata/extends/sibling.yaml
+++ b/loader/testdata/extends/sibling.yaml
@@ -1,0 +1,3 @@
+services:
+  test:
+    build: .


### PR DESCRIPTION
closes https://github.com/docker/compose/issues/11377
closes https://github.com/docker/compose/issues/11379

note: custom resource loaders defined by docker/compose will have to implement `Dir(path string)` returning (absolute) path for file within the remote download cache