### PR TITLE
Allow extends in referencing same file

### DIFF
--- a/loader/extends.go
+++ b/loader/extends.go
@@ -135,7 +135,6 @@ func getExtendsBaseFromFile(ctx context.Context, name string, path string, opts 
 		extendsOpts.SkipNormalization = true
 		extendsOpts.SkipConsistencyCheck = true
 		extendsOpts.SkipInclude = true
-		extendsOpts.SkipExtends = true    // we manage extends recursively based on raw service definition
 		extendsOpts.SkipValidation = true // we validate the merge result
 		source, err := loadYamlModel(ctx, types.ConfigDetails{
 			WorkingDir: relworkingdir,


### PR DESCRIPTION
When the yaml is loaded and transformed into an map, the default value for the context is "."  https://github.com/compose-spec/compose-go/blob/5a8e67720466339ad22c8bac1249f97e0e73e831/transform/build.go#L25-L31 
Currently, there is an assumption of one level when searching for the extended value from files, by skipping the extended operation.
https://github.com/compose-spec/compose-go/blob/5a8e67720466339ad22c8bac1249f97e0e73e831/loader/extends.go#L117-L138

However, the presented use case in https://github.com/docker/compose/issues/11431 looks valid and so we can't do this assumption.
Fix: https://github.com/docker/compose/issues/11431