### PR TITLE
run checkConsistency after profiles were applied

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -554,15 +554,15 @@ func modelToProject(dict map[string]interface{}, opts *Options, configDetails ty
 		}
 	}
 
+	if project, err = project.WithProfiles(opts.Profiles); err != nil {
+		return nil, err
+	}
+
 	if !opts.SkipConsistencyCheck {
 		err := checkConsistency(project)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	if project, err = project.WithProfiles(opts.Profiles); err != nil {
-		return nil, err
 	}
 
 	if !opts.SkipResolveEnvironment {


### PR DESCRIPTION
run checkConsistency after profiles were applied. 
If we don't, some services may refer to dependencies disabled by profile

As a side effect, this also allows to (ab)use profiles to define same resource twice with distinct configuration:
close https://github.com/docker/compose/issues/11619.
