### PR TITLE
keep empty environment variables as those must be UNSET in container

### DIFF
--- a/loader/normalize_test.go
+++ b/loader/normalize_test.go
@@ -336,3 +336,43 @@ services:
 	assert.NilError(t, err)
 	assert.DeepEqual(t, expect, model)
 }
+
+func TestNormalizeEnvironment(t *testing.T) {
+	project := `
+name: myProject
+services:  
+  test: 
+    environment:
+      - FOO
+      - BAR
+      - ZOT=QIX
+`
+
+	expected := `
+name: myProject
+networks:
+  default:
+    name: myProject_default
+services:  
+  test: 
+    environment:
+      - FOO
+      - BAR=bar
+      - ZOT=QIX
+    networks:
+      default: null
+`
+	var model map[string]any
+	err := yaml.Unmarshal([]byte(project), &model)
+	assert.NilError(t, err)
+	model, err = Normalize(model, map[string]string{
+		"BAR": "bar",
+		"ZOT": "zot",
+	})
+	assert.NilError(t, err)
+
+	var expect map[string]any
+	err = yaml.Unmarshal([]byte(expected), &expect)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, expect, model)
+}


### PR DESCRIPTION
environment `FOO` with no value nor equal sign means "propagate value from user's environment, or unset variable"
So, as we resolve environment, empty value with no matching entry in user's environment MUST not result into removing entry from service definition.
Build args do not follow this rule. `--build-arg FOO` will propagate user's environment value, but if not set build arg will keep using value set by Dockerfile

fixes https://github.com/docker/compose/issues/11962
supersede https://github.com/compose-spec/compose-go/pull/634
see https://github.com/docker/compose/pull/11965