### PR TITLE
Add getters for services that have defined build, extends, depends_on, capabilities, gpu and tpu

### DIFF
--- a/types/services.go
+++ b/types/services.go
@@ -33,3 +33,13 @@ func (s Services) GetProfiles() []string {
 	}
 	return profiles
 }
+
+func (s Services) Filter(predicate func(ServiceConfig) bool) Services {
+	services := Services{}
+	for name, service := range s {
+		if predicate(service) {
+			services[name] = service
+		}
+	}
+	return services
+}

--- a/utils/collectionutils.go
+++ b/utils/collectionutils.go
@@ -51,3 +51,18 @@ func ArrayContains[T comparable](source []T, toCheck []T) bool {
 	}
 	return true
 }
+
+func RemoveDuplicates[T comparable](slice []T) []T {
+	// Create a map to store unique elements
+	seen := make(map[T]bool)
+	result := []T{}
+
+	// Loop through the slice, adding elements to the map if they haven't been seen before
+	for _, val := range slice {
+		if _, ok := seen[val]; !ok {
+			seen[val] = true
+			result = append(result, val)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
Add methods to retrieve which services have defined:
- build
- extends
- depends_on
- capabilities
- gpu
- tpu

This will be used in compose for two telemetry purposes. We want to know the complexity of compose files and if compose is being used for AI/ML development