### PR TITLE
Add extensions to watch.trigger

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2885,6 +2885,7 @@ services:
         # sync static content
         - path: ./webapp/html
           action: sync
+          x-initialSync: true
           target: /var/www
           ignore:
             - node_modules/
@@ -2920,6 +2921,9 @@ services:
 				Action: types.WatchActionSync,
 				Target: "/var/www",
 				Ignore: []string{"node_modules/"},
+				Extensions: types.Extensions{
+					"x-initialSync": true,
+				},
 			},
 		},
 	})

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -480,7 +480,9 @@
               "path": {"type": "string"},
               "action": {"type": "string", "enum": ["rebuild", "sync", "sync+restart"]},
               "target": {"type": "string"}
-            }
+            },
+            "additionalProperties": false,
+            "patternProperties": {"^x-": {}}
           },
           "additionalProperties": false,
           "patternProperties": {"^x-": {}}

--- a/types/derived.gen.go
+++ b/types/derived.gen.go
@@ -1814,6 +1814,12 @@ func deriveDeepCopy_40(dst, src *Trigger) {
 		}
 		copy(dst.Ignore, src.Ignore)
 	}
+	if src.Extensions != nil {
+		dst.Extensions = make(map[string]any, len(src.Extensions))
+		src.Extensions.DeepCopy(dst.Extensions)
+	} else {
+		dst.Extensions = nil
+	}
 }
 
 // deriveDeepCopy_41 recursively copies the contents of src into dst.

--- a/types/develop.go
+++ b/types/develop.go
@@ -31,8 +31,9 @@ const (
 )
 
 type Trigger struct {
-	Path   string      `yaml:"path" json:"path"`
-	Action WatchAction `yaml:"action" json:"action"`
-	Target string      `yaml:"target,omitempty" json:"target,omitempty"`
-	Ignore []string    `yaml:"ignore,omitempty" json:"ignore,omitempty"`
+	Path       string      `yaml:"path" json:"path"`
+	Action     WatchAction `yaml:"action" json:"action"`
+	Target     string      `yaml:"target,omitempty" json:"target,omitempty"`
+	Ignore     []string    `yaml:"ignore,omitempty" json:"ignore,omitempty"`
+	Extensions Extensions  `yaml:"#extensions,inline,omitempty" json:"-"`
 }


### PR DESCRIPTION
Add Extensions to watch object

This is necessary in order to first introduce `x-initalSync` inside a watch confioguration related to:
- https://github.com/docker/compose/pull/12047