### PR TITLE
Fix relative path resolution when combining include+extends

### DIFF
--- a/loader/extends_test.go
+++ b/loader/extends_test.go
@@ -173,6 +173,31 @@ services:
 	assert.NilError(t, err)
 }
 
+func TestIncludeWithExtends(t *testing.T) {
+	yaml := `
+name: test-include-with-extends
+include: 
+  - testdata/extends/nested.yaml
+`
+	abs, err := filepath.Abs(".")
+	assert.NilError(t, err)
+
+	p, err := LoadWithContext(context.Background(), types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{
+			{
+				Content:  []byte(yaml),
+				Filename: "(inline)",
+			},
+		},
+		WorkingDir: abs,
+	}, func(options *Options) {
+		options.ResolvePaths = false
+		options.SkipValidation = true
+	})
+	assert.NilError(t, err)
+	assert.Check(t, p.Services["with-build"].Build != nil)
+}
+
 func TestExtendsPortOverride(t *testing.T) {
 	yaml := `
 name: test-extends-port

--- a/loader/include.go
+++ b/loader/include.go
@@ -83,6 +83,9 @@ func ApplyInclude(ctx context.Context, configDetails types.ConfigDetails, model 
 		loadOptions.ResolvePaths = true
 		loadOptions.SkipNormalization = true
 		loadOptions.SkipConsistencyCheck = true
+		loadOptions.ResourceLoaders = append(loadOptions.RemoteResourceLoaders(), localResourceLoader{
+			WorkingDir: r.ProjectDirectory,
+		})
 
 		if len(r.EnvFile) == 0 {
 			f := filepath.Join(r.ProjectDirectory, ".env")

--- a/loader/testdata/extends/nested.yaml
+++ b/loader/testdata/extends/nested.yaml
@@ -1,0 +1,5 @@
+services:
+  with-build:
+    extends:
+      file: sibling.yaml
+      service: test


### PR DESCRIPTION
relative references resolved by localResourceLoader must be relative to include's project directory, not caller project directory

fixes https://github.com/docker/compose/issues/11412
fixes https://github.com/docker/compose/issues/11444