### PR TITLE
Support urls as config files

### DIFF
--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -18,6 +18,10 @@ package cli
 
 import (
 	"fmt"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -213,7 +217,7 @@ func TestProjectFromSetOfFiles(t *testing.T) {
 	assert.Equal(t, service.Image, "haproxy")
 }
 
-func TestProjectComposefilesFromSetOfFiles(t *testing.T) {
+func TestProjectComposeFilesFromSetOfFiles(t *testing.T) {
 	opts, err := NewProjectOptions([]string{},
 		WithWorkingDirectory("testdata/simple/"),
 		WithName("my_project"),
@@ -226,7 +230,7 @@ func TestProjectComposefilesFromSetOfFiles(t *testing.T) {
 	assert.DeepEqual(t, p.ComposeFiles, []string{absPath})
 }
 
-func TestProjectComposefilesFromWorkingDir(t *testing.T) {
+func TestProjectComposeFilesFromWorkingDir(t *testing.T) {
 	opts, err := NewProjectOptions([]string{
 		"testdata/simple/compose.yaml",
 		"testdata/simple/compose-with-overrides.yaml",
@@ -351,4 +355,112 @@ func TestEnvVariablePrecedence(t *testing.T) {
 			assert.DeepEqual(t, test.expected, options.Environment)
 		})
 	}
+}
+
+// TestProjectFromURL tests if a project create with remote compose files is the same as one create with local files
+func TestProjectFromURL(t *testing.T) {
+	// serve compose files
+	svr := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			prefix := filepath.Join("testdata", "simple")
+			filePath := prefix + r.URL.Path
+			if _, err := os.Stat(filePath); err != nil {
+				fmt.Println("here")
+				http.NotFound(w, r)
+				return
+			}
+			http.ServeFile(w, r, filePath)
+		}))
+	defer svr.Close()
+
+	urlBaseFile, err := url.JoinPath(svr.URL, "compose.yaml")
+	assert.NilError(t, err)
+	urlOverrideFile, err := url.JoinPath(svr.URL, "compose-with-overrides.yaml")
+	assert.NilError(t, err)
+	urlDoesNotExist, err := url.JoinPath(svr.URL, "compose-missing-file,yaml")
+	assert.NilError(t, err)
+
+	t.Run("from remote files", func(t *testing.T) {
+		// project from compose files served by server
+		optsUrl, err := NewProjectOptions([]string{
+			urlBaseFile, urlOverrideFile,
+		}, WithName("my_project"))
+		assert.NilError(t, err)
+		pUrl, err := ProjectFromOptions(optsUrl)
+		assert.NilError(t, err)
+
+		// project from local compose files
+		wd, err := os.Getwd()
+		assert.NilError(t, err)
+		optsFile, err := NewProjectOptions([]string{
+			"testdata/simple/compose.yaml",
+			"testdata/simple/compose-with-overrides.yaml",
+		}, WithName("my_project"),
+			WithWorkingDirectory(wd)) // if base compose file is url then project working dir should be the current working dir
+		assert.NilError(t, err)
+		pFile, err := ProjectFromOptions(optsFile)
+		assert.NilError(t, err)
+		pFile.ComposeFiles = pUrl.ComposeFiles // override compose file names
+
+		assert.DeepEqual(t, pUrl, pFile)
+	})
+
+	t.Run("from remote base", func(t *testing.T) {
+		// project from remote base file and local override file
+		optsUrl, err := NewProjectOptions([]string{
+			urlBaseFile,
+			"testdata/simple/compose-with-overrides.yaml",
+		}, WithName("my_project"))
+		assert.NilError(t, err)
+		pUrl, err := ProjectFromOptions(optsUrl)
+		assert.NilError(t, err)
+
+		// project from local compose files
+		wd, err := os.Getwd()
+		assert.NilError(t, err)
+		optsFile, err := NewProjectOptions([]string{
+			"testdata/simple/compose.yaml",
+			"testdata/simple/compose-with-overrides.yaml",
+		}, WithName("my_project"),
+			WithWorkingDirectory(wd)) // if base compose file is url then project working dir should be the current working dir
+		assert.NilError(t, err)
+		pFile, err := ProjectFromOptions(optsFile)
+		assert.NilError(t, err)
+		pFile.ComposeFiles = pUrl.ComposeFiles // override compose file names
+
+		assert.DeepEqual(t, pUrl, pFile)
+	})
+
+	t.Run("from remote override", func(t *testing.T) {
+		// project from local base file and remote override file
+		optsUrl, err := NewProjectOptions([]string{
+			"testdata/simple/compose.yaml",
+			urlOverrideFile,
+		}, WithName("my_project"))
+		assert.NilError(t, err)
+		pUrl, err := ProjectFromOptions(optsUrl)
+		assert.NilError(t, err)
+
+		// project from local compose files
+		assert.NilError(t, err)
+		optsFile, err := NewProjectOptions([]string{
+			"testdata/simple/compose.yaml",
+			"testdata/simple/compose-with-overrides.yaml",
+		}, WithName("my_project"))
+		assert.NilError(t, err)
+		pFile, err := ProjectFromOptions(optsFile)
+		assert.NilError(t, err)
+		pFile.ComposeFiles = pUrl.ComposeFiles // override compose file names
+
+		assert.DeepEqual(t, pUrl, pFile)
+	})
+
+	t.Run("from bad url", func(t *testing.T) {
+		optsUrl, err := NewProjectOptions([]string{
+			urlDoesNotExist,
+		}, WithName("my_project"))
+		assert.NilError(t, err)
+		_, err = ProjectFromOptions(optsUrl)
+		assert.ErrorType(t, err, err.(*fs.PathError))
+	})
 }


### PR DESCRIPTION
Closes #554.

When ingesting the config files if one is detected to be a URL instead of a file path a http get request is sent and the underlying file is read.
If the base file is a URL the working directory is set to the user working directory.


Tests that compare using a URL and using local files to create a project have been included.