### PR TITLE
warn user `version` is obsolete

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -438,6 +438,11 @@ func loadYamlModel(ctx context.Context, config types.ConfigDetails, opts *Option
 		}
 	}
 
+	if _, ok := dict["version"]; ok {
+		logrus.Warning("`version` is obsolete")
+		delete(dict, "version")
+	}
+
 	dict, err = transform.Canonical(dict)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Since compose-specification was released, `version` attribute is obsolete as it doesn't guarantee any form of compatibility. While users adopted new features introduced in the spec, we still see many of them using `version: "3"` in compose files.

This adds a warning to encourage users to stop using this useless attirbute