### PR TITLE
Update include definition in JSON schema to fix strings marked as Invalid type

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -19,7 +19,6 @@
     "include": {
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/definitions/include"
       },
       "description": "compose sub-projects to be included."


### PR DESCRIPTION
In a compose.yaml file, when you use include to reference other compose files with a string instead of an object, you may encounter the following error:

![image](https://github.com/user-attachments/assets/2fa94f18-e3d4-43c4-ae4f-198796b7e96a)

For more details, refer to issue [462](https://github.com/compose-spec/compose-spec/issues/462) in compose-spec