### PR TITLE
feat(options): Add WithUser to set current user id and group id

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -86,6 +86,11 @@ type ProjectOptions struct {
 
 type ProjectOptionsFn func(*ProjectOptions) error
 
+var (
+	getUid = os.Getuid
+	getGid = os.Getgid
+)
+
 // NewProjectOptions creates ProjectOptions
 func NewProjectOptions(configs []string, opts ...ProjectOptionsFn) (*ProjectOptions, error) {
 	options := &ProjectOptions{
@@ -242,6 +247,16 @@ func WithOsEnv(o *ProjectOptions) error {
 			continue
 		}
 		o.Environment[k] = v
+	}
+	return nil
+}
+
+func WithUserEnv(o *ProjectOptions) error {
+	if _, ok := o.Environment[consts.ComposeUserId]; !ok {
+		o.Environment[consts.ComposeUserId] = strconv.Itoa(getUid())
+	}
+	if _, ok := o.Environment[consts.ComposeGroupId]; !ok {
+		o.Environment[consts.ComposeGroupId] = strconv.Itoa(getGid())
 	}
 	return nil
 }

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -201,6 +201,39 @@ func TestProjectName(t *testing.T) {
 	})
 }
 
+/**
+func WithUserEnv(o *ProjectOptions) error {
+	if _, ok := o.Environment[consts.ComposeUserId]; !ok {
+		o.Environment[consts.ComposeUserId] = strconv.Itoa(os.Getuid())
+	}
+	if _, ok := o.Environment[consts.ComposeGroupId]; !ok {
+		o.Environment[consts.ComposeGroupId] = strconv.Itoa(os.Getgid())
+	}
+	return nil
+}
+*/
+
+func TestWithUserEnv(t *testing.T) {
+	opts, err := NewProjectOptions([]string{"testdata/simple/compose-with-user-variables.yaml"})
+	assert.NilError(t, err)
+
+	getUid = func() int { return 111 }
+	getGid = func() int { return 222 }
+
+	_ = WithUserEnv(opts)
+	assert.Equal(t, opts.Environment[consts.ComposeUserId], "111")
+	assert.Equal(t, opts.Environment[consts.ComposeGroupId], "222")
+
+	opts.Environment = map[string]string{
+		consts.ComposeUserId:  "333",
+		consts.ComposeGroupId: "444",
+	}
+	_ = WithUserEnv(opts)
+
+	assert.Equal(t, opts.Environment[consts.ComposeUserId], "333")
+	assert.Equal(t, opts.Environment[consts.ComposeGroupId], "444")
+}
+
 func TestProjectFromSetOfFiles(t *testing.T) {
 	opts, err := NewProjectOptions([]string{
 		"testdata/simple/compose.yaml",

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -22,6 +22,8 @@ const (
 	ComposeFilePath              = "COMPOSE_FILE"
 	ComposeDisableDefaultEnvFile = "COMPOSE_DISABLE_ENV_FILE"
 	ComposeProfiles              = "COMPOSE_PROFILES"
+	ComposeUserId                = "COMPOSE_USER_ID"
+	ComposeGroupId               = "COMPOSE_GROUP_ID"
 )
 
 const Extensions = "#extensions" // Using # prefix, we prevent risk to conflict with an actual yaml key


### PR DESCRIPTION
Issue https://github.com/docker/compose/issues/7853

Added `WithUserEnv` to support `COMPOSE_USER_ID` and `COMPOSE_GROUP_ID` env values in `compose.yaml`