### PR TITLE
add go binding for storage_opt

### DIFF
--- a/loader/full-example.yml
+++ b/loader/full-example.yml
@@ -273,7 +273,8 @@ services:
     stop_grace_period: 20s
 
     stop_signal: SIGUSR1
-
+    storage_opt:
+      size: "20G"
     sysctls:
       net.core.somaxconn: 1024
       net.ipv4.tcp_syncookies: 0

--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -411,6 +411,7 @@ func services(workingDir, homeDir string) types.Services {
 			},
 			StdinOpen:       true,
 			StopSignal:      "SIGUSR1",
+			StorageOpt:      map[string]string{"size": "20G"},
 			StopGracePeriod: durationPtr(20 * time.Second),
 			Sysctls: map[string]string{
 				"net.core.somaxconn":      "1024",
@@ -895,6 +896,8 @@ services:
     stdin_open: true
     stop_grace_period: 20s
     stop_signal: SIGUSR1
+    storage_opt:
+      size: 20G
     sysctls:
       net.core.somaxconn: "1024"
       net.ipv4.tcp_syncookies: "0"
@@ -1558,6 +1561,9 @@ func fullExampleJSON(workingDir, homeDir string) string {
       "stdin_open": true,
       "stop_grace_period": "20s",
       "stop_signal": "SIGUSR1",
+      "storage_opt": {
+        "size": "20G"
+      },
       "sysctls": {
         "net.core.somaxconn": "1024",
         "net.ipv4.tcp_syncookies": "0"

--- a/types/types.go
+++ b/types/types.go
@@ -120,6 +120,7 @@ type ServiceConfig struct {
 	StdinOpen       bool                             `yaml:"stdin_open,omitempty" json:"stdin_open,omitempty"`
 	StopGracePeriod *Duration                        `yaml:"stop_grace_period,omitempty" json:"stop_grace_period,omitempty"`
 	StopSignal      string                           `yaml:"stop_signal,omitempty" json:"stop_signal,omitempty"`
+	StorageOpt      map[string]string                `yaml:"storage_opt,omitempty" json:"storage_opt,omitempty"`
 	Sysctls         Mapping                          `yaml:"sysctls,omitempty" json:"sysctls,omitempty"`
 	Tmpfs           StringList                       `yaml:"tmpfs,omitempty" json:"tmpfs,omitempty"`
 	Tty             bool                             `yaml:"tty,omitempty" json:"tty,omitempty"`


### PR DESCRIPTION
`storage_opt` is already defined by compose-spec schema but we didn't had binding set in go structs for it

see https://github.com/docker/compose/issues/11395