### PR TITLE
Add listeners to trace file metadata

### DIFF
--- a/loader/extends.go
+++ b/loader/extends.go
@@ -70,8 +70,10 @@ func applyServiceExtends(ctx context.Context, name string, services map[string]a
 	case map[string]any:
 		ref = v["service"].(string)
 		file = v["file"]
+		opts.ProcessEvent("extends", v)
 	case string:
 		ref = v
+		opts.ProcessEvent("extends", map[string]any{"service": ref})
 	}
 
 	var base any
@@ -121,6 +123,7 @@ func applyServiceExtends(ctx context.Context, name string, services map[string]a
 		return nil, err
 	}
 	delete(merged, "extends")
+	services[name] = merged
 	return merged, nil
 }
 

--- a/loader/extends_test.go
+++ b/loader/extends_test.go
@@ -52,6 +52,7 @@ services:
 	abs, err := filepath.Abs(".")
 	assert.NilError(t, err)
 
+	extendsCount := 0
 	p, err := LoadWithContext(context.Background(), types.ConfigDetails{
 		ConfigFiles: []types.ConfigFile{
 			{
@@ -60,11 +61,21 @@ services:
 			},
 		},
 		WorkingDir: abs,
+	}, func(options *Options) {
+		options.ResolvePaths = false
+		options.Listeners = []Listener{
+			func(event string, metadata map[string]any) {
+				if event == "extends" {
+					extendsCount++
+				}
+			},
+		}
 	})
 	assert.NilError(t, err)
 	assert.DeepEqual(t, p.Services["test1"].Hostname, "test1")
 	assert.Equal(t, p.Services["test2"].Hostname, "test2")
 	assert.Equal(t, p.Services["test3"].Hostname, "test3")
+	assert.Equal(t, extendsCount, 4)
 }
 
 func TestExtendsPort(t *testing.T) {
@@ -262,6 +273,7 @@ services:
 
 	assert.NilError(t, os.WriteFile(filepath.Join(tmpdir, "compose.yaml"), []byte(rootYAML), 0o600))
 
+	extendsCount := 0
 	actual, err := Load(types.ConfigDetails{
 		WorkingDir: tmpdir,
 		ConfigFiles: []types.ConfigFile{{
@@ -272,6 +284,13 @@ services:
 		options.SkipNormalization = true
 		options.SkipConsistencyCheck = true
 		options.SetProjectName("project", true)
+		options.Listeners = []Listener{
+			func(event string, metadata map[string]any) {
+				if event == "extends" {
+					extendsCount++
+				}
+			},
+		}
 	})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Len(actual.Services, 2))
@@ -283,6 +302,8 @@ services:
 	svcB, err := actual.GetService("out-service")
 	assert.NilError(t, err)
 	assert.Equal(t, svcB.Build.Context, tmpdir)
+
+	assert.Equal(t, extendsCount, 3)
 }
 
 func TestRejectExtendsWithServiceRef(t *testing.T) {
@@ -357,4 +378,85 @@ services:
 			assert.ErrorContains(t, err, tt.wantErr)
 		})
 	}
+}
+
+func TestLoadExtendsListener(t *testing.T) {
+	yaml := `
+  name: listener-extends
+  services:
+    foo:
+      image: busybox
+      extends: bar
+    bar:
+      image: alpine
+      command: echo
+      extends: wee
+    wee:
+      extends: last
+      command: echo
+    last:
+      image: python`
+	extendsCount := 0
+	_, err := Load(buildConfigDetails(yaml, nil), func(options *Options) {
+		options.SkipConsistencyCheck = true
+		options.SkipNormalization = true
+		options.ResolvePaths = true
+		options.Listeners = []Listener{
+			func(event string, metadata map[string]any) {
+				if event == "extends" {
+					extendsCount++
+				}
+			},
+		}
+	})
+
+	assert.NilError(t, err)
+	assert.Equal(t, extendsCount, 3)
+}
+
+func TestLoadExtendsListenerMultipleFiles(t *testing.T) {
+	tmpdir := t.TempDir()
+	subDir := filepath.Join(tmpdir, "sub")
+	assert.NilError(t, os.Mkdir(subDir, 0o700))
+	subYAML := `
+services:
+  b:
+    extends: c
+    build:
+      target: fake
+  c:
+    command: echo
+`
+	assert.NilError(t, os.WriteFile(filepath.Join(tmpdir, "sub", "compose.yaml"), []byte(subYAML), 0o600))
+
+	rootYAML := `
+services:
+  a:
+    extends:
+      file: ./sub/compose.yaml
+      service: b
+`
+	assert.NilError(t, os.WriteFile(filepath.Join(tmpdir, "compose.yaml"), []byte(rootYAML), 0o600))
+
+	extendsCount := 0
+	_, err := Load(types.ConfigDetails{
+		WorkingDir: tmpdir,
+		ConfigFiles: []types.ConfigFile{{
+			Filename: filepath.Join(tmpdir, "compose.yaml"),
+		}},
+		Environment: nil,
+	}, func(options *Options) {
+		options.SkipNormalization = true
+		options.SkipConsistencyCheck = true
+		options.SetProjectName("project", true)
+		options.Listeners = []Listener{
+			func(event string, metadata map[string]any) {
+				if event == "extends" {
+					extendsCount++
+				}
+			},
+		}
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, extendsCount, 2)
 }

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -80,6 +80,17 @@ type Options struct {
 	ResourceLoaders []ResourceLoader
 	// KnownExtensions manages x-* attribute we know and the corresponding go structs
 	KnownExtensions map[string]any
+	// Metada for telemetry
+	Listeners []Listener
+}
+
+type Listener = func(event string, metadata map[string]any)
+
+// Invoke all listeners for an event
+func (o *Options) ProcessEvent(event string, metadata map[string]any) {
+	for _, l := range o.Listeners {
+		l(event, metadata)
+	}
 }
 
 // ResourceLoader is a plugable remote resource resolver
@@ -153,6 +164,7 @@ func (o *Options) clone() *Options {
 		Profiles:                   o.Profiles,
 		ResourceLoaders:            o.ResourceLoaders,
 		KnownExtensions:            o.KnownExtensions,
+		Listeners:                  o.Listeners,
 	}
 }
 


### PR DESCRIPTION
## Description
This PR intends to retrieve metadata from the parsing file. This was an issue when tracking the occurrences of `extends` in a project for telemetry since at the time the metrics are sent the Project is fully resolved thus no extends instances.

This will be one out of three PRs.
https://github.com/docker/compose/pull/11492
## Interaction

```mermaid
sequenceDiagram
    participant pinata
    participant compose
    participant compose-go
    compose->>compose-go: register listeners 
    compose->>+compose-go: load project
    compose-go->>+compose-go/extends: ApplyExtends
   Note right of compose-go/extends: options.ProcessEvent("extends", metadata)
    compose-go/extends-->>-compose-go: finish extends
    compose-go-->>-compose: finish load
    compose-->>pinata: send OTEL metrics
```
## Fix
by adding the listener to increment the number of processed extends, found a bug where when going down the search tree, we were not updating the leafs after the merge. In a case where we had chained extends, we would over look the tree, since we would only update the `services` at the head of the recursion in `ApplyExtends`