### PR TITLE
Fix broken interpolation with JSON (curly braces) default values

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -258,7 +258,7 @@ func getFirstBraceClosingIndex(s string) int {
 				return i
 			}
 		}
-		if strings.HasPrefix(s[i:], "${") {
+		if s[i] == '{' {
 			openVariableBraces++
 			i++
 		}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -26,8 +26,9 @@ import (
 )
 
 var defaults = map[string]string{
-	"FOO": "first",
-	"BAR": "",
+	"FOO":  "first",
+	"BAR":  "",
+	"JSON": `{"json":2}`,
 }
 
 func defaultMapping(name string) (string, bool) {
@@ -628,5 +629,21 @@ func TestSubstitutionFunctionChoice(t *testing.T) {
 				fmt.Sprintf("Wrong on output for: %s got symbol -> %#v", tc.input, symbol),
 			)
 		})
+	}
+}
+
+func TestNoValueWithCurlyBracesDefault(t *testing.T) {
+	for _, template := range []string{`ok ${missing:-{"json":1}}`, `ok ${missing-{"json":1}}`} {
+		result, err := Substitute(template, defaultMapping)
+		assert.NilError(t, err)
+		assert.Check(t, is.Equal(`ok {"json":1}`, result))
+	}
+}
+
+func TestValueWithCurlyBracesDefault(t *testing.T) {
+	for _, template := range []string{`ok ${JSON:-{"json":1}}`, `ok ${JSON-{"json":1}}`} {
+		result, err := Substitute(template, defaultMapping)
+		assert.NilError(t, err)
+		assert.Check(t, is.Equal(`ok {"json":2}`, result))
 	}
 }


### PR DESCRIPTION
Hopefully should be enough to fix a downstream docker compose issue:

```yaml
   environment:
      PARSING_LIMITS: ${PARSING_LIMITS:-{"commits":1}}
```

Now it returns:

```sh
$ export PARSING_LIMITS='{"commits":2}'
$ docker-compose -f docker-compose.yaml config | grep PARSING
PARSING_LIMITS: '{"commits":2}}'
```

Mind an extra `}` at the end of the value.

It prevents from using JSON string as a default value for an environment variable.