### PR TITLE
refs issue:11706 Resolving the Alias value of Alias type node

### DIFF
--- a/loader/reset.go
+++ b/loader/reset.go
@@ -42,14 +42,8 @@ func (p *ResetProcessor) UnmarshalYAML(value *yaml.Node) error {
 // resolveReset detects `!reset` tag being set on yaml nodes and record position in the yaml tree
 func (p *ResetProcessor) resolveReset(node *yaml.Node, path tree.Path) (*yaml.Node, error) {
 	// If the path contains "<<", removing the "<<" element and merging the path
-	if strings.Contains(path.String(), "<<") {
-		pathArr := strings.Split(path.String(), ".")
-		path = tree.NewPath(pathArr[0])
-		for _, el := range pathArr[1:] {
-			if el != "<<" {
-				path = tree.Path(strings.Join([]string{path.String(), el}, "."))
-			}
-		}
+	if strings.Contains(path.String(), ".<<") {
+		path = tree.NewPath(strings.Replace(path.String(), ".<<", "", 1))
 	}
 	// If the node is an alias, We need to process the alias field in order to consider the !override and !reset tags
 	if node.Kind == yaml.AliasNode {

--- a/loader/reset.go
+++ b/loader/reset.go
@@ -19,6 +19,7 @@ package loader
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/compose-spec/compose-go/v2/tree"
 	"gopkg.in/yaml.v3"
@@ -40,6 +41,21 @@ func (p *ResetProcessor) UnmarshalYAML(value *yaml.Node) error {
 
 // resolveReset detects `!reset` tag being set on yaml nodes and record position in the yaml tree
 func (p *ResetProcessor) resolveReset(node *yaml.Node, path tree.Path) (*yaml.Node, error) {
+	// If the path contains "<<", removing the "<<" element and merging the path
+	if strings.Contains(path.String(), "<<") {
+		pathArr := strings.Split(path.String(), ".")
+		path = tree.NewPath(pathArr[0])
+		for _, el := range pathArr[1:] {
+			if el != "<<" {
+				path = tree.Path(strings.Join([]string{path.String(), el}, "."))
+			}
+		}
+	}
+	// If the node is an alias, We need to process the alias field in order to consider the !override and !reset tags
+	if node.Kind == yaml.AliasNode {
+		return p.resolveReset(node.Alias, path)
+	}
+
 	if node.Tag == "!reset" {
 		p.paths = append(p.paths, path)
 		return nil, nil


### PR DESCRIPTION
**Changes:**

1.  If the node is of `Alias` kind, we need to preserve the current path and process the Alias value separately.
2. By doing this, the `!overwrite ` tag won't be ignored.

**Testing:**

1. Created setup that mentioned on this issue: https://github.com/docker/compose/issues/11706
2. Results:

containers are spawned successfully:

<img width="792" alt="2024-04-11 (1)" src="https://github.com/compose-spec/compose-go/assets/57858357/33ca0471-606d-4d3e-8c3a-46ebeaba0f77">


Here, we can see in the configs section for `y` that there is only one entry for `configs`

<img width="971" alt="2024-04-11" src="https://github.com/compose-spec/compose-go/assets/57858357/28a9dd77-672e-45b6-9ff1-fbb12b21528f">