### PR TITLE
process `extends` recursively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@
 IMAGE_PREFIX=composespec/conformance-tests-
 
 .PHONY: build
-build: ## Run tests
-	go build ./...
+build: ## Build command line
+	go build -o compose-spec cmd/main.go
 
 .PHONY: test
 test: ## Run tests

--- a/loader/extends.go
+++ b/loader/extends.go
@@ -48,6 +48,9 @@ func ApplyExtends(ctx context.Context, dict map[string]any, opts *Options, track
 
 func applyServiceExtends(ctx context.Context, name string, services map[string]any, opts *Options, tracker *cycleTracker, post ...PostProcessor) (any, error) {
 	s := services[name]
+	if s == nil {
+		return nil, nil
+	}
 	service, ok := s.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("services.%s must be a mapping", name)
@@ -92,6 +95,9 @@ func applyServiceExtends(ctx context.Context, name string, services map[string]a
 		return nil, err
 	}
 
+	if base == nil {
+		return service, nil
+	}
 	source := deepClone(base).(map[string]any)
 	for _, processor := range post {
 		processor.Apply(map[string]any{

--- a/loader/extends_test.go
+++ b/loader/extends_test.go
@@ -142,3 +142,31 @@ services:
 	assert.NilError(t, err)
 	assert.Equal(t, p.Services["test"].Build.Context, filepath.Join("testdata", "extends"))
 }
+
+func TestExtendsNil(t *testing.T) {
+	yaml := `
+name: test-extends-port
+services:
+  test:
+    image: test
+    extends:
+      file: testdata/extends/base.yaml
+      service: nil
+`
+	abs, err := filepath.Abs(".")
+	assert.NilError(t, err)
+
+	_, err = LoadWithContext(context.Background(), types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{
+			{
+				Content:  []byte(yaml),
+				Filename: "(inline)",
+			},
+		},
+		WorkingDir: abs,
+	}, func(options *Options) {
+		options.ResolvePaths = false
+		options.SkipValidation = true
+	})
+	assert.NilError(t, err)
+}

--- a/loader/testdata/extends/base.yaml
+++ b/loader/testdata/extends/base.yaml
@@ -22,3 +22,4 @@ services:
       file: sibling.yaml
       service: test
 
+  nil: #left intentionally empty

--- a/paths/extends.go
+++ b/paths/extends.go
@@ -1,0 +1,25 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package paths
+
+func (r *relativePathsResolver) absExtendsPath(value any) (any, error) {
+	v := value.(string)
+	if r.isRemoteResource(v) {
+		return v, nil
+	}
+	return r.absPath(v)
+}

--- a/transform/services.go
+++ b/transform/services.go
@@ -21,8 +21,12 @@ import (
 )
 
 func transformService(data any, p tree.Path) (any, error) {
-	value := data.(map[string]any)
-	return transformMapping(value, p)
+	switch value := data.(type) {
+	case map[string]any:
+		return transformMapping(value, p)
+	default:
+		return value, nil
+	}
 }
 
 func transformServiceNetworks(data any, _ tree.Path) (any, error) {


### PR DESCRIPTION
fixes https://github.com/docker/compose/issues/11394

issue takes place when there's a chain of extending services:
```yaml
services:
  level1:
    build:
      context: ..

  level2:
    extends: level1

  service:
    extends: level2
    build:
      target: target
```

The root cause for this issue is that we try to extends a service before the compose model has been fully resolved. Typically loading this illustration example, if first service (which go map iteration makes random) to be processed is `service`, it will merge with sibling `level2`. This results in a `build` mapping defined without a `context`, and will default to `.`. But if `level2` is loaded first, it will have `build.context` set to `..`, and then `service` will do as well.

This PR changes the logic so that we force `extends` to be applied recursively on services using new func `applyServiceExtends`. This one will process a service to apply `extends` if needed (otherwise is no-op). Once it has identified the base service used by extends, it executes recursively to enforce this one to be fully defined