### PR TITLE
feat(compose-spec): Add content property for secrets in compose-spec.json

### DIFF
--- a/loader/environment.go
+++ b/loader/environment.go
@@ -79,7 +79,7 @@ func resolveSecretsEnvironment(dict map[string]any, environment types.Mapping) {
 			continue
 		}
 		if found, ok := environment[env]; ok {
-			secret["content"] = found
+			secret[types.SecretConfigXValue] = found
 		}
 		secrets[name] = secret
 	}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -774,6 +774,11 @@ func secretConfigDecoderHook(from, to reflect.Type, data interface{}) (interface
 				if val, ok := ext[types.SecretConfigXValue].(string); ok {
 					// Return a map with the Content field populated
 					v["Content"] = val
+					delete(ext, types.SecretConfigXValue)
+
+					if len(ext) == 0 {
+						delete(v, "#extensions")
+					}
 				}
 			}
 		}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -738,7 +738,9 @@ func Transform(source interface{}, target interface{}) error {
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			nameServices,
 			decoderHook,
-			cast),
+			cast,
+			secretConfigDecoderHook,
+		),
 		Result:   target,
 		TagName:  "yaml",
 		Metadata: &data,
@@ -762,6 +764,23 @@ func nameServices(from reflect.Value, to reflect.Value) (interface{}, error) {
 		}
 	}
 	return from.Interface(), nil
+}
+
+func secretConfigDecoderHook(from, to reflect.Type, data interface{}) (interface{}, error) {
+	// Check if the input is a map and we're decoding into a SecretConfig
+	if from.Kind() == reflect.Map && to == reflect.TypeOf(types.SecretConfig{}) {
+		if v, ok := data.(map[string]interface{}); ok {
+			if ext, ok := v["#extensions"].(map[string]interface{}); ok {
+				if val, ok := ext[types.SecretConfigXValue].(string); ok {
+					// Return a map with the Content field populated
+					v["Content"] = val
+				}
+			}
+		}
+	}
+
+	// Return the original data so the rest is handled by default mapstructure logic
+	return data, nil
 }
 
 // keys need to be converted to strings for jsonschema

--- a/types/types.go
+++ b/types/types.go
@@ -239,6 +239,10 @@ const (
 	NetworkModeContainerPrefix = ContainerPrefix
 )
 
+const (
+	SecretConfigXValue = "x-#value"
+)
+
 // GetDependencies retrieves all services this service depends on
 func (s ServiceConfig) GetDependencies() []string {
 	var dependencies []string


### PR DESCRIPTION
Fixes https://github.com/docker/compose/issues/12033

Add `content` to `secret` property, because in case of environment value, we add "content" property but it wasn't defined in the spec