### PR TITLE
feat(loader): made interpolation after merge

### DIFF
--- a/interpolation/interpolation.go
+++ b/interpolation/interpolation.go
@@ -33,8 +33,8 @@ type Options struct {
 	TypeCastMapping map[tree.Path]Cast
 	// Substitution function to use
 	Substitute func(string, template.Mapping) (string, error)
-	// Keys to interpolate, if nil all keys are interpolated
-	KeysToInterpolate []string
+	// Paths to interpolate, if nil all paths are interpolated
+	PathsToInterpolate []tree.Path
 }
 
 // LookupValue is a function which maps from variable names to values.
@@ -74,7 +74,7 @@ func Interpolate(config map[string]interface{}, opts Options) (map[string]interf
 func recursiveInterpolate(value interface{}, path tree.Path, opts Options) (interface{}, error) {
 	switch value := value.(type) {
 	case string:
-		if !shouldInterpolate(path, opts.KeysToInterpolate) {
+		if !path.MatchesAny(opts.PathsToInterpolate) {
 			return value, nil
 		}
 
@@ -117,20 +117,6 @@ func recursiveInterpolate(value interface{}, path tree.Path, opts Options) (inte
 	default:
 		return value, nil
 	}
-}
-
-func shouldInterpolate(path tree.Path, keysToInterpolate []string) bool {
-	if keysToInterpolate == nil {
-		return true
-	}
-
-	for _, key := range keysToInterpolate {
-		if path.ContainsPart(key) {
-			return true
-		}
-	}
-
-	return false
 }
 
 func newPathError(path tree.Path, err error) error {

--- a/interpolation/interpolation.go
+++ b/interpolation/interpolation.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"slices"
 
 	"github.com/compose-spec/compose-go/v2/template"
 	"github.com/compose-spec/compose-go/v2/tree"
@@ -121,7 +120,17 @@ func recursiveInterpolate(value interface{}, path tree.Path, opts Options) (inte
 }
 
 func shouldInterpolate(path tree.Path, keysToInterpolate []string) bool {
-	return keysToInterpolate == nil || slices.Contains(keysToInterpolate, path.Last())
+	if keysToInterpolate == nil {
+		return true
+	}
+
+	for _, key := range keysToInterpolate {
+		if path.ContainsPart(key) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func newPathError(path tree.Path, err error) error {

--- a/interpolation/interpolation_test.go
+++ b/interpolation/interpolation_test.go
@@ -67,6 +67,41 @@ func TestInterpolate(t *testing.T) {
 	assert.Check(t, is.DeepEqual(expected, result))
 }
 
+func TestInterpolateWithKeysToInterpolate(t *testing.T) {
+	services := map[string]interface{}{
+		"servicea": map[string]interface{}{
+			"image":   "example:${USER}",
+			"volumes": []interface{}{"$FOO:/target"},
+			"logging": map[string]interface{}{
+				"driver": "${FOO}",
+				"options": map[string]interface{}{
+					"user": "$USER",
+				},
+			},
+		},
+	}
+	expected := map[string]interface{}{
+		"servicea": map[string]interface{}{
+			"image":   "example:${USER}",
+			"volumes": []interface{}{"bar:/target"},
+			"logging": map[string]interface{}{
+				"driver": "${FOO}",
+				"options": map[string]interface{}{
+					"user": "jenny",
+				},
+			},
+		},
+	}
+	result, err := Interpolate(
+		services, Options{
+			LookupValue:       defaultMapping,
+			KeysToInterpolate: []string{"volumes", "user"},
+		},
+	)
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(expected, result))
+}
+
 func TestInvalidInterpolation(t *testing.T) {
 	services := map[string]interface{}{
 		"servicea": map[string]interface{}{

--- a/interpolation/interpolation_test.go
+++ b/interpolation/interpolation_test.go
@@ -69,7 +69,7 @@ func TestInterpolate(t *testing.T) {
 
 func TestInterpolateWithKeysToInterpolate(t *testing.T) {
 	services := map[string]interface{}{
-		"servicea": map[string]interface{}{
+		"services": map[string]interface{}{
 			"image":   "example:${USER}",
 			"volumes": []interface{}{"$FOO:/target"},
 			"logging": map[string]interface{}{
@@ -81,11 +81,11 @@ func TestInterpolateWithKeysToInterpolate(t *testing.T) {
 		},
 	}
 	expected := map[string]interface{}{
-		"servicea": map[string]interface{}{
+		"services": map[string]interface{}{
 			"image":   "example:${USER}",
-			"volumes": []interface{}{"bar:/target"},
+			"volumes": []interface{}{"$FOO:/target"},
 			"logging": map[string]interface{}{
-				"driver": "${FOO}",
+				"driver": "bar",
 				"options": map[string]interface{}{
 					"user": "jenny",
 				},
@@ -94,8 +94,11 @@ func TestInterpolateWithKeysToInterpolate(t *testing.T) {
 	}
 	result, err := Interpolate(
 		services, Options{
-			LookupValue:       defaultMapping,
-			KeysToInterpolate: []string{"volumes", "user"},
+			LookupValue: defaultMapping,
+			PathsToInterpolate: []tree.Path{
+				tree.NewPath("services.**.driver"),
+				tree.NewPath("services.logging.**.user"),
+			},
 		},
 	)
 	assert.NilError(t, err)

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -362,7 +362,10 @@ func loadYamlModel(ctx context.Context, config types.ConfigDetails, opts *Option
 
 	if opts.Interpolate != nil && !opts.SkipInterpolation {
 		interpolateOptsBeforeMerge = opts.Interpolate.Clone()
-		interpolateOptsBeforeMerge.KeysToInterpolate = []string{"include", "extends"}
+		interpolateOptsBeforeMerge.PathsToInterpolate = []tree.Path{
+			tree.NewPath("services", tree.PathMatchAll, "extends", tree.PathMatchAnything),
+			tree.NewPath("include", tree.PathMatchAnything),
+		}
 	}
 	for _, file := range config.ConfigFiles {
 		fctx := context.WithValue(ctx, consts.ComposeFileKey{}, file.Filename)

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -378,13 +378,6 @@ func loadYamlModel(ctx context.Context, config types.ConfigDetails, opts *Option
 				return errors.New("Top-level object must be a mapping")
 			}
 
-			if opts.Interpolate != nil && !opts.SkipInterpolation {
-				cfg, err = interp.Interpolate(cfg, *opts.Interpolate)
-				if err != nil {
-					return err
-				}
-			}
-
 			fixEmptyNotNull(cfg)
 
 			if !opts.SkipExtends {
@@ -419,9 +412,6 @@ func loadYamlModel(ctx context.Context, config types.ConfigDetails, opts *Option
 			}
 
 			if !opts.SkipValidation {
-				if err := schema.Validate(dict); err != nil {
-					return fmt.Errorf("validating %s: %w", file.Filename, err)
-				}
 				if _, ok := dict["version"]; ok {
 					opts.warnObsoleteVersion(file.Filename)
 					delete(dict, "version")
@@ -452,6 +442,19 @@ func loadYamlModel(ctx context.Context, config types.ConfigDetails, opts *Option
 			if err := processRawYaml(file.Config); err != nil {
 				return nil, err
 			}
+		}
+	}
+
+	if opts.Interpolate != nil && !opts.SkipInterpolation {
+		dict, err = interp.Interpolate(dict, *opts.Interpolate)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if !opts.SkipValidation {
+		if err := schema.Validate(dict); err != nil {
+			return nil, fmt.Errorf("validating: %w", err)
 		}
 	}
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -424,6 +424,16 @@ func loadYamlModel(ctx context.Context, config types.ConfigDetails, opts *Option
 				return err
 			}
 
+			if !opts.SkipValidation {
+				if err := schema.Validate(dict); err != nil {
+					return fmt.Errorf("validating %s: %w", file.Filename, err)
+				}
+				if _, ok := dict["version"]; ok {
+					opts.warnObsoleteVersion(file.Filename)
+					delete(dict, "version")
+				}
+			}
+
 			return err
 		}
 

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2476,7 +2476,7 @@ func TestDeviceWriteBps(t *testing.T) {
 
 func TestInvalidProjectNameType(t *testing.T) {
 	p, err := loadYAML(`name: 123`)
-	assert.Error(t, err, "validating filename0.yml: name must be a string")
+	assert.Error(t, err, "validating: name must be a string")
 	assert.Assert(t, is.Nil(p))
 }
 
@@ -2951,7 +2951,7 @@ services:
 `, nil), func(options *Options) {
 		options.ResolvePaths = false
 	})
-	assert.ErrorContains(t, err, "validating filename0.yml: services.frontend.develop.watch.0 action is required")
+	assert.ErrorContains(t, err, "validating: services.frontend.develop.watch.0 action is required")
 }
 
 func TestBadServiceConfig(t *testing.T) {

--- a/loader/loader_yaml_test.go
+++ b/loader/loader_yaml_test.go
@@ -56,6 +56,46 @@ services:
 	})
 }
 
+func TestParseYAMLFilesInterpolateAfterMerge(t *testing.T) {
+	model, err := loadYamlModel(
+		context.TODO(), types.ConfigDetails{
+			ConfigFiles: []types.ConfigFile{
+				{
+					Filename: "test.yaml",
+					Content: []byte(`
+services:
+  test:
+    image: foo
+    environment:
+      my_env: ${my_env?my_env must be set}
+`),
+				},
+				{
+					Filename: "override.yaml",
+					Content: []byte(`
+services:
+  test:
+    image: bar
+    environment:
+      my_env: ${my_env:-default}
+`),
+				},
+			},
+		}, &Options{}, &cycleTracker{}, nil,
+	)
+	assert.NilError(t, err)
+	assert.DeepEqual(
+		t, model, map[string]interface{}{
+			"services": map[string]interface{}{
+				"test": map[string]interface{}{
+					"image":       "bar",
+					"environment": []any{"my_env=${my_env:-default}"},
+				},
+			},
+		},
+	)
+}
+
 func TestParseYAMLFilesMergeOverride(t *testing.T) {
 	model, err := loadYamlModel(context.TODO(), types.ConfigDetails{
 		ConfigFiles: []types.ConfigFile{

--- a/tree/path.go
+++ b/tree/path.go
@@ -51,6 +51,16 @@ func (p Path) Parts() []string {
 	return strings.Split(string(p), pathSeparator)
 }
 
+func (p Path) ContainsPart(part string) bool {
+	parts := p.Parts()
+	for _, p := range parts {
+		if p == part {
+			return true
+		}
+	}
+	return false
+}
+
 func (p Path) Matches(pattern Path) bool {
 	patternParts := pattern.Parts()
 	parts := p.Parts()

--- a/tree/path.go
+++ b/tree/path.go
@@ -61,28 +61,33 @@ func (p Path) Matches(pattern Path) bool {
 	patternParts := pattern.Parts()
 	parts := p.Parts()
 
-	shouldMatchAnything := false
 	patternIdx := 0
-	for _, part := range parts {
+	for i := 0; i < len(parts); i++ {
 		if patternIdx >= len(patternParts) {
-			return shouldMatchAnything
+			return false
 		}
 		switch patternParts[patternIdx] {
-		case part:
-			shouldMatchAnything = false
+		case parts[i]:
 			patternIdx++
 			continue
 		case PathMatchAll:
 			patternIdx++
 			continue
 		case PathMatchAnything:
-			shouldMatchAnything = true
-			patternIdx++
+			// If this is the last pattern part, it should match any remaining parts in 'parts'
+			if patternIdx == len(patternParts)-1 {
+				return true
+			}
+			// Otherwise, we need to find the next matching part in 'parts'
+			for j := i; j < len(parts); j++ {
+				if parts[j] == patternParts[patternIdx+1] {
+					i = j // Jump 'i' to the matching part in 'parts'
+					patternIdx += 2
+					break
+				}
+			}
 			continue
 		default:
-			if shouldMatchAnything {
-				continue
-			}
 			return false
 		}
 	}

--- a/tree/path_test.go
+++ b/tree/path_test.go
@@ -97,3 +97,81 @@ func TestPathMatches(t *testing.T) {
 		assert.Assert(t, is.Equal(testcase.expected, testcase.path.Matches(testcase.pattern)), testcase.doc)
 	}
 }
+
+func TestPathMatchesAny(t *testing.T) {
+	var testcases = []struct {
+		doc      string
+		path     Path
+		patterns []Path
+		expected bool
+	}{
+		{
+			doc:      "empty patterns slice should return true",
+			path:     NewPath("one", "two", "three"),
+			patterns: nil,
+			expected: true,
+		},
+		{
+			doc:      "match with one pattern containing *",
+			path:     NewPath("one", "two", "three"),
+			patterns: []Path{NewPath("one", "*", "three")},
+			expected: true,
+		},
+		{
+			doc:      "match with multiple patterns including",
+			path:     NewPath("one", "two", "three"),
+			patterns: []Path{NewPath("one", "*", "three"), NewPath("one", "two", "four"), NewPath("**", "two", "four")},
+			expected: true,
+		},
+		{
+			doc:      "match with ** at the beginning",
+			path:     NewPath("one", "two", "three"),
+			patterns: []Path{NewPath("**", "three")},
+			expected: true,
+		},
+		{
+			doc:      "match with ** in the middle",
+			path:     NewPath("one", "two", "three", "four"),
+			patterns: []Path{NewPath("one", "**", "four")},
+			expected: true,
+		},
+		{
+			doc:      "match with ** at the end",
+			path:     NewPath("one", "two", "three", "four", "five", "six"),
+			patterns: []Path{NewPath("one", "two", "three", "**")},
+			expected: true,
+		},
+		{
+			doc:  "no match with any pattern",
+			path: NewPath("one", "two", "three"),
+			patterns: []Path{
+				NewPath("one", "four", "three"),
+				NewPath("not one", "**", "three"),
+				NewPath("not one", "**", "three"),
+			},
+			expected: false,
+		},
+		{
+			doc:      "empty path should not match any non-empty pattern",
+			path:     NewPath(""),
+			patterns: []Path{NewPath("one")},
+			expected: false,
+		},
+		{
+			doc:      "empty path should match empty pattern",
+			path:     NewPath(""),
+			patterns: []Path{NewPath("")},
+			expected: true,
+		},
+		{
+			doc:      "empty pattern should match empty path",
+			path:     NewPath(""),
+			patterns: []Path{NewPath("")},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		assert.Equal(t, tc.expected, tc.path.MatchesAny(tc.patterns), tc.doc)
+	}
+}

--- a/tree/path_test.go
+++ b/tree/path_test.go
@@ -67,3 +67,70 @@ func TestPathMatches(t *testing.T) {
 		assert.Check(t, is.Equal(testcase.expected, testcase.path.Matches(testcase.pattern)))
 	}
 }
+
+func TestPathContainsPart(t *testing.T) {
+	var testcases = []struct {
+		doc      string
+		path     Path
+		part     string
+		expected bool
+	}{
+		{
+			doc:      "empty pattern",
+			path:     NewPath(),
+			part:     "one",
+			expected: false,
+		},
+		{
+			doc:      "path does not contain part",
+			path:     NewPath("one", "two", "three"),
+			part:     "four",
+			expected: false,
+		},
+		{
+			doc:      "part is empty",
+			path:     NewPath("one", "two", "three"),
+			part:     "",
+			expected: false,
+		},
+		{
+			doc:      "part partially matches",
+			path:     NewPath("one", "two", "three"),
+			part:     "on",
+			expected: false,
+		},
+		{
+			doc:      "part partially matches 2",
+			path:     NewPath("one", "two", "three"),
+			part:     "onet",
+			expected: false,
+		},
+		{
+			doc:      "equals",
+			path:     NewPath("one"),
+			part:     "one",
+			expected: true,
+		},
+		{
+			doc:      "path starts with part",
+			path:     NewPath("one", "two"),
+			part:     "one",
+			expected: true,
+		},
+		{
+			doc:      "path ends with part",
+			path:     NewPath("something", "one"),
+			part:     "one",
+			expected: true,
+		},
+		{
+			doc:      "part in the middle of the path",
+			path:     NewPath("one", "two", "three"),
+			part:     "two",
+			expected: true,
+		},
+	}
+	for _, testcase := range testcases {
+		assert.Check(t, is.Equal(testcase.expected, testcase.path.ContainsPart(testcase.part)))
+	}
+}

--- a/tree/path_test.go
+++ b/tree/path_test.go
@@ -62,75 +62,38 @@ func TestPathMatches(t *testing.T) {
 			pattern:  NewPath("one", "two", "three"),
 			expected: true,
 		},
-	}
-	for _, testcase := range testcases {
-		assert.Check(t, is.Equal(testcase.expected, testcase.path.Matches(testcase.pattern)))
-	}
-}
-
-func TestPathContainsPart(t *testing.T) {
-	var testcases = []struct {
-		doc      string
-		path     Path
-		part     string
-		expected bool
-	}{
 		{
-			doc:      "empty pattern",
-			path:     NewPath(),
-			part:     "one",
-			expected: false,
-		},
-		{
-			doc:      "path does not contain part",
+			doc:      "any at the beginning",
 			path:     NewPath("one", "two", "three"),
-			part:     "four",
-			expected: false,
-		},
-		{
-			doc:      "part is empty",
-			path:     NewPath("one", "two", "three"),
-			part:     "",
-			expected: false,
-		},
-		{
-			doc:      "part partially matches",
-			path:     NewPath("one", "two", "three"),
-			part:     "on",
-			expected: false,
-		},
-		{
-			doc:      "part partially matches 2",
-			path:     NewPath("one", "two", "three"),
-			part:     "onet",
-			expected: false,
-		},
-		{
-			doc:      "equals",
-			path:     NewPath("one"),
-			part:     "one",
+			pattern:  NewPath("**", "three"),
 			expected: true,
 		},
 		{
-			doc:      "path starts with part",
-			path:     NewPath("one", "two"),
-			part:     "one",
-			expected: true,
-		},
-		{
-			doc:      "path ends with part",
-			path:     NewPath("something", "one"),
-			part:     "one",
-			expected: true,
-		},
-		{
-			doc:      "part in the middle of the path",
+			doc:      "any at the beginning followed by a wrong part",
 			path:     NewPath("one", "two", "three"),
-			part:     "two",
+			pattern:  NewPath("**", "four"),
+			expected: false,
+		},
+		{
+			doc:      "any in the middle",
+			path:     NewPath("one", "two", "three", "four"),
+			pattern:  NewPath("one", "**", "four"),
+			expected: true,
+		},
+		{
+			doc:      "any in the middle followed by a wrong part",
+			path:     NewPath("one", "two", "three", "four"),
+			pattern:  NewPath("one", "**", "five"),
+			expected: false,
+		},
+		{
+			doc:      "any at the end",
+			path:     NewPath("one", "two", "three", "four", "five", "six"),
+			pattern:  NewPath("one", "two", "three", "**"),
 			expected: true,
 		},
 	}
 	for _, testcase := range testcases {
-		assert.Check(t, is.Equal(testcase.expected, testcase.path.ContainsPart(testcase.part)))
+		assert.Assert(t, is.Equal(testcase.expected, testcase.path.Matches(testcase.pattern)), testcase.doc)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Changed interpolation order, it used to interpolate for each config file separately, but now it interpolates after merge.  
To be honest, I'm not sure it's a good idea, maybe it'll be better to add an option to control it, like `--interpolate-after-merge`


**Which issue(s) this PR fixes**:
Fixes https://github.com/docker/compose/issues/11925

