### PR TITLE
Use ResourceLoader to ingest compose files

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -395,22 +395,24 @@ func (o *ProjectOptions) GetWorkingDir() (string, error) {
 	return os.Getwd()
 }
 
-func (o *ProjectOptions) GeConfigFiles() ([]types.ConfigFile, error) {
-	configPaths, err := o.getConfigPaths()
+// ReadConfigFiles reads ConfigFiles and populates the content field
+func (o ProjectOptions) ReadConfigFiles(ctx context.Context, options *ProjectOptions) (*types.ConfigDetails, error) {
+	config, err := loader.LoadConfigFiles(ctx, options.ConfigPaths, options.loadOptions...)
 	if err != nil {
 		return nil, err
 	}
+	configs := make([][]byte, len(config.ConfigFiles))
 
-	var configs []types.ConfigFile
-	for _, f := range configPaths {
+	for i, c := range config.ConfigFiles {
+		var err error
 		var b []byte
-		if f == "-" {
+		if c.Filename == "-" {
 			b, err = io.ReadAll(os.Stdin)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			f, err := filepath.Abs(f)
+			f, err := filepath.Abs(c.Filename)
 			if err != nil {
 				return nil, err
 			}
@@ -419,27 +421,31 @@ func (o *ProjectOptions) GeConfigFiles() ([]types.ConfigFile, error) {
 				return nil, err
 			}
 		}
-		configs = append(configs, types.ConfigFile{
-			Filename: f,
-			Content:  b,
-		})
+		configs[i] = b
 	}
-	return configs, err
+	for i, c := range configs {
+		config.ConfigFiles[i].Content = c
+	}
+	return config, nil
 }
 
 // LoadProject loads compose file according to options and bind to types.Project go structs
 func (o *ProjectOptions) LoadProject(ctx context.Context) (*types.Project, error) {
-	configDetails, err := o.prepare()
+	config, err := o.prepare(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	project, err := loader.LoadWithContext(ctx, configDetails, o.loadOptions...)
+	project, err := loader.LoadWithContext(ctx, types.ConfigDetails{
+		ConfigFiles: config.ConfigFiles,
+		WorkingDir:  config.WorkingDir,
+		Environment: o.Environment,
+	}, o.loadOptions...)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, config := range configDetails.ConfigFiles {
+	for _, config := range config.ConfigFiles {
 		project.ComposeFiles = append(project.ComposeFiles, config.Filename)
 	}
 
@@ -448,36 +454,31 @@ func (o *ProjectOptions) LoadProject(ctx context.Context) (*types.Project, error
 
 // LoadModel loads compose file according to options and returns a raw (yaml tree) model
 func (o *ProjectOptions) LoadModel(ctx context.Context) (map[string]any, error) {
-	configDetails, err := o.prepare()
+	configDetails, err := o.prepare(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return loader.LoadModelWithContext(ctx, configDetails, o.loadOptions...)
+	return loader.LoadModelWithContext(ctx, *configDetails, o.loadOptions...)
 }
 
 // prepare converts ProjectOptions into loader's types.ConfigDetails and configures default load options
-func (o *ProjectOptions) prepare() (types.ConfigDetails, error) {
-	configs, err := o.GeConfigFiles()
+func (o *ProjectOptions) prepare(ctx context.Context) (*types.ConfigDetails, error) {
+	defaultDir, err := o.GetWorkingDir()
 	if err != nil {
-		return types.ConfigDetails{}, err
+		return &types.ConfigDetails{}, err
 	}
 
-	workingDir, err := o.GetWorkingDir()
+	configDetails, err := o.ReadConfigFiles(ctx, o)
 	if err != nil {
-		return types.ConfigDetails{}, err
-	}
-
-	configDetails := types.ConfigDetails{
-		ConfigFiles: configs,
-		WorkingDir:  workingDir,
-		Environment: o.Environment,
+		return configDetails, err
 	}
 
 	o.loadOptions = append(o.loadOptions,
-		withNamePrecedenceLoad(workingDir, o),
+		withNamePrecedenceLoad(defaultDir, o),
 		withConvertWindowsPaths(o),
 		withListeners(o))
+
 	return configDetails, nil
 }
 


### PR DESCRIPTION
Related to PR #555 and Issue #554 

To achieve consistency in the way resources are loaded for docker compose the config files are now ingested via `ResourceLoader`. For local files the existing `localResourceLoader` is used.

To add new ways of loading compose files in the future a new `ResourceLoader` should be implemented and added to the project options.