### PR TITLE
Fix env parsing panics

### DIFF
--- a/override/uncity.go
+++ b/override/uncity.go
@@ -198,12 +198,15 @@ func portIndexer(y any, p tree.Path) (string, error) {
 	return "", nil
 }
 
-func envFileIndexer(y any, _ tree.Path) (string, error) {
+func envFileIndexer(y any, p tree.Path) (string, error) {
 	switch value := y.(type) {
 	case string:
 		return value, nil
 	case map[string]any:
-		return value["path"].(string), nil
+		if pathValue, ok := value["path"]; ok {
+			return pathValue.(string), nil
+		}
+		return "", fmt.Errorf("environment path attribut %s is missing", p)
 	}
 	return "", nil
 }

--- a/types/stringOrList.go
+++ b/types/stringOrList.go
@@ -28,7 +28,11 @@ func (l *StringList) DecodeMapstructure(value interface{}) error {
 	case []interface{}:
 		list := make([]string, len(v))
 		for i, e := range v {
-			list[i] = e.(string)
+			val, ok := e.(string)
+			if !ok {
+				return fmt.Errorf("invalid type %T for string list", value)
+			}
+			list[i] = val
 		}
 		*l = list
 	default:


### PR DESCRIPTION
Return errors instead of trigger panic when asserting types.

Fixes https://github.com/docker/compose/issues/11772 and https://github.com/docker/compose/issues/11771 