### PR TITLE
Add option to keep empty environment variable keys in normalization

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -67,6 +67,8 @@ type Options struct {
 	SkipResolveEnvironment bool
 	// SkipDefaultValues will ignore missing required attributes
 	SkipDefaultValues bool
+	// KeepEmptyEnvironment will keep empty environment variable keys in the environment section
+	KeepEmptyEnvironment bool
 	// Interpolation options
 	Interpolate *interp.Options
 	// Discard 'env_file' entries after resolving to 'environment' section
@@ -519,7 +521,7 @@ func load(ctx context.Context, configDetails types.ConfigDetails, opts *Options,
 
 	if !opts.SkipNormalization {
 		dict["name"] = opts.projectName
-		dict, err = Normalize(dict, configDetails.Environment)
+		dict, err = Normalize(dict, configDetails.Environment, opts)
 		if err != nil {
 			return nil, err
 		}

--- a/loader/normalize.go
+++ b/loader/normalize.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Normalize compose project by moving deprecated attributes to their canonical position and injecting implicit defaults
-func Normalize(dict map[string]any, env types.Mapping) (map[string]any, error) {
+func Normalize(dict map[string]any, env types.Mapping, opts *Options) (map[string]any, error) {
 	normalizeNetworks(dict)
 
 	if d, ok := dict["services"]; ok {
@@ -52,14 +52,14 @@ func Normalize(dict map[string]any, env types.Mapping) (map[string]any, error) {
 				}
 
 				if a, ok := build["args"]; ok {
-					build["args"], _ = resolve(a, fn)
+					build["args"], _ = resolve(a, fn, false)
 				}
 
 				service["build"] = build
 			}
 
 			if e, ok := service["environment"]; ok {
-				service["environment"], _ = resolve(e, fn)
+				service["environment"], _ = resolve(e, fn, opts.KeepEmptyEnvironment)
 			}
 
 			var dependsOn map[string]any
@@ -178,12 +178,12 @@ func normalizeNetworks(dict map[string]any) {
 	}
 }
 
-func resolve(a any, fn func(s string) (string, bool)) (any, bool) {
+func resolve(a any, fn func(s string) (string, bool), keepEmpty bool) (any, bool) {
 	switch v := a.(type) {
 	case []any:
 		var resolved []any
 		for _, val := range v {
-			if r, ok := resolve(val, fn); ok {
+			if r, ok := resolve(val, fn, keepEmpty); ok {
 				resolved = append(resolved, r)
 			}
 		}
@@ -204,6 +204,9 @@ func resolve(a any, fn func(s string) (string, bool)) (any, bool) {
 		if !strings.Contains(v, "=") {
 			if val, ok := fn(v); ok {
 				return fmt.Sprintf("%s=%s", v, val), true
+			}
+			if keepEmpty {
+				return v, true
 			}
 			return "", false
 		}


### PR DESCRIPTION
In #589, the normalisation logic strips off any environment variables that does not have a value in config, however, i my use case, I am still interested in any empty environment variables names that has been set, which i'll resolve the value at a later stage, so I am implementing an naive option to allow me keep them during normalisation, please let me know if there is a better way of doing it. Currently, I have to load the project twice, use the one without normalisation to detect those empty environment variables.