### PR TITLE
Reset extends

### DIFF
--- a/loader/extends_test.go
+++ b/loader/extends_test.go
@@ -465,3 +465,22 @@ services:
 	assert.NilError(t, err)
 	assert.Equal(t, extendsCount, 2)
 }
+
+func TestExtendsReset(t *testing.T) {
+	yaml := `
+name: test-extends-reset
+services:
+  test:
+    extends:
+      file: testdata/extends/reset.yaml
+      service: base
+`
+	p, err := Load(types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{{
+			Content:  []byte(yaml),
+			Filename: "-",
+		}},
+	})
+	assert.NilError(t, err)
+	assert.Check(t, p.Services["test"].Command == nil)
+}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -358,112 +358,13 @@ func loadYamlModel(ctx context.Context, config types.ConfigDetails, opts *Option
 		dict = map[string]interface{}{}
 		err  error
 	)
+	workingDir, environment := config.WorkingDir, config.Environment
+
 	for _, file := range config.ConfigFiles {
-		fctx := context.WithValue(ctx, consts.ComposeFileKey{}, file.Filename)
-		if file.Content == nil && file.Config == nil {
-			content, err := os.ReadFile(file.Filename)
-			if err != nil {
-				return nil, err
-			}
-			file.Content = content
+		dict, _, err = loadYamlFile(ctx, file, opts, workingDir, environment, ct, dict, included)
+		if err != nil {
+			return nil, err
 		}
-
-		processRawYaml := func(raw interface{}, processors ...PostProcessor) error {
-			converted, err := convertToStringKeysRecursive(raw, "")
-			if err != nil {
-				return err
-			}
-			cfg, ok := converted.(map[string]interface{})
-			if !ok {
-				return errors.New("Top-level object must be a mapping")
-			}
-
-			if opts.Interpolate != nil && !opts.SkipInterpolation {
-				cfg, err = interp.Interpolate(cfg, *opts.Interpolate)
-				if err != nil {
-					return err
-				}
-			}
-
-			fixEmptyNotNull(cfg)
-
-			if !opts.SkipExtends {
-				err = ApplyExtends(fctx, cfg, opts, ct, processors...)
-				if err != nil {
-					return err
-				}
-			}
-
-			for _, processor := range processors {
-				if err := processor.Apply(dict); err != nil {
-					return err
-				}
-			}
-
-			if !opts.SkipInclude {
-				included = append(included, config.ConfigFiles[0].Filename)
-				err = ApplyInclude(ctx, config, cfg, opts, included)
-				if err != nil {
-					return err
-				}
-			}
-
-			dict, err = override.Merge(dict, cfg)
-			if err != nil {
-				return err
-			}
-
-			dict, err = override.EnforceUnicity(dict)
-			if err != nil {
-				return err
-			}
-
-			if !opts.SkipValidation {
-				if err := schema.Validate(dict); err != nil {
-					return fmt.Errorf("validating %s: %w", file.Filename, err)
-				}
-				if _, ok := dict["version"]; ok {
-					opts.warnObsoleteVersion(file.Filename)
-					delete(dict, "version")
-				}
-			}
-
-			return err
-		}
-
-		if file.Config == nil {
-			r := bytes.NewReader(file.Content)
-			decoder := yaml.NewDecoder(r)
-			for {
-				var raw interface{}
-				processor := &ResetProcessor{target: &raw}
-				err := decoder.Decode(processor)
-				if err != nil && errors.Is(err, io.EOF) {
-					break
-				}
-				if err != nil {
-					return nil, err
-				}
-				if err := processRawYaml(raw, processor); err != nil {
-					return nil, err
-				}
-			}
-		} else {
-			if err := processRawYaml(file.Config); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	dict, err = transform.Canonical(dict, opts.SkipInterpolation)
-	if err != nil {
-		return nil, err
-	}
-
-	// Canonical transformation can reveal duplicates, typically as ports can be a range and conflict with an override
-	dict, err = override.EnforceUnicity(dict)
-	if err != nil {
-		return nil, err
 	}
 
 	if !opts.SkipDefaultValues {
@@ -492,6 +393,113 @@ func loadYamlModel(ctx context.Context, config types.ConfigDetails, opts *Option
 	resolveServicesEnvironment(dict, config)
 
 	return dict, nil
+}
+
+func loadYamlFile(ctx context.Context, file types.ConfigFile, opts *Options, workingDir string, environment types.Mapping, ct *cycleTracker, dict map[string]interface{}, included []string) (map[string]interface{}, PostProcessor, error) {
+	ctx = context.WithValue(ctx, consts.ComposeFileKey{}, file.Filename)
+	if file.Content == nil && file.Config == nil {
+		content, err := os.ReadFile(file.Filename)
+		if err != nil {
+			return nil, nil, err
+		}
+		file.Content = content
+	}
+
+	processRawYaml := func(raw interface{}, processors ...PostProcessor) error {
+		converted, err := convertToStringKeysRecursive(raw, "")
+		if err != nil {
+			return err
+		}
+		cfg, ok := converted.(map[string]interface{})
+		if !ok {
+			return errors.New("Top-level object must be a mapping")
+		}
+
+		if opts.Interpolate != nil && !opts.SkipInterpolation {
+			cfg, err = interp.Interpolate(cfg, *opts.Interpolate)
+			if err != nil {
+				return err
+			}
+		}
+
+		fixEmptyNotNull(cfg)
+
+		if !opts.SkipExtends {
+			err = ApplyExtends(ctx, cfg, opts, ct, processors...)
+			if err != nil {
+				return err
+			}
+		}
+
+		for _, processor := range processors {
+			if err := processor.Apply(dict); err != nil {
+				return err
+			}
+		}
+
+		if !opts.SkipInclude {
+			included = append(included, file.Filename)
+			err = ApplyInclude(ctx, workingDir, environment, cfg, opts, included)
+			if err != nil {
+				return err
+			}
+		}
+
+		dict, err = override.Merge(dict, cfg)
+		if err != nil {
+			return err
+		}
+
+		dict, err = override.EnforceUnicity(dict)
+		if err != nil {
+			return err
+		}
+
+		if !opts.SkipValidation {
+			if err := schema.Validate(dict); err != nil {
+				return fmt.Errorf("validating %s: %w", file.Filename, err)
+			}
+			if _, ok := dict["version"]; ok {
+				opts.warnObsoleteVersion(file.Filename)
+				delete(dict, "version")
+			}
+		}
+
+		dict, err = transform.Canonical(dict, opts.SkipInterpolation)
+		if err != nil {
+			return err
+		}
+
+		// Canonical transformation can reveal duplicates, typically as ports can be a range and conflict with an override
+		dict, err = override.EnforceUnicity(dict)
+		return err
+	}
+
+	var processor PostProcessor
+	if file.Config == nil {
+		r := bytes.NewReader(file.Content)
+		decoder := yaml.NewDecoder(r)
+		for {
+			var raw interface{}
+			reset := &ResetProcessor{target: &raw}
+			err := decoder.Decode(reset)
+			if err != nil && errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				return nil, nil, err
+			}
+			processor = reset
+			if err := processRawYaml(raw, processor); err != nil {
+				return nil, nil, err
+			}
+		}
+	} else {
+		if err := processRawYaml(file.Config); err != nil {
+			return nil, nil, err
+		}
+	}
+	return dict, processor, nil
 }
 
 func load(ctx context.Context, configDetails types.ConfigDetails, opts *Options, loaded []string) (map[string]interface{}, error) {

--- a/loader/testdata/extends/reset.yaml
+++ b/loader/testdata/extends/reset.yaml
@@ -1,0 +1,7 @@
+services:
+  init:
+    image: alpine:latest
+    command: "sleep infinity"
+  base:
+    extends: { service: init }
+    command: !reset


### PR DESCRIPTION
This introduces `loadYamlFile` to load a single compose file, running _most_ of the processing. 
`!reset` tags collected by a post-processor is returned to caller. It is used when running the recursive extends processing outside the main loading-and-merge pipeline

fixes https://github.com/docker/compose/issues/11937