### PR TITLE
chore: added readme link to score-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,4 @@ make check_compose_spec
 * [testcontainers-go's Compose module](https://github.com/testcontainers/testcontainers-go/tree/main/modules/compose)
 * [compose2nix](https://github.com/aksiksi/compose2nix)
 * [Defang](https://github.com/DefangLabs/defang)
+* [score-compose](https://github.com/score-spec/score-compose)


### PR DESCRIPTION
See https://github.com/score-spec/score-compose for more details. score-compose is a tool for converting Score workload specifications into compose specification files and uses the types in the compose-go library internally to build and validate the result.

