### PR TITLE
build binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,60 @@
 name: Release
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch"
-        required: true
-        default: "main"
-      tag:
-        description: "Release Tag"
-
-
 
 jobs:
-  release:
-    runs-on: ubuntu-latest      
+  binary:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [linux, darwin, windows]
+        arch: [amd64, arm64]
     steps:
-      - name: Release it!
-        if: ${{ github.event.inputs.tag != '' }} # don't release if no tag is specified
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go version
+      -
+        name: Build
+        run: |
+          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
+      -
+        name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: compose-spec
+          path: ./bin/*
+          if-no-files-found: error
+
+  release:
+    permissions:
+      contents: write # to create a release (ncipollo/release-action)
+    runs-on: ubuntu-latest
+    needs:
+      - binary
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: compose-spec
+          path: bin/release
+      -
+        name: GitHub Release
         uses: ncipollo/release-action@v1
         with:
+          artifacts: bin/release/*
           generateReleaseNotes: true
           draft: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.event.inputs.tag }}
-          commit: ${{ github.event.inputs.branch }}

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,13 @@
 
 IMAGE_PREFIX=composespec/conformance-tests-
 
+ifeq ($(OS),Windows_NT)
+	BINARY_EXT=.exe
+endif
+
 .PHONY: build
 build: ## Build command line
-	go build -o bin/compose-spec cmd/main.go
+	go build -o bin/compose-spec-$(GOOS)-$(GOARCH)$(BINARY_EXT) cmd/main.go
 
 .PHONY: test
 test: ## Run tests


### PR DESCRIPTION
update the release process to be triggered by a tag, and build binaries for the compose-spec command line (cross-compile)