### PR TITLE
schema is hosted by compose-go, no need to sync anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Check license
         run: DOCKER_BUILDKIT=1 make check-license
-      - name: Check schema
-        run: make check-schema
 
   test:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,6 @@ lint: build-validate-image
 check-license: build-validate-image
 	docker run --rm $(IMAGE_PREFIX)validate bash -c "./scripts/validate/fileheader"
 
-.PHONY: check-schema
-check-schema:
-	curl -fSL -o schema/compose-spec.json https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json
-	git diff --exit-code schema/compose-spec.json
-
 .PHONY: setup
 setup: ## Setup the precommit hook
 	@which pre-commit > /dev/null 2>&1 || (echo "pre-commit not installed see README." && false)


### PR DESCRIPTION
json schema is hosted in compose-go repository in sync with implementation code. This is now compose-spec doing the sync since https://github.com/compose-spec/compose-spec/pull/455