### PR TITLE
Fix GetWorkingDir to get the right working dir from config files

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -391,16 +391,38 @@ func (o *ProjectOptions) GetWorkingDir() (string, error) {
 	if o.WorkingDir != "" {
 		return filepath.Abs(o.WorkingDir)
 	}
+
+	osWorkingDir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	workingDir := ""
 	for _, path := range o.ConfigPaths {
 		if path != "-" {
 			absPath, err := filepath.Abs(path)
 			if err != nil {
 				return "", err
 			}
-			return filepath.Dir(absPath), nil
+
+			absDir := filepath.Dir(absPath)
+
+			if absDir == osWorkingDir {
+				workingDir = osWorkingDir
+				continue
+			}
+
+			if workingDir == "" {
+				workingDir = absDir
+			}
 		}
 	}
-	return os.Getwd()
+
+	if workingDir == "" {
+		workingDir = osWorkingDir
+	}
+
+	return workingDir, nil
 }
 
 func (o *ProjectOptions) GeConfigFiles() ([]types.ConfigFile, error) {

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -353,3 +353,103 @@ func TestEnvVariablePrecedence(t *testing.T) {
 		})
 	}
 }
+
+func TestGetWorkingDirWithWorkingDirFileAndSubDirFile(t *testing.T) {
+	wd, err := os.Getwd()
+	assert.NilError(t, err)
+	err = os.Chdir("testdata/simple")
+	assert.NilError(t, err)
+	defer os.Chdir(wd) //nolint:errcheck
+
+	opts, err := NewProjectOptions([]string{
+		"compose.yaml",
+		"subdirectory/compose.yaml",
+	}, WithName("my_project"))
+	assert.NilError(t, err)
+	currentDir, err := opts.GetWorkingDir()
+	assert.NilError(t, err)
+	assert.Equal(t, currentDir, filepath.Join(wd, "testdata", "simple"))
+}
+
+func TestGetWorkingDirWithSubDirFileAndWorkingDirFile(t *testing.T) {
+	wd, err := os.Getwd()
+	assert.NilError(t, err)
+	err = os.Chdir("testdata/simple")
+	assert.NilError(t, err)
+	defer os.Chdir(wd) //nolint:errcheck
+
+	opts, err := NewProjectOptions([]string{
+		"subdirectory/compose.yaml",
+		"compose.yaml",
+	}, WithName("my_project"))
+	assert.NilError(t, err)
+	currentDir, err := opts.GetWorkingDir()
+	assert.NilError(t, err)
+	assert.Equal(t, currentDir, filepath.Join(wd, "testdata", "simple"))
+}
+
+func TestGetWorkingDirWithOneSubDirFile(t *testing.T) {
+	wd, err := os.Getwd()
+	assert.NilError(t, err)
+	err = os.Chdir("testdata/simple")
+	assert.NilError(t, err)
+	defer os.Chdir(wd) //nolint:errcheck
+
+	opts, err := NewProjectOptions([]string{
+		"subdirectory/compose.yaml",
+	}, WithName("my_project"))
+	assert.NilError(t, err)
+	currentDir, err := opts.GetWorkingDir()
+	assert.NilError(t, err)
+	assert.Equal(t, currentDir, filepath.Join(wd, "testdata", "simple", "subdirectory"))
+}
+
+func TestGetWorkingDirWithTwoSubDirFiles(t *testing.T) {
+	wd, err := os.Getwd()
+	assert.NilError(t, err)
+	err = os.Chdir("testdata/simple")
+	assert.NilError(t, err)
+	defer os.Chdir(wd) //nolint:errcheck
+
+	opts, err := NewProjectOptions([]string{
+		"subdirectory/compose.yaml",
+		"subdirectory/compose-other.yaml",
+	}, WithName("my_project"))
+	assert.NilError(t, err)
+	currentDir, err := opts.GetWorkingDir()
+	assert.NilError(t, err)
+	assert.Equal(t, currentDir, filepath.Join(wd, "testdata", "simple", "subdirectory"))
+}
+
+func TestGetWorkingDirWithOneWorkingDirFile(t *testing.T) {
+	wd, err := os.Getwd()
+	assert.NilError(t, err)
+	err = os.Chdir("testdata/simple")
+	assert.NilError(t, err)
+	defer os.Chdir(wd) //nolint:errcheck
+
+	opts, err := NewProjectOptions([]string{
+		"compose.yaml",
+	}, WithName("my_project"))
+	assert.NilError(t, err)
+	currentDir, err := opts.GetWorkingDir()
+	assert.NilError(t, err)
+	assert.Equal(t, currentDir, filepath.Join(wd, "testdata", "simple"))
+}
+
+func TestGetWorkingDirWithTwoWorkingDirFiles(t *testing.T) {
+	wd, err := os.Getwd()
+	assert.NilError(t, err)
+	err = os.Chdir("testdata/simple")
+	assert.NilError(t, err)
+	defer os.Chdir(wd) //nolint:errcheck
+
+	opts, err := NewProjectOptions([]string{
+		"compose.yaml",
+		"compose-other.yaml",
+	}, WithName("my_project"))
+	assert.NilError(t, err)
+	currentDir, err := opts.GetWorkingDir()
+	assert.NilError(t, err)
+	assert.Equal(t, currentDir, filepath.Join(wd, "testdata", "simple"))
+}

--- a/cli/testdata/simple/compose-other.yaml
+++ b/cli/testdata/simple/compose-other.yaml
@@ -1,0 +1,3 @@
+services:
+  other:
+    image: nginx

--- a/cli/testdata/simple/subdirectory/compose-other.yaml
+++ b/cli/testdata/simple/subdirectory/compose-other.yaml
@@ -1,0 +1,3 @@
+services:
+  other:
+    image: nginx

--- a/cli/testdata/simple/subdirectory/compose.yaml
+++ b/cli/testdata/simple/subdirectory/compose.yaml
@@ -1,0 +1,3 @@
+services:
+  subdirectory:
+    image: nginx


### PR DESCRIPTION
Fix https://github.com/docker/compose/issues/12054

Hi,
I've tried to fix the bug mentioned above by using the true working directory if there is a configuration file in it, otherwise it behaves the same way as before.

I'm not an expert in golang so don't hesitate to make comments.

Have a nice day!