### PR TITLE
feat(volume): Add device with colon support

### DIFF
--- a/format/volume_test.go
+++ b/format/volume_test.go
@@ -97,6 +97,21 @@ func TestParseVolumeRelativeBindMountWindows(t *testing.T) {
 	}
 }
 
+func TestParseVolumeWithDeviceWithMultipleColons(t *testing.T) {
+	volume, err := ParseVolume("/dev/usb-0:1.3:1.0-port0:/dev/usb-0:1.3:1.0-port0")
+	expected := types.ServiceVolumeConfig{
+		Type:   "bind",
+		Source: "/dev/usb-0:1.3:1.0-port0",
+		Target: "/dev/usb-0:1.3:1.0-port0",
+		Bind: &types.ServiceVolumeBind{
+			CreateHostPath: true,
+			Propagation:    "",
+		},
+	}
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(expected, volume))
+}
+
 func TestParseVolumeWithBindOptions(t *testing.T) {
 	volume, err := ParseVolume("/source:/target:slave")
 	expected := types.ServiceVolumeConfig{

--- a/override/uncity.go
+++ b/override/uncity.go
@@ -42,7 +42,7 @@ func init() {
 	unique["services.*.build.labels"] = keyValueIndexer
 	unique["services.*.cap_add"] = keyValueIndexer
 	unique["services.*.cap_drop"] = keyValueIndexer
-	unique["services.*.devices"] = volumeIndexer
+	unique["services.*.devices"] = devicesIndexer
 	unique["services.*.configs"] = mountIndexer("")
 	unique["services.*.deploy.labels"] = keyValueIndexer
 	unique["services.*.dns"] = keyValueIndexer
@@ -127,6 +127,24 @@ func volumeIndexer(y any, p tree.Path) (string, error) {
 		target, ok := value["target"].(string)
 		if !ok {
 			return "", fmt.Errorf("service volume %s is missing a mount target", p)
+		}
+		return target, nil
+	case string:
+		volume, err := format.ParseVolume(value)
+		if err != nil {
+			return "", err
+		}
+		return volume.Target, nil
+	}
+	return "", nil
+}
+
+func devicesIndexer(y any, p tree.Path) (string, error) {
+	switch value := y.(type) {
+	case map[string]any:
+		target, ok := value["target"].(string)
+		if !ok {
+			return "", fmt.Errorf("service devices %s is missing a mount target", p)
 		}
 		return target, nil
 	case string:


### PR DESCRIPTION
Closes #https://github.com/docker/compose/issues/12052

Added device with colon support, we used to support it before this commit https://github.com/compose-spec/compose-go/commit/072aa6418dcd93b4e31d0235df9dad5a6c11e63e

Example:
```
services:
  app:
    image: alpine
    command: ["sh", "-c", "while true; do echo 'Hello, World!'; sleep 3; done"]
    devices:
      - /dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4:1.0-port0:/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4:1.0-port0:ro
      - /dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.3:1.0-port0:/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.3:1.0-port0
```
