### PR TITLE
Revert "run interpolation after merge, but for required attributes"

### DIFF
--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -253,7 +253,7 @@ func TestProjectWithDotEnv(t *testing.T) {
 		"compose-with-variables.yaml",
 	}, WithName("my_project"), WithEnvFiles(), WithDotEnv)
 	assert.NilError(t, err)
-	p, err := opts.LoadProject(context.TODO())
+	p, err := ProjectFromOptions(context.TODO(), opts)
 	assert.NilError(t, err)
 	service, err := p.GetService("simple")
 	assert.NilError(t, err)

--- a/cli/testdata/env-file/compose-with-env-files.yaml
+++ b/cli/testdata/env-file/compose-with-env-files.yaml
@@ -1,3 +1,4 @@
+version: "3"
 services:
   simple:
     image: nginx

--- a/loader/extends.go
+++ b/loader/extends.go
@@ -22,11 +22,8 @@ import (
 	"path/filepath"
 
 	"github.com/compose-spec/compose-go/v2/consts"
-	"github.com/compose-spec/compose-go/v2/interpolation"
 	"github.com/compose-spec/compose-go/v2/override"
 	"github.com/compose-spec/compose-go/v2/paths"
-	"github.com/compose-spec/compose-go/v2/template"
-	"github.com/compose-spec/compose-go/v2/transform"
 	"github.com/compose-spec/compose-go/v2/types"
 )
 
@@ -71,22 +68,10 @@ func applyServiceExtends(ctx context.Context, name string, services map[string]a
 	)
 	switch v := extends.(type) {
 	case map[string]any:
-		if opts.Interpolate != nil {
-			v, err = interpolation.Interpolate(v, *opts.Interpolate)
-			if err != nil {
-				return nil, err
-			}
-		}
 		ref = v["service"].(string)
 		file = v["file"]
 		opts.ProcessEvent("extends", v)
 	case string:
-		if opts.Interpolate != nil {
-			v, err = opts.Interpolate.Substitute(v, template.Mapping(opts.Interpolate.LookupValue))
-			if err != nil {
-				return nil, err
-			}
-		}
 		ref = v
 		opts.ProcessEvent("extends", map[string]any{"service": ref})
 	}
@@ -188,12 +173,6 @@ func getExtendsBaseFromFile(
 				ref,
 				refPath,
 			)
-		}
-
-		// Attempt to make a canonical model so ResolveRelativePaths can operate on source:target short syntax
-		source, err = transform.Canonical(source, true)
-		if err != nil {
-			return nil, nil, err
 		}
 
 		var remotes []paths.RemoteResource

--- a/loader/include.go
+++ b/loader/include.go
@@ -30,7 +30,7 @@ import (
 )
 
 // loadIncludeConfig parse the required config from raw yaml
-func loadIncludeConfig(source any, options *Options) ([]types.IncludeConfig, error) {
+func loadIncludeConfig(source any) ([]types.IncludeConfig, error) {
 	if source == nil {
 		return nil, nil
 	}
@@ -45,23 +45,13 @@ func loadIncludeConfig(source any, options *Options) ([]types.IncludeConfig, err
 			}
 		}
 	}
-	if options.Interpolate != nil {
-		for i, config := range configs {
-			interpolated, err := interp.Interpolate(config.(map[string]any), *options.Interpolate)
-			if err != nil {
-				return nil, err
-			}
-			configs[i] = interpolated
-		}
-	}
-
 	var requires []types.IncludeConfig
 	err := Transform(source, &requires)
 	return requires, err
 }
 
 func ApplyInclude(ctx context.Context, workingDir string, environment types.Mapping, model map[string]any, options *Options, included []string) error {
-	includeConfig, err := loadIncludeConfig(model["include"], options)
+	includeConfig, err := loadIncludeConfig(model["include"])
 	if err != nil {
 		return err
 	}

--- a/loader/loader_yaml_test.go
+++ b/loader/loader_yaml_test.go
@@ -56,46 +56,6 @@ services:
 	})
 }
 
-func TestParseYAMLFilesInterpolateAfterMerge(t *testing.T) {
-	model, err := loadYamlModel(
-		context.TODO(), types.ConfigDetails{
-			ConfigFiles: []types.ConfigFile{
-				{
-					Filename: "test.yaml",
-					Content: []byte(`
-services:
-  test:
-    image: foo
-    environment:
-      my_env: ${my_env?my_env must be set}
-`),
-				},
-				{
-					Filename: "override.yaml",
-					Content: []byte(`
-services:
-  test:
-    image: bar
-    environment:
-      my_env: ${my_env:-default}
-`),
-				},
-			},
-		}, &Options{}, &cycleTracker{}, nil,
-	)
-	assert.NilError(t, err)
-	assert.DeepEqual(
-		t, model, map[string]interface{}{
-			"services": map[string]interface{}{
-				"test": map[string]interface{}{
-					"image":       "bar",
-					"environment": []any{"my_env=${my_env:-default}"},
-				},
-			},
-		},
-	)
-}
-
 func TestParseYAMLFilesMergeOverride(t *testing.T) {
 	model, err := loadYamlModel(context.TODO(), types.ConfigDetails{
 		ConfigFiles: []types.ConfigFile{

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -155,8 +155,8 @@
           },
           "additionalProperties": false
         },
-        "cap_add": {"type": "array", "items": {"type": "string"}},
-        "cap_drop": {"type": "array", "items": {"type": "string"}},
+        "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "cgroup": {"type": "string", "enum": ["host", "private"]},
         "cgroup_parent": {"type": "string"},
         "command": {"$ref": "#/definitions/command"},
@@ -216,9 +216,9 @@
           ]
         },
         "device_cgroup_rules": {"$ref": "#/definitions/list_of_strings"},
-        "devices": {"type": "array", "items": {"type": "string"}},
+        "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "dns": {"$ref": "#/definitions/string_or_list"},
-        "dns_opt": {"type": "array","items": {"type": "string"}},
+        "dns_opt": {"type": "array","items": {"type": "string"}, "uniqueItems": true},
         "dns_search": {"$ref": "#/definitions/string_or_list"},
         "domainname": {"type": "string"},
         "entrypoint": {"$ref": "#/definitions/command"},
@@ -230,7 +230,8 @@
           "items": {
             "type": ["string", "number"],
             "format": "expose"
-          }
+          },
+          "uniqueItems": true
         },
         "extends": {
           "oneOf": [
@@ -247,13 +248,14 @@
             }
           ]
         },
-        "external_links": {"type": "array", "items": {"type": "string"}},
+        "external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
         "group_add": {
           "type": "array",
           "items": {
             "type": ["string", "number"]
-          }
+          },
+          "uniqueItems": true
         },
         "healthcheck": {"$ref": "#/definitions/healthcheck"},
         "hostname": {"type": "string"},
@@ -262,7 +264,7 @@
         "ipc": {"type": "string"},
         "isolation": {"type": "string"},
         "labels": {"$ref": "#/definitions/list_or_dict"},
-        "links": {"type": "array", "items": {"type": "string"}},
+        "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "logging": {
           "type": "object",
 
@@ -348,7 +350,8 @@
                 "patternProperties": {"^x-": {}}
               }
             ]
-          }
+          },
+          "uniqueItems": true
         },
         "privileged": {"type": ["boolean", "string"]},
         "profiles": {"$ref": "#/definitions/list_of_strings"},
@@ -363,7 +366,7 @@
         "scale": {
           "type": ["integer", "string"]
         },
-        "security_opt": {"type": "array", "items": {"type": "string"}},
+        "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "shm_size": {"type": ["number", "string"]},
         "secrets": {"$ref": "#/definitions/service_config_or_secret"},
         "sysctls": {"$ref": "#/definitions/list_or_dict"},
@@ -429,11 +432,13 @@
                 "patternProperties": {"^x-": {}}
               }
             ]
-          }
+          },
+          "uniqueItems": true
         },
         "volumes_from": {
           "type": "array",
-          "items": {"type": "string"}
+          "items": {"type": "string"},
+          "uniqueItems": true
         },
         "working_dir": {"type": "string"}
       },
@@ -828,7 +833,8 @@
 
     "list_of_strings": {
       "type": "array",
-      "items": {"type": "string"}
+      "items": {"type": "string"},
+      "uniqueItems": true
     },
 
     "list_or_dict": {
@@ -842,7 +848,7 @@
           },
           "additionalProperties": false
         },
-        {"type": "array", "items": {"type": "string"}}
+        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
       ]
     },
 


### PR DESCRIPTION
This reverts commit 65600cee45d45771a1faa6ddaf87b23ca4d2400c.

The commit led to this issue https://github.com/docker/compose/issues/12001, a quick fix is to revert the commit and release it.  