### PR TITLE
NetworksByPriority: ensure the sort order is stable

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -162,6 +162,9 @@ func (s *ServiceConfig) NetworksByPriority() []string {
 		})
 	}
 	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].priority == keys[j].priority {
+			return keys[i].name < keys[j].name
+		}
 		return keys[i].priority > keys[j].priority
 	})
 	var sorted []string

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -269,6 +269,18 @@ func TestNetworksByPriority(t *testing.T) {
 	assert.DeepEqual(t, s.NetworksByPriority(), []string{"qix", "zot", "bar", "foo"})
 }
 
+func TestNetworksByPriorityWithEqualPriorities(t *testing.T) {
+	s := ServiceConfig{
+		Networks: map[string]*ServiceNetworkConfig{
+			"foo": nil,
+			"bar": nil,
+			"zot": nil,
+			"qix": nil,
+		},
+	}
+	assert.DeepEqual(t, s.NetworksByPriority(), []string{"bar", "foo", "qix", "zot"})
+}
+
 func TestMarshalServiceEntrypoint(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Related to:
- https://github.com/docker/compose/issues/11510
- https://github.com/docker/compose/pull/11429

NetworksByPriority calls sort.Slice() to sort the map of networks attached to a given service by their respective priority. The Priority property being non mandatory, it defaults to 0 when unspecified.

The godoc for sort.Slice() specifies:

> The sort is not guaranteed to be stable: equal elements may be reversed from their original order. For a stable sort, use SliceStable.

SliceStable() won't work either, since NetworksByPriority has to transform the map of networks into a list before calling sort.Slice() -- Go makes no guarantee about the order of items in a map.

The only way to guarantee a stable order is to fall back to lexicographic sorting when two networks have the same priority. It seems to be the best option as the compose-spec doesn't specify how multiple network attachment referencing the same network should be handled.

A regression test has been added.