### PR TITLE
remove constraint for container_name unicity while loading model

### DIFF
--- a/loader/validate.go
+++ b/loader/validate.go
@@ -28,7 +28,6 @@ import (
 
 // checkConsistency validate a compose model is consistent
 func checkConsistency(project *types.Project) error {
-	containerNames := map[string]string{}
 	for _, s := range project.Services {
 		if s.Build == nil && s.Image == "" {
 			return fmt.Errorf("service %q has neither an image nor a build context specified: %w", s.Name, errdefs.ErrInvalid)
@@ -143,13 +142,6 @@ func checkConsistency(project *types.Project) error {
 				return fmt.Errorf("services.%s: can't set distinct values on 'pids_limit' and 'deploy.resources.limits.pids': %w",
 					s.Name, errdefs.ErrInvalid)
 			}
-		}
-
-		if s.ContainerName != "" {
-			if existing, ok := containerNames[s.ContainerName]; ok {
-				return fmt.Errorf(`"services.%s": container name "%s" is already in use by "services.%s": %w`, s.Name, s.ContainerName, existing, errdefs.ErrInvalid)
-			}
-			containerNames[s.ContainerName] = s.Name
 		}
 
 		if s.GetScale() > 1 && s.ContainerName != "" {

--- a/loader/validate_test.go
+++ b/loader/validate_test.go
@@ -262,7 +262,7 @@ func TestValidateDependsOn(t *testing.T) {
 }
 
 func TestValidateContainerName(t *testing.T) {
-	project := types.Project{
+	project := &types.Project{
 		Services: types.Services{
 			"myservice": {
 				Name:          "myservice",
@@ -276,7 +276,7 @@ func TestValidateContainerName(t *testing.T) {
 			},
 		},
 	}
-	err := checkConsistency(&project)
+	err := project.CheckContainerNameUnicity()
 	assert.Assert(t, strings.Contains(err.Error(), `container name "mycontainer" is already in use by`))
 }
 

--- a/types/project.go
+++ b/types/project.go
@@ -696,3 +696,17 @@ func (p *Project) WithServicesTransform(fn func(name string, s ServiceConfig) (S
 	}
 	return newProject, eg.Wait()
 }
+
+// CheckContainerNameUnicity validate project doesn't have services declaring the same container_name
+func (p *Project) CheckContainerNameUnicity() error {
+	names := utils.Set[string]{}
+	for name, s := range p.Services {
+		if s.ContainerName != "" {
+			if existing, ok := names[s.ContainerName]; ok {
+				return fmt.Errorf(`services.%s: container name %q is already in use by service %s"`, name, s.ContainerName, existing)
+			}
+			names.Add(s.ContainerName)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
such validation should occur later, as we actually select containers to be created

see https://github.com/docker/compose/issues/11619#issuecomment-2047995758 for context