### PR TITLE
go.mod: migrate to github.com/go-viper/mapstructure/v2 v2.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/distribution/reference v0.5.0
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0
+	github.com/go-viper/mapstructure/v2 v2.0.0
 	github.com/google/go-cmp v0.5.9
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/copystructure v1.2.0
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/go-viper/mapstructure/v2 v2.0.0 h1:dhn8MZ1gZ0mzeodTG3jt5Vj/o87xZKuNAprG2mQfMfc=
+github.com/go-viper/mapstructure/v2 v2.0.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -14,8 +16,6 @@ github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebG
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
-github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -39,7 +39,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/tree"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/compose-spec/compose-go/v2/validation"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"

--- a/loader/mapstructure_test.go
+++ b/loader/mapstructure_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"gotest.tools/v3/assert"
 )
 

--- a/parsing.md
+++ b/parsing.md
@@ -161,7 +161,7 @@ volumes:
 # Phase 15: go binding
 
 Eventually, the yaml tree can be unmarshalled into go structs. We rely on
-[mapstructure](https://github.com/mitchellh/mapstructure) library for this purpose.
+[mapstructure](https://github.com/go-viper/mapstructure/) library for this purpose.
 Decoder is configured so that custom decode function can be defined by target type, 
 allowing type conversions. For example, byte units (`640k`) and durations set in yaml
 as plain string are actually modeled in go types as `int64`.

--- a/transform/ports.go
+++ b/transform/ports.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/tree"
 	"github.com/compose-spec/compose-go/v2/types"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 func transformPorts(data any, p tree.Path, ignoreParseError bool) (any, error) {

--- a/types/config.go
+++ b/types/config.go
@@ -21,7 +21,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 var (


### PR DESCRIPTION
- relates to https://github.com/mitchellh/mapstructure/issues/349
- relates to https://github.com/docker/cli/pull/4744


github.com/mitchellh/mapstructure will no longer be maintained by the author, and github.com/go-viper/mapstructure is nominated as the endorsed fork.

- v1.x changes since last release from mitchellh: https://github.com/go-viper/mapstructure/compare/v1.5.0...v1.6.0
- v2.0 changes: https://github.com/go-viper/mapstructure/compare/v1.6.0...v2.0.0

Breaking changes

Error is removed in favor of errors.Join (backported from Go 1.20 to preserve compatibility with earlier versions)

What's Changed

- feat!: update module path
- build: update dev env
- feature: add StringToBasicTypeHookFunc and support complex
- Add an example showing how to use a DecodeHookFunc to parse a custom field.
- Remove exposed error type
- Replace internal joined error with errors.Join