### PR TITLE
fix(extends): fix extends related logs

### DIFF
--- a/loader/extends.go
+++ b/loader/extends.go
@@ -128,7 +128,13 @@ func applyServiceExtends(ctx context.Context, name string, services map[string]a
 	return merged, nil
 }
 
-func getExtendsBaseFromFile(ctx context.Context, 	name, ref string, path, refPath string, opts *Options, ct *cycleTracker) (map[string]any, PostProcessor, error) {
+func getExtendsBaseFromFile(
+	ctx context.Context,
+	name, ref string,
+	path, refPath string,
+	opts *Options,
+	ct *cycleTracker,
+) (map[string]any, PostProcessor, error) {
 	for _, loader := range opts.ResourceLoaders {
 		if !loader.Accept(refPath) {
 			continue


### PR DESCRIPTION
Fixes https://github.com/docker/compose/issues/11571

It used to output wrong data if you extends from file and not full data if you want to use service in current file, new outputs:
_local service_:  
**before**: 
`cannot extend service "known" in /Users/main/Development/idsulik/compose/tmp/docker-compose.yaml: service not found`
**after**: 
`cannot extend service "known" in /Users/main/Development/*/compose/tmp/docker-compose.yaml: service "blah" not found`



_service from file_:
**before**:
`cannot extend service "blah" in in.yaml: service not found`
**after**:
`cannot extend service "known" in /Users/main/Development/*/compose/tmp/docker-compose.yaml: service "blah" not found in in.yaml`

**docker-compose-yaml**:
```
services:
  known:
    extends:
        file: in.yaml
        service: blah
    image: image
```