### PR TITLE
introduce CheckCycle to detect cycles in project's depends_on

### DIFF
--- a/graph/cycle.go
+++ b/graph/cycle.go
@@ -1,0 +1,63 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package graph
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/compose-spec/compose-go/v2/utils"
+	"golang.org/x/exp/slices"
+)
+
+// CheckCycle analyze project's depends_on relation and report an error on cycle detection
+func CheckCycle(project *types.Project) error {
+	g, err := newGraph(project)
+	if err != nil {
+		return err
+	}
+	return g.checkCycle()
+}
+
+func (g *graph[T]) checkCycle() error {
+	// iterate on vertices in a name-order to render a predicable error message
+	// this is required by tests and enforce command reproducibility by user, which otherwise could be confusing
+	names := utils.MapKeys(g.vertices)
+	for _, name := range names {
+		err := searchCycle([]string{name}, g.vertices[name])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func searchCycle[T any](path []string, v *vertex[T]) error {
+	names := utils.MapKeys(v.children)
+	for _, name := range names {
+		if i := slices.Index(path, name); i > 0 {
+			return fmt.Errorf("dependency cycle detected: %s", strings.Join(path[i:], " -> "))
+		}
+		ch := v.children[name]
+		err := searchCycle(append(path, name), ch)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -16,14 +16,6 @@
 
 package graph
 
-import (
-	"fmt"
-	"strings"
-
-	"github.com/compose-spec/compose-go/v2/utils"
-	"golang.org/x/exp/slices"
-)
-
 // graph represents project as service dependencies
 type graph[T any] struct {
 	vertices map[string]*vertex[T]
@@ -70,34 +62,6 @@ func (g *graph[T]) leaves() []*vertex[T] {
 	}
 
 	return res
-}
-
-func (g *graph[T]) checkCycle() error {
-	// iterate on vertices in a name-order to render a predicable error message
-	// this is required by tests and enforce command reproducibility by user, which otherwise could be confusing
-	names := utils.MapKeys(g.vertices)
-	for _, name := range names {
-		err := searchCycle([]string{name}, g.vertices[name])
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func searchCycle[T any](path []string, v *vertex[T]) error {
-	names := utils.MapKeys(v.children)
-	for _, name := range names {
-		if i := slices.Index(path, name); i > 0 {
-			return fmt.Errorf("dependency cycle detected: %s", strings.Join(path[i:], " -> "))
-		}
-		ch := v.children[name]
-		err := searchCycle(append(path, name), ch)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // descendents return all descendents for a vertex, might contain duplicates

--- a/loader/validate.go
+++ b/loader/validate.go
@@ -17,7 +17,6 @@
 package loader
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -75,12 +74,6 @@ func checkConsistency(project *types.Project) error {
 			if _, err := project.GetService(dependedService); err != nil {
 				return fmt.Errorf("service %q depends on undefined service %q: %w", s.Name, dependedService, errdefs.ErrInvalid)
 			}
-		}
-		// Check there isn't a cycle in depends_on declarations
-		if err := graph.InDependencyOrder(context.Background(), project, func(ctx context.Context, s string, config types.ServiceConfig) error {
-			return nil
-		}); err != nil {
-			return err
 		}
 
 		if strings.HasPrefix(s.NetworkMode, types.ServicePrefix) {
@@ -159,5 +152,5 @@ func checkConsistency(project *types.Project) error {
 		}
 	}
 
-	return nil
+	return graph.CheckCycle(project)
 }


### PR DESCRIPTION
fix: cycle detection was ran for each and every service in project, not once per project 😅
also introduced a more explicit way to use the graph logic to search for cycles, vs running a no-op "in dependency order", where cycle detection is just an implementation detail

see https://github.com/docker/compose/issues/11437