### PR TITLE
marshall json with 2 indent (align with yaml marshalling)

### DIFF
--- a/types/project.go
+++ b/types/project.go
@@ -597,7 +597,7 @@ func (p *Project) MarshalJSON() ([]byte, error) {
 	for k, v := range p.Extensions {
 		m[k] = v
 	}
-	return json.Marshal(m)
+	return json.MarshalIndent(m, "", "  ")
 }
 
 // WithServicesEnvironmentResolved parses env_files set for services to resolve the actual environment map for services


### PR DESCRIPTION
make it easier to review json config output and write e2e tests for this feature