### PR TITLE
use standard errors package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,18 +1,20 @@
-run:
-  deadline: 2m
-
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 linters:
   disable-all: true
   enable:
+  - errorlint
   - gocritic
   - gofmt
   - goimports
-  - revive
+  - gomodguard
   - gosimple
+  - govet
   - ineffassign
   - misspell
   - nakedret
-  - govet
+  - revive
 linters-settings:
   gocritic:
     # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint run` to see all tags and checks.
@@ -25,3 +27,12 @@ linters-settings:
       - paramTypeCombine
       - unnamedResult
       - whyNoLint
+  gomodguard:
+    blocked:
+      modules:
+      - github.com/pkg/errors:
+          recommendations:
+          - errors
+          - fmt
+run:
+  timeout: 2m

--- a/cli/options.go
+++ b/cli/options.go
@@ -18,13 +18,13 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/compose-spec/compose-go/v2/consts"
@@ -472,7 +472,7 @@ func getConfigPathsFromOptions(options *ProjectOptions) ([]string, error) {
 	if len(options.ConfigPaths) != 0 {
 		return absolutePaths(options.ConfigPaths)
 	}
-	return nil, errors.Wrap(errdefs.ErrNotFound, "no configuration file provided")
+	return nil, fmt.Errorf("no configuration file provided: %w", errdefs.ErrNotFound)
 }
 
 func findFiles(names []string, pwd string) []string {

--- a/dotenv/env.go
+++ b/dotenv/env.go
@@ -18,10 +18,9 @@ package dotenv
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 )
 
 func GetEnvFromFile(currentEnv map[string]string, filenames []string) (map[string]string, error) {
@@ -36,7 +35,7 @@ func GetEnvFromFile(currentEnv map[string]string, filenames []string) (map[strin
 
 		s, err := os.Stat(dotEnvFile)
 		if os.IsNotExist(err) {
-			return envMap, errors.Errorf("Couldn't find env file: %s", dotEnvFile)
+			return envMap, fmt.Errorf("Couldn't find env file: %s", dotEnvFile)
 		}
 		if err != nil {
 			return envMap, err
@@ -46,12 +45,12 @@ func GetEnvFromFile(currentEnv map[string]string, filenames []string) (map[strin
 			if len(filenames) == 0 {
 				return envMap, nil
 			}
-			return envMap, errors.Errorf("%s is a directory", dotEnvFile)
+			return envMap, fmt.Errorf("%s is a directory", dotEnvFile)
 		}
 
 		b, err := os.ReadFile(dotEnvFile)
 		if os.IsNotExist(err) {
-			return nil, errors.Errorf("Couldn't read env file: %s", dotEnvFile)
+			return nil, fmt.Errorf("Couldn't read env file: %s", dotEnvFile)
 		}
 		if err != nil {
 			return envMap, err
@@ -66,7 +65,7 @@ func GetEnvFromFile(currentEnv map[string]string, filenames []string) (map[strin
 			return v, ok
 		})
 		if err != nil {
-			return envMap, errors.Wrapf(err, "failed to read %s", dotEnvFile)
+			return envMap, fmt.Errorf("failed to read %s: %w", dotEnvFile, err)
 		}
 		for k, v := range env {
 			envMap[k] = v

--- a/dotenv/godotenv_test.go
+++ b/dotenv/godotenv_test.go
@@ -2,6 +2,7 @@ package dotenv
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,7 +49,8 @@ func loadEnvAndCompareValues(t *testing.T, loader func(files ...string) error, e
 
 func TestLoadWithNoArgsLoadsDotEnv(t *testing.T) {
 	err := Load()
-	pathError := err.(*os.PathError)
+	var pathError *os.PathError
+	errors.As(err, &pathError)
 	if pathError == nil || pathError.Op != "open" || pathError.Path != ".env" {
 		t.Errorf("Didn't try and open .env by default")
 	}

--- a/format/volume.go
+++ b/format/volume.go
@@ -17,12 +17,13 @@
 package format
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"unicode"
 	"unicode/utf8"
 
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/pkg/errors"
 )
 
 const endOfSpec = rune(0)
@@ -48,7 +49,7 @@ func ParseVolume(spec string) (types.ServiceVolumeConfig, error) {
 		case char == ':' || char == endOfSpec:
 			if err := populateFieldFromBuffer(char, buffer, &volume); err != nil {
 				populateType(&volume)
-				return volume, errors.Wrapf(err, "invalid spec: %s", spec)
+				return volume, fmt.Errorf("invalid spec: %s: %w", spec, err)
 			}
 			buffer = nil
 		default:

--- a/loader/include.go
+++ b/loader/include.go
@@ -27,7 +27,6 @@ import (
 	"github.com/compose-spec/compose-go/v2/dotenv"
 	interp "github.com/compose-spec/compose-go/v2/interpolation"
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/pkg/errors"
 )
 
 // loadIncludeConfig parse the require config from raw yaml
@@ -64,7 +63,7 @@ func ApplyInclude(ctx context.Context, configDetails types.ConfigDetails, model 
 		for _, f := range included {
 			if f == mainFile {
 				included = append(included, mainFile)
-				return errors.Errorf("include cycle detected:\n%s\n include %s", included[0], strings.Join(included[1:], "\n include "))
+				return fmt.Errorf("include cycle detected:\n%s\n include %s", included[0], strings.Join(included[1:], "\n include "))
 			}
 		}
 

--- a/loader/interpolate.go
+++ b/loader/interpolate.go
@@ -17,12 +17,12 @@
 package loader
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
 	interp "github.com/compose-spec/compose-go/v2/interpolation"
 	"github.com/compose-spec/compose-go/v2/tree"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -112,6 +112,6 @@ func toBoolean(value string) (interface{}, error) {
 		logrus.Warnf("%q for boolean is not supported by YAML 1.2, please use `false`", value)
 		return false, nil
 	default:
-		return nil, errors.Errorf("invalid boolean: %s", value)
+		return nil, fmt.Errorf("invalid boolean: %s", value)
 	}
 }

--- a/loader/normalize.go
+++ b/loader/normalize.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/errdefs"
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -246,7 +245,7 @@ func relocateLogOpt(s *types.ServiceConfig) error {
 			if _, ok := s.Logging.Options[k]; !ok {
 				s.Logging.Options[k] = v
 			} else {
-				return errors.Wrap(errdefs.ErrInvalid, "can't use both 'log_opt' (deprecated) and 'logging.options'")
+				return fmt.Errorf("can't use both 'log_opt' (deprecated) and 'logging.options': %w", errdefs.ErrInvalid)
 			}
 		}
 	}
@@ -262,7 +261,7 @@ func relocateLogDriver(s *types.ServiceConfig) error {
 		if s.Logging.Driver == "" {
 			s.Logging.Driver = s.LogDriver
 		} else {
-			return errors.Wrap(errdefs.ErrInvalid, "can't use both 'log_driver' (deprecated) and 'logging.driver'")
+			return fmt.Errorf("can't use both 'log_driver' (deprecated) and 'logging.driver': %w", errdefs.ErrInvalid)
 		}
 	}
 	return nil
@@ -277,7 +276,7 @@ func relocateDockerfile(s *types.ServiceConfig) error {
 		if s.Dockerfile == "" {
 			s.Build.Dockerfile = s.Dockerfile
 		} else {
-			return errors.Wrap(errdefs.ErrInvalid, "can't use both 'dockerfile' (deprecated) and 'build.dockerfile'")
+			return fmt.Errorf("can't use both 'dockerfile' (deprecated) and 'build.dockerfile': %w", errdefs.ErrInvalid)
 		}
 	}
 	return nil

--- a/paths/resolve.go
+++ b/paths/resolve.go
@@ -17,12 +17,12 @@
 package paths
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 
 	"github.com/compose-spec/compose-go/v2/tree"
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/pkg/errors"
 )
 
 type resolver func(any) (any, error)

--- a/transform/build.go
+++ b/transform/build.go
@@ -17,8 +17,9 @@
 package transform
 
 import (
+	"fmt"
+
 	"github.com/compose-spec/compose-go/v2/tree"
-	"github.com/pkg/errors"
 )
 
 func transformBuild(data any, p tree.Path) (any, error) {
@@ -33,6 +34,6 @@ func transformBuild(data any, p tree.Path) (any, error) {
 			"context": v,
 		}, nil
 	default:
-		return data, errors.Errorf("%s: invalid type %T for build", p, v)
+		return data, fmt.Errorf("%s: invalid type %T for build", p, v)
 	}
 }

--- a/transform/dependson.go
+++ b/transform/dependson.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/compose-spec/compose-go/v2/tree"
-	"github.com/pkg/errors"
 )
 
 func transformDependsOn(data any, p tree.Path) (any, error) {
@@ -49,6 +48,6 @@ func transformDependsOn(data any, p tree.Path) (any, error) {
 		}
 		return d, nil
 	default:
-		return data, errors.Errorf("%s: invalid type %T for depend_on", p, v)
+		return data, fmt.Errorf("%s: invalid type %T for depend_on", p, v)
 	}
 }

--- a/transform/envfile.go
+++ b/transform/envfile.go
@@ -17,8 +17,9 @@
 package transform
 
 import (
+	"fmt"
+
 	"github.com/compose-spec/compose-go/v2/tree"
-	"github.com/pkg/errors"
 )
 
 func transformEnvFile(data any, p tree.Path) (any, error) {
@@ -33,7 +34,7 @@ func transformEnvFile(data any, p tree.Path) (any, error) {
 		}
 		return v, nil
 	default:
-		return nil, errors.Errorf("%s: invalid type %T for env_file", p, v)
+		return nil, fmt.Errorf("%s: invalid type %T for env_file", p, v)
 	}
 }
 

--- a/transform/extends.go
+++ b/transform/extends.go
@@ -17,8 +17,9 @@
 package transform
 
 import (
+	"fmt"
+
 	"github.com/compose-spec/compose-go/v2/tree"
-	"github.com/pkg/errors"
 )
 
 func transformExtends(data any, p tree.Path) (any, error) {
@@ -30,6 +31,6 @@ func transformExtends(data any, p tree.Path) (any, error) {
 			"service": v,
 		}, nil
 	default:
-		return data, errors.Errorf("%s: invalid type %T for extends", p, v)
+		return data, fmt.Errorf("%s: invalid type %T for extends", p, v)
 	}
 }

--- a/transform/include.go
+++ b/transform/include.go
@@ -17,8 +17,9 @@
 package transform
 
 import (
+	"fmt"
+
 	"github.com/compose-spec/compose-go/v2/tree"
-	"github.com/pkg/errors"
 )
 
 func transformInclude(data any, p tree.Path) (any, error) {
@@ -30,6 +31,6 @@ func transformInclude(data any, p tree.Path) (any, error) {
 			"path": v,
 		}, nil
 	default:
-		return data, errors.Errorf("%s: invalid type %T for external", p, v)
+		return data, fmt.Errorf("%s: invalid type %T for external", p, v)
 	}
 }

--- a/transform/mapping.go
+++ b/transform/mapping.go
@@ -17,10 +17,10 @@
 package transform
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/tree"
-	"github.com/pkg/errors"
 )
 
 func transformKeyValue(data any, p tree.Path) (any, error) {
@@ -32,12 +32,12 @@ func transformKeyValue(data any, p tree.Path) (any, error) {
 		for _, e := range v {
 			before, after, found := strings.Cut(e.(string), "=")
 			if !found {
-				return nil, errors.Errorf("%s: invalid value %s, expected key=value", p, e)
+				return nil, fmt.Errorf("%s: invalid value %s, expected key=value", p, e)
 			}
 			mapping[before] = after
 		}
 		return mapping, nil
 	default:
-		return nil, errors.Errorf("%s: invalid type %T", p, v)
+		return nil, fmt.Errorf("%s: invalid type %T", p, v)
 	}
 }

--- a/transform/ports.go
+++ b/transform/ports.go
@@ -22,7 +22,6 @@ import (
 	"github.com/compose-spec/compose-go/v2/tree"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 )
 
 func transformPorts(data any, p tree.Path) (any, error) {
@@ -64,12 +63,12 @@ func transformPorts(data any, p tree.Path) (any, error) {
 			case map[string]any:
 				ports = append(ports, value)
 			default:
-				return data, errors.Errorf("%s: invalid type %T for port", p, value)
+				return data, fmt.Errorf("%s: invalid type %T for port", p, value)
 			}
 		}
 		return ports, nil
 	default:
-		return data, errors.Errorf("%s: invalid type %T for port", p, entries)
+		return data, fmt.Errorf("%s: invalid type %T for port", p, entries)
 	}
 }
 

--- a/transform/ssh.go
+++ b/transform/ssh.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/tree"
-	"github.com/pkg/errors"
 )
 
 func transformSSH(data any, p tree.Path) (any, error) {
@@ -47,6 +46,6 @@ func transformSSH(data any, p tree.Path) (any, error) {
 		}
 		return result, nil
 	default:
-		return data, errors.Errorf("%s: invalid type %T for ssh", p, v)
+		return data, fmt.Errorf("%s: invalid type %T for ssh", p, v)
 	}
 }

--- a/transform/ulimits.go
+++ b/transform/ulimits.go
@@ -17,8 +17,9 @@
 package transform
 
 import (
+	"fmt"
+
 	"github.com/compose-spec/compose-go/v2/tree"
-	"github.com/pkg/errors"
 )
 
 func transformUlimits(data any, p tree.Path) (any, error) {
@@ -28,6 +29,6 @@ func transformUlimits(data any, p tree.Path) (any, error) {
 	case int:
 		return v, nil
 	default:
-		return data, errors.Errorf("%s: invalid type %T for external", p, v)
+		return data, fmt.Errorf("%s: invalid type %T for external", p, v)
 	}
 }

--- a/transform/volume.go
+++ b/transform/volume.go
@@ -17,11 +17,11 @@
 package transform
 
 import (
+	"fmt"
 	"path"
 
 	"github.com/compose-spec/compose-go/v2/format"
 	"github.com/compose-spec/compose-go/v2/tree"
-	"github.com/pkg/errors"
 )
 
 func transformVolumeMount(data any, p tree.Path) (any, error) {
@@ -37,7 +37,7 @@ func transformVolumeMount(data any, p tree.Path) (any, error) {
 
 		return encode(volume)
 	default:
-		return data, errors.Errorf("%s: invalid type %T for service volume mount", p, v)
+		return data, fmt.Errorf("%s: invalid type %T for service volume mount", p, v)
 	}
 }
 

--- a/types/device.go
+++ b/types/device.go
@@ -17,10 +17,9 @@
 package types
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 type DeviceRequest struct {
@@ -43,11 +42,11 @@ func (c *DeviceCount) DecodeMapstructure(value interface{}) error {
 		}
 		i, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
-			return errors.Errorf("invalid value %q, the only value allowed is 'all' or a number", v)
+			return fmt.Errorf("invalid value %q, the only value allowed is 'all' or a number", v)
 		}
 		*c = DeviceCount(i)
 	default:
-		return errors.Errorf("invalid type %T for device count", v)
+		return fmt.Errorf("invalid type %T for device count", v)
 	}
 	return nil
 }

--- a/types/options.go
+++ b/types/options.go
@@ -16,11 +16,7 @@
 
 package types
 
-import (
-	"fmt"
-
-	"github.com/pkg/errors"
-)
+import "fmt"
 
 // Options is a mapping type for options we pass as-is to container runtime
 type Options map[string]string
@@ -40,7 +36,7 @@ func (d *Options) DecodeMapstructure(value interface{}) error {
 	case map[string]string:
 		*d = v
 	default:
-		return errors.Errorf("invalid type %T for options", value)
+		return fmt.Errorf("invalid type %T for options", value)
 	}
 	return nil
 }

--- a/types/project.go
+++ b/types/project.go
@@ -29,7 +29,6 @@ import (
 	"github.com/distribution/reference"
 	"github.com/mitchellh/copystructure"
 	godigest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v3"
 )
@@ -582,18 +581,18 @@ func (p Project) WithServicesEnvironmentResolved(discardEnvFiles bool) (*Project
 		for _, envFile := range service.EnvFiles {
 			if _, err := os.Stat(envFile.Path); os.IsNotExist(err) {
 				if envFile.Required {
-					return nil, errors.Wrapf(err, "env file %s not found", envFile.Path)
+					return nil, fmt.Errorf("env file %s not found: %w", envFile.Path, err)
 				}
 				continue
 			}
 			b, err := os.ReadFile(envFile.Path)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to load %s", envFile.Path)
+				return nil, fmt.Errorf("failed to load %s: %w", envFile.Path, err)
 			}
 
 			fileVars, err := dotenv.ParseWithLookup(bytes.NewBuffer(b), resolve)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to read %s", envFile.Path)
+				return nil, fmt.Errorf("failed to read %s: %w", envFile.Path, err)
 			}
 			environment.OverrideBy(Mapping(fileVars).ToMappingWithEquals())
 		}

--- a/types/stringOrList.go
+++ b/types/stringOrList.go
@@ -16,11 +16,7 @@
 
 package types
 
-import (
-	"fmt"
-
-	"github.com/pkg/errors"
-)
+import "fmt"
 
 // StringList is a type for fields that can be a string or list of strings
 type StringList []string
@@ -36,7 +32,7 @@ func (l *StringList) DecodeMapstructure(value interface{}) error {
 		}
 		*l = list
 	default:
-		return errors.Errorf("invalid type %T for string list", value)
+		return fmt.Errorf("invalid type %T for string list", value)
 	}
 	return nil
 }
@@ -55,7 +51,7 @@ func (l *StringOrNumberList) DecodeMapstructure(value interface{}) error {
 		}
 		*l = list
 	default:
-		return errors.Errorf("invalid type %T for string list", value)
+		return fmt.Errorf("invalid type %T for string list", value)
 	}
 	return nil
 }

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/tree"
-	"github.com/pkg/errors"
 )
 
 type checkerFunc func(value any, p tree.Path) error
@@ -91,7 +90,7 @@ func checkFileObject(keys ...string) checkerFunc {
 func checkPath(value any, p tree.Path) error {
 	v := value.(string)
 	if v == "" {
-		return errors.Errorf("%s: value can't be blank", p)
+		return fmt.Errorf("%s: value can't be blank", p)
 	}
 	return nil
 }


### PR DESCRIPTION
`github.com/pkg/errors` is not maintained anymore.
This is replacing the library with the standard errors 

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>