### PR TITLE
networks.enable_ipv6: make it optional

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1689,6 +1689,7 @@ networks:
 
 	workingDir, err := os.Getwd()
 	assert.NilError(t, err)
+	enableIPv6 := true
 	expected := &types.Project{
 		Name:       "load-network-link-local-ips",
 		WorkingDir: workingDir,
@@ -1711,7 +1712,7 @@ networks:
 			"network1": {
 				Name:       "network1",
 				Driver:     "bridge",
-				EnableIPv6: true,
+				EnableIPv6: &enableIPv6,
 				Ipam: types.IPAMConfig{
 					Config: []*types.IPAMPool{
 						{Subnet: "10.1.0.0/16"},

--- a/types/types.go
+++ b/types/types.go
@@ -698,7 +698,7 @@ type NetworkConfig struct {
 	Internal   bool       `yaml:"internal,omitempty" json:"internal,omitempty"`
 	Attachable bool       `yaml:"attachable,omitempty" json:"attachable,omitempty"`
 	Labels     Labels     `yaml:"labels,omitempty" json:"labels,omitempty"`
-	EnableIPv6 bool       `yaml:"enable_ipv6,omitempty" json:"enable_ipv6,omitempty"`
+	EnableIPv6 *bool      `yaml:"enable_ipv6,omitempty" json:"enable_ipv6,omitempty"`
 	Extensions Extensions `yaml:"#extensions,inline,omitempty" json:"-"`
 }
 


### PR DESCRIPTION
This field isn't marked as required in the compose-spec, but it's implemented as a basic `bool` in this package. This means it automatically defaults to `false` when not specified.

A recent change was made to Docker Engine to allow users to define a daemon-wide default value for the equivalent API field. Without this change, Compose would always send a value to the Engine API, preventing it from defining its own default value.

See https://github.com/moby/moby/pull/47867.