### PR TITLE
set default values to required attributes

### DIFF
--- a/loader/extends.go
+++ b/loader/extends.go
@@ -140,6 +140,7 @@ func getExtendsBaseFromFile(ctx context.Context, name string, path string, opts 
 		extendsOpts.SkipInclude = true
 		extendsOpts.SkipExtends = true    // we manage extends recursively based on raw service definition
 		extendsOpts.SkipValidation = true // we validate the merge result
+		extendsOpts.SkipDefaultValues = true
 		source, err := loadYamlModel(ctx, types.ConfigDetails{
 			WorkingDir: relworkingdir,
 			ConfigFiles: []types.ConfigFile{

--- a/loader/full-example.yml
+++ b/loader/full-example.yml
@@ -26,7 +26,8 @@ services:
       additional_contexts:
         foo: ./bar
       secrets:
-        - secret1
+        - source: secret1
+          target: /run/secrets/secret1
         - source: secret2
           target: my_secret
           uid: '103'
@@ -257,7 +258,8 @@ services:
     restart: always
 
     secrets:
-      - secret1
+      - source: secret1
+        target: /run/secrets/secret1
       - source: secret2
         target: my_secret
         uid: '103'

--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -65,6 +65,7 @@ func services(workingDir, homeDir string) types.Services {
 				Secrets: []types.ServiceSecretConfig{
 					{
 						Source: "secret1",
+						Target: "/run/secrets/secret1",
 					},
 					{
 						Source: "secret2",
@@ -396,6 +397,7 @@ func services(workingDir, homeDir string) types.Services {
 			Secrets: []types.ServiceSecretConfig{
 				{
 					Source: "secret1",
+					Target: "/run/secrets/secret1",
 				},
 				{
 					Source: "secret2",
@@ -627,6 +629,7 @@ services:
       target: foo
       secrets:
         - source: secret1
+          target: /run/secrets/secret1
         - source: secret2
           target: my_secret
           uid: "103"
@@ -885,6 +888,7 @@ services:
     restart: always
     secrets:
       - source: secret1
+        target: /run/secrets/secret1
       - source: secret2
         target: my_secret
         uid: "103"
@@ -1180,7 +1184,8 @@ func fullExampleJSON(workingDir, homeDir string) string {
         "target": "foo",
         "secrets": [
           {
-            "source": "secret1"
+            "source": "secret1",
+            "target": "/run/secrets/secret1"
           },
           {
             "source": "secret2",
@@ -1544,7 +1549,8 @@ func fullExampleJSON(workingDir, homeDir string) string {
       "restart": "always",
       "secrets": [
         {
-          "source": "secret1"
+          "source": "secret1",
+          "target": "/run/secrets/secret1"
         },
         {
           "source": "secret2",

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -64,6 +64,8 @@ type Options struct {
 	SkipInclude bool
 	// SkipResolveEnvironment will ignore computing `environment` for services
 	SkipResolveEnvironment bool
+	// SkipDefaultValues will ignore missing required attributes
+	SkipDefaultValues bool
 	// Interpolation options
 	Interpolate *interp.Options
 	// Discard 'env_file' entries after resolving to 'environment' section
@@ -415,6 +417,13 @@ func loadYamlModel(ctx context.Context, config types.ConfigDetails, opts *Option
 	dict, err = override.EnforceUnicity(dict)
 	if err != nil {
 		return nil, err
+	}
+
+	if !opts.SkipDefaultValues {
+		dict, err = transform.SetDefaultValues(dict)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if !opts.SkipValidation {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -438,7 +438,7 @@ services:
 
 	svcB, err := actual.GetService("b")
 	assert.NilError(t, err)
-	assert.Equal(t, svcB.Build.Context, bDir)
+	assert.Equal(t, svcB.Build.Context, tmpdir)
 }
 
 func TestLoadExtendsWihReset(t *testing.T) {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -828,6 +828,7 @@ networks:
 				Secrets: []types.ServiceSecretConfig{
 					{
 						Source: "super",
+						Target: "/run/secrets/super",
 						Mode:   uint32Ptr(555),
 					},
 				},
@@ -1842,6 +1843,7 @@ secrets:
 				Secrets: []types.ServiceSecretConfig{
 					{
 						Source: "secret",
+						Target: "/run/secrets/secret",
 					},
 				},
 			},
@@ -1911,6 +1913,7 @@ secrets:
 				Secrets: []types.ServiceSecretConfig{
 					{
 						Source: "secret",
+						Target: "/run/secrets/secret",
 					},
 				},
 			},

--- a/parsing.md
+++ b/parsing.md
@@ -127,13 +127,19 @@ During loading, all those attributes are transformed into canonical
 representation, so that we get a single format that will match to go structs
 for binding.
 
-# Phase 12: extensions
+# Phase 12: set-defaults
+
+Some attributes are required by the model but optional in the compose file, as an implicit 
+default value is defined by the specification, like [`build.context`](https://github.com/compose-spec/compose-spec/blob/master/build.md#context)
+During this phase, such unset attributes get default value assigned.
+
+# Phase 13: extensions
 
 Extension (`x-*` attributes) can be used in any place in the yaml document.
 To make unmarshalling easier, parsing move them all into a custom `#extension`
 attribute. This hack is very specific to the go binding.
 
-# Phase 13: relative paths
+# Phase 14: relative paths
 
 Compose allows paths to be set relative to the project directory. Those get resolved
 into absolute paths during this phase. This involves a few corner cases, as
@@ -152,7 +158,7 @@ volumes:
       device: './data' # such a relative path must be resolved
 ```
 
-# Phase 14: go binding
+# Phase 15: go binding
 
 Eventually, the yaml tree can be unmarshalled into go structs. We rely on
 [mapstructure](https://github.com/mitchellh/mapstructure) library for this purpose.

--- a/transform/build.go
+++ b/transform/build.go
@@ -25,9 +25,6 @@ import (
 func transformBuild(data any, p tree.Path) (any, error) {
 	switch v := data.(type) {
 	case map[string]any:
-		if _, ok := v["context"]; !ok {
-			v["context"] = "." // TODO(ndeloof) maybe we miss an explicit "set-defaults" loading phase
-		}
 		return transformMapping(v, p)
 	case string:
 		return map[string]any{
@@ -35,5 +32,17 @@ func transformBuild(data any, p tree.Path) (any, error) {
 		}, nil
 	default:
 		return data, fmt.Errorf("%s: invalid type %T for build", p, v)
+	}
+}
+
+func defaultBuildContext(data any, _ tree.Path) (any, error) {
+	switch v := data.(type) {
+	case map[string]any:
+		if _, ok := v["context"]; !ok {
+			v["context"] = "."
+		}
+		return v, nil
+	default:
+		return data, nil
 	}
 }

--- a/transform/build_test.go
+++ b/transform/build_test.go
@@ -43,7 +43,6 @@ func Test_transformBuild(t *testing.T) {
 				"dockerfile": "foo.Dockerfile",
 			},
 			want: map[string]any{
-				"context":    ".",
 				"dockerfile": "foo.Dockerfile",
 			},
 		},

--- a/transform/defaults.go
+++ b/transform/defaults.go
@@ -24,6 +24,7 @@ var defaultValues = map[tree.Path]transformFunc{}
 
 func init() {
 	defaultValues["services.*.build"] = defaultBuildContext
+	defaultValues["services.*.secrets.*"] = defaultSecretMount
 }
 
 // SetDefaultValues transforms a compose model to set default values to missing attributes

--- a/transform/defaults.go
+++ b/transform/defaults.go
@@ -1,0 +1,86 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package transform
+
+import (
+	"github.com/compose-spec/compose-go/v2/tree"
+)
+
+var defaultValues = map[tree.Path]transformFunc{}
+
+func init() {
+	defaultValues["services.*.build"] = defaultBuildContext
+}
+
+// SetDefaultValues transforms a compose model to set default values to missing attributes
+func SetDefaultValues(yaml map[string]any) (map[string]any, error) {
+	result, err := setDefaults(yaml, tree.NewPath())
+	if err != nil {
+		return nil, err
+	}
+	return result.(map[string]any), nil
+}
+
+func setDefaults(data any, p tree.Path) (any, error) {
+	for pattern, transformer := range defaultValues {
+		if p.Matches(pattern) {
+			t, err := transformer(data, p)
+			if err != nil {
+				return nil, err
+			}
+			return t, nil
+		}
+	}
+	switch v := data.(type) {
+	case map[string]any:
+		a, err := setDefaultsMapping(v, p)
+		if err != nil {
+			return a, err
+		}
+		return v, nil
+	case []any:
+		a, err := setDefaultsSequence(v, p)
+		if err != nil {
+			return a, err
+		}
+		return v, nil
+	default:
+		return data, nil
+	}
+}
+
+func setDefaultsSequence(v []any, p tree.Path) ([]any, error) {
+	for i, e := range v {
+		t, err := setDefaults(e, p.Next("[]"))
+		if err != nil {
+			return nil, err
+		}
+		v[i] = t
+	}
+	return v, nil
+}
+
+func setDefaultsMapping(v map[string]any, p tree.Path) (map[string]any, error) {
+	for k, e := range v {
+		t, err := setDefaults(e, p.Next(k))
+		if err != nil {
+			return nil, err
+		}
+		v[k] = t
+	}
+	return v, nil
+}

--- a/transform/secrets.go
+++ b/transform/secrets.go
@@ -34,3 +34,16 @@ func transformFileMount(data any, p tree.Path) (any, error) {
 		return nil, fmt.Errorf("%s: unsupported type %T", p, data)
 	}
 }
+
+func defaultSecretMount(data any, p tree.Path) (any, error) {
+	switch v := data.(type) {
+	case map[string]any:
+		source := v["source"]
+		if _, ok := v["target"]; !ok {
+			v["target"] = fmt.Sprintf("/run/secrets/%s", source)
+		}
+		return v, nil
+	default:
+		return nil, fmt.Errorf("%s: unsupported type %T", p, data)
+	}
+}


### PR DESCRIPTION
This is an alternative to https://github.com/compose-spec/compose-go/pull/557

having an explicit "set-defaults" step parsing compose.yaml files allows to keep the `extends` source in its original form, without an implicit `context: .` value, and prevent incorrect path resolution to take place depending we extends within same file (already parsed) or from another one (to be parsed).
