### PR TITLE
!override can be used to replace value

### DIFF
--- a/loader/reset.go
+++ b/loader/reset.go
@@ -44,6 +44,10 @@ func (p *ResetProcessor) resolveReset(node *yaml.Node, path tree.Path) (*yaml.No
 		p.paths = append(p.paths, path)
 		return nil, nil
 	}
+	if node.Tag == "!override" {
+		p.paths = append(p.paths, path)
+		return node, nil
+	}
 	switch node.Kind {
 	case yaml.SequenceNode:
 		var nodes []*yaml.Node

--- a/loader/reset_test.go
+++ b/loader/reset_test.go
@@ -1,0 +1,83 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package loader
+
+import (
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"gotest.tools/v3/assert"
+)
+
+func TestResetRemove(t *testing.T) {
+	p, err := Load(types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{
+			{
+				Filename: "(inline)",
+				Content: []byte(`
+name: test-reset
+networks:
+  test:
+    name: test
+    external: true
+`),
+			},
+			{
+				Filename: "(override)",
+				Content: []byte(`
+networks:
+  test: !reset {}
+`),
+			},
+		},
+	}, func(options *Options) {
+		options.SkipNormalization = true
+		options.SkipConsistencyCheck = true
+	})
+	assert.NilError(t, err)
+	_, ok := p.Networks["test"]
+	assert.Check(t, !ok)
+}
+
+func TestOverrideReplace(t *testing.T) {
+	p, err := Load(types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{
+			{
+				Filename: "(inline)",
+				Content: []byte(`
+name: test-override
+networks:
+  test:
+    name: test
+    external: true
+`),
+			},
+			{
+				Filename: "(override)",
+				Content: []byte(`
+networks:
+  test: !override {}
+`),
+			},
+		},
+	}, func(options *Options) {
+		options.SkipNormalization = true
+		options.SkipConsistencyCheck = true
+	})
+	assert.NilError(t, err)
+	assert.Check(t, p.Networks["test"].External == false)
+}

--- a/override/merge.go
+++ b/override/merge.go
@@ -62,6 +62,9 @@ func mergeYaml(e any, o any, p tree.Path) (any, error) {
 			return merged, nil
 		}
 	}
+	if o == nil {
+		return e, nil
+	}
 	switch value := e.(type) {
 	case map[string]any:
 		other, ok := o.(map[string]any)


### PR DESCRIPTION
Introduce `!override` so one can replace any entry in compose.override.yaml, while `!reset` would remove but not allow to re-define
i.e:
- `foo: !reset null` removes `foo` attribute from merged yaml (value is ignored)
- `foo: !override hello` overrides any previous `foo` attribute value with new value `"hello"`

**TODO**: document this on the compose spec


fixes https://github.com/docker/compose/issues/11408