### PR TITLE
enforce limits are consistent with deploy section

### DIFF
--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -121,11 +121,11 @@ func services(workingDir, homeDir string) types.Services {
 				},
 				Resources: types.Resources{
 					Limits: &types.Resource{
-						NanoCPUs:    "0.001",
+						NanoCPUs:    0.001,
 						MemoryBytes: 50 * 1024 * 1024,
 					},
 					Reservations: &types.Resource{
-						NanoCPUs:    "0.0001",
+						NanoCPUs:    0.0001,
 						MemoryBytes: 20 * 1024 * 1024,
 						GenericResources: []types.GenericResource{
 							{
@@ -690,10 +690,10 @@ services:
         order: start-first
       resources:
         limits:
-          cpus: "0.001"
+          cpus: 0.001
           memory: "52428800"
         reservations:
-          cpus: "0.0001"
+          cpus: 0.0001
           memory: "20971520"
           generic_resources:
             - discrete_resource_spec:
@@ -1267,11 +1267,11 @@ func fullExampleJSON(workingDir, homeDir string) string {
         },
         "resources": {
           "limits": {
-            "cpus": "0.001",
+            "cpus": 0.001,
             "memory": "52428800"
           },
           "reservations": {
-            "cpus": "0.0001",
+            "cpus": 0.0001,
             "memory": "20971520",
             "generic_resources": [
               {

--- a/loader/validate.go
+++ b/loader/validate.go
@@ -117,6 +117,31 @@ func checkConsistency(project *types.Project) error {
 			s.Deploy.Replicas = s.Scale
 		}
 
+		if s.CPUS != 0 && s.Deploy != nil {
+			if s.Deploy.Resources.Limits != nil && s.Deploy.Resources.Limits.NanoCPUs.Value() != s.CPUS {
+				return fmt.Errorf("services.%s: can't set distinct values on 'cpus' and 'deploy.resources.limits.cpus': %w",
+					s.Name, errdefs.ErrInvalid)
+			}
+		}
+		if s.MemLimit != 0 && s.Deploy != nil {
+			if s.Deploy.Resources.Limits != nil && s.Deploy.Resources.Limits.MemoryBytes != s.MemLimit {
+				return fmt.Errorf("services.%s: can't set distinct values on 'mem_limit' and 'deploy.resources.limits.memory': %w",
+					s.Name, errdefs.ErrInvalid)
+			}
+		}
+		if s.MemReservation != 0 && s.Deploy != nil {
+			if s.Deploy.Resources.Reservations != nil && s.Deploy.Resources.Reservations.MemoryBytes != s.MemReservation {
+				return fmt.Errorf("services.%s: can't set distinct values on 'mem_reservation' and 'deploy.resources.reservations.memory': %w",
+					s.Name, errdefs.ErrInvalid)
+			}
+		}
+		if s.PidsLimit != 0 && s.Deploy != nil {
+			if s.Deploy.Resources.Limits != nil && s.Deploy.Resources.Limits.Pids != s.PidsLimit {
+				return fmt.Errorf("services.%s: can't set distinct values on 'pids_limit' and 'deploy.resources.limits.pids': %w",
+					s.Name, errdefs.ErrInvalid)
+			}
+		}
+
 		if s.ContainerName != "" {
 			if existing, ok := containerNames[s.ContainerName]; ok {
 				return fmt.Errorf(`"services.%s": container name "%s" is already in use by "services.%s": %w`, s.Name, s.ContainerName, existing, errdefs.ErrInvalid)

--- a/types/types.go
+++ b/types/types.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/docker/go-connections/nat"
@@ -365,13 +366,37 @@ type Resources struct {
 // Resource is a resource to be limited or reserved
 type Resource struct {
 	// TODO: types to convert from units and ratios
-	NanoCPUs         string            `yaml:"cpus,omitempty" json:"cpus,omitempty"`
+	NanoCPUs         NanoCPUs          `yaml:"cpus,omitempty" json:"cpus,omitempty"`
 	MemoryBytes      UnitBytes         `yaml:"memory,omitempty" json:"memory,omitempty"`
 	Pids             int64             `yaml:"pids,omitempty" json:"pids,omitempty"`
 	Devices          []DeviceRequest   `yaml:"devices,omitempty" json:"devices,omitempty"`
 	GenericResources []GenericResource `yaml:"generic_resources,omitempty" json:"generic_resources,omitempty"`
 
 	Extensions Extensions `yaml:"#extensions,inline,omitempty" json:"-"`
+}
+
+type NanoCPUs float32
+
+func (n *NanoCPUs) DecodeMapstructure(a any) error {
+	switch v := a.(type) {
+	case string:
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return err
+		}
+		*n = NanoCPUs(f)
+	case float32:
+		*n = NanoCPUs(v)
+	case float64:
+		*n = NanoCPUs(v)
+	default:
+		return fmt.Errorf("unexpected value type %T for cpus", v)
+	}
+	return nil
+}
+
+func (n *NanoCPUs) Value() float32 {
+	return float32(*n)
 }
 
 // GenericResource represents a "user defined" resource which can


### PR DESCRIPTION
Introduce `NanoCPUs` to manage "string or number"
Enforce consistent values between limits declared by service and `deploy` section

see https://github.com/compose-spec/compose-spec/pull/475
closes https://github.com/docker/compose/issues/11634