### PR TITLE
Always set COMPOSE_PROJECT_NAME

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -329,17 +329,9 @@ func loadModelWithContext(ctx context.Context, configDetails *types.ConfigDetail
 		return nil, errors.New("No files specified")
 	}
 
-	err := projectName(*configDetails, opts)
+	err := projectName(configDetails, opts)
 	if err != nil {
 		return nil, err
-	}
-
-	// TODO(milas): this should probably ALWAYS set (overriding any existing)
-	if _, ok := configDetails.Environment[consts.ComposeProjectName]; !ok && opts.projectName != "" {
-		if configDetails.Environment == nil {
-			configDetails.Environment = map[string]string{}
-		}
-		configDetails.Environment[consts.ComposeProjectName] = opts.projectName
 	}
 
 	return load(ctx, *configDetails, opts, nil)
@@ -601,10 +593,14 @@ func InvalidProjectNameErr(v string) error {
 // projectName determines the canonical name to use for the project considering
 // the loader Options as well as `name` fields in Compose YAML fields (which
 // also support interpolation).
-//
-// TODO(milas): restructure loading so that we don't need to re-parse the YAML
-// here, as it's both wasteful and makes this code error-prone.
-func projectName(details types.ConfigDetails, opts *Options) error {
+func projectName(details *types.ConfigDetails, opts *Options) error {
+	defer func() {
+		if details.Environment == nil {
+			details.Environment = map[string]string{}
+		}
+		details.Environment[consts.ComposeProjectName] = opts.projectName
+	}()
+
 	if opts.projectNameImperativelySet {
 		if NormalizeProjectName(opts.projectName) != opts.projectName {
 			return InvalidProjectNameErr(opts.projectName)

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2376,20 +2376,21 @@ services:
 		assert.Equal(t, "overrided-proxy", svc.ContainerName)
 	})
 
-	t.Run("project name env variable interpolation", func(t *testing.T) {
+	t.Run("project name override", func(t *testing.T) {
 		yaml := `
-name: interpolated
+name: another_name
 services:
   web:
     image: web
     container_name: ${COMPOSE_PROJECT_NAME}-web
 `
-		configDetails := buildConfigDetails(yaml, map[string]string{"COMPOSE_PROJECT_NAME": "env-var"})
-		actual, err := LoadWithContext(context.TODO(), configDetails)
+		configDetails := buildConfigDetails(yaml, map[string]string{})
+
+		actual, err := Load(configDetails, withProjectName("interpolated", true))
 		assert.NilError(t, err)
 		svc, err := actual.GetService("web")
 		assert.NilError(t, err)
-		assert.Equal(t, "env-var-web", svc.ContainerName)
+		assert.Equal(t, "interpolated-web", svc.ContainerName)
 	})
 }
 


### PR DESCRIPTION
Always set COMPOSE_PROJECT_NAME based on project name being computed from various options.
This enforce COMPOSE_PROJECT_NAME interpolation always get the expected value

fixes https://github.com/docker/compose/issues/11734