### PR TITLE
let resourceloader compute relative working dir

### DIFF
--- a/loader/testdata/combined/compose.yaml
+++ b/loader/testdata/combined/compose.yaml
@@ -1,0 +1,4 @@
+include:
+  - path:
+      - dir/included.yaml
+

--- a/loader/testdata/combined/dir/extended.yaml
+++ b/loader/testdata/combined/dir/extended.yaml
@@ -1,0 +1,4 @@
+services:
+  service:
+    build: .
+

--- a/loader/testdata/combined/dir/included.yaml
+++ b/loader/testdata/combined/dir/included.yaml
@@ -1,0 +1,6 @@
+services:
+  service:
+    extends:
+      file: extended.yaml
+      service: service
+


### PR DESCRIPTION
When nesting includes + extends recursively, `WorkingDir` is set to a relative path, so `filepath` func fail to compute absolute/relative paths, this is why `ResourceLoader.Dir` was introduced. But I forgot to use it to compute include's relative workingdir. This PR fixes this mistake

closes https://github.com/docker/compose/issues/11552