### PR TITLE
ignore failure parsing yaml file when looking for project name

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -3084,3 +3084,27 @@ services:
 	assert.Check(t, ok)
 	assert.Equal(t, magic.Foo, "bar")
 }
+
+func TestLoadWithEmptyFile(t *testing.T) {
+	yaml := `
+name: test-with-empty-file
+services:
+  test:
+    image: foo
+`
+
+	p, err := LoadWithContext(context.Background(), types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{
+			{
+				Filename: "(inlined)",
+				Content:  []byte(yaml),
+			},
+			{
+				Filename: "(override)",
+				Content:  []byte(""),
+			},
+		},
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, p.Name, "test-with-empty-file")
+}


### PR DESCRIPTION
postpone checking a project name is set, so that we can just ignore yaml parsing error looking for `name`

fixes https://github.com/docker/compose/issues/11450