### PR TITLE
load secrets/configs from environment while parsing compose model

### DIFF
--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -588,6 +588,7 @@ func secrets(workingDir string) map[string]types.SecretConfig {
 		"secret4": {
 			Name:        "bar",
 			Environment: "BAR",
+			Content:     "this is a secret",
 			Extensions: map[string]interface{}{
 				"x-bar": "baz",
 				"x-foo": "bar",

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -407,7 +407,7 @@ func loadYamlModel(ctx context.Context, config types.ConfigDetails, opts *Option
 			return nil, err
 		}
 	}
-	resolveServicesEnvironment(dict, config)
+	ResolveEnvironment(dict, config.Environment)
 
 	return dict, nil
 }

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -3288,3 +3288,29 @@ services:
 	build := p.Services["test"].Build
 	assert.DeepEqual(t, build.Entitlements, []string{"network.host", "security.insecure"})
 }
+
+func TestLoadSecretEnvironment(t *testing.T) {
+	config, err := loadYAMLWithEnv(`
+name: load-secret-environment
+configs:
+  config:
+    environment: GA
+secrets:
+  secret:
+    environment: MEU
+`, map[string]string{
+		"GA":  "BU",
+		"MEU": "Shadoks",
+	})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, config.Configs, types.Configs{
+		"config": {
+			Environment: "GA",
+			Content:     "BU",
+		}})
+	assert.DeepEqual(t, config.Secrets, types.Secrets{
+		"secret": {
+			Environment: "MEU",
+			Content:     "Shadoks",
+		}})
+}

--- a/types/types.go
+++ b/types/types.go
@@ -782,8 +782,40 @@ type ExtendsConfig struct {
 // SecretConfig for a secret
 type SecretConfig FileObjectConfig
 
+// MarshalYAML makes SecretConfig implement yaml.Marshaller
+func (s SecretConfig) MarshalYAML() (interface{}, error) {
+	// secret content is set while loading model. Never marshall it
+	s.Content = ""
+	return FileObjectConfig(s), nil
+}
+
+// MarshalJSON makes SecretConfig implement json.Marshaller
+func (s SecretConfig) MarshalJSON() ([]byte, error) {
+	// secret content is set while loading model. Never marshall it
+	s.Content = ""
+	return json.Marshal(FileObjectConfig(s))
+}
+
 // ConfigObjConfig is the config for the swarm "Config" object
 type ConfigObjConfig FileObjectConfig
+
+// MarshalYAML makes ConfigObjConfig implement yaml.Marshaller
+func (s ConfigObjConfig) MarshalYAML() (interface{}, error) {
+	// config content may have been set from environment while loading model. Marshall actual source
+	if s.Environment != "" {
+		s.Content = ""
+	}
+	return FileObjectConfig(s), nil
+}
+
+// MarshalJSON makes ConfigObjConfig implement json.Marshaller
+func (s ConfigObjConfig) MarshalJSON() ([]byte, error) {
+	// config content may have been set from environment while loading model. Marshall actual source
+	if s.Environment != "" {
+		s.Content = ""
+	}
+	return json.Marshal(FileObjectConfig(s))
+}
 
 type IncludeConfig struct {
 	Path             StringList `yaml:"path,omitempty" json:"path,omitempty"`


### PR DESCRIPTION
As we load compose model with environment, resolve secrets and config values based on declared environment value. 
This allows a nested model loading (using `include`) to resolve such values based on configured `env_file`, not just top-level environment.
when marshaling model to yaml/json resolved content is hidden if it was set by environment, to keep definition consistency


closes https://github.com/docker/compose/issues/11952