### PR TITLE
Revert "accept dashes in variable names"

### DIFF
--- a/dotenv/fixtures/special.env
+++ b/dotenv/fixtures/special.env
@@ -1,3 +1,0 @@
-VAR.WITH.DOTS=dots
-VAR_WITH_UNDERSCORES=underscores
-VAR-WITH-DASHES=dashes

--- a/dotenv/godotenv_test.go
+++ b/dotenv/godotenv_test.go
@@ -691,14 +691,6 @@ func TestUTF8BOM(t *testing.T) {
 	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
 }
 
-func TestDash(t *testing.T) {
-	loadEnvAndCompareValues(t, Load, "fixtures/special.env", map[string]string{
-		"VAR-WITH-DASHES":      "dashes",
-		"VAR.WITH.DOTS":        "dots",
-		"VAR_WITH_UNDERSCORES": "underscores",
-	}, noopPresets)
-}
-
 func TestGetEnvFromFile(t *testing.T) {
 	wd := t.TempDir()
 	f := filepath.Join(wd, ".env")

--- a/dotenv/parser.go
+++ b/dotenv/parser.go
@@ -119,7 +119,7 @@ loop:
 			offset = i + 1
 			inherited = rune == '\n'
 			break loop
-		case '_', '.', '-', '[', ']':
+		case '_', '.', '[', ']':
 		default:
 			// variable name should match [A-Za-z0-9_.-]
 			if unicode.IsLetter(rune) || unicode.IsNumber(rune) {

--- a/dotenv/parser_test.go
+++ b/dotenv/parser_test.go
@@ -13,17 +13,17 @@ var testInput = `
 a=b
 a[1]=c
 a.propertyKey=d
-árvíztűrő-TÜKÖRFÚRÓGÉP=ÁRVÍZTŰRŐ-tükörfúrógép
+árvíztűrőTÜKÖRFÚRÓGÉP=ÁRVÍZTŰRŐtükörfúrógép
 `
 
 func TestParseBytes(t *testing.T) {
 	p := newParser()
 
 	expectedOutput := map[string]string{
-		"a":                      "b",
-		"a[1]":                   "c",
-		"a.propertyKey":          "d",
-		"árvíztűrő-TÜKÖRFÚRÓGÉP": "ÁRVÍZTŰRŐ-tükörfúrógép",
+		"a":                     "b",
+		"a[1]":                  "c",
+		"a.propertyKey":         "d",
+		"árvíztűrőTÜKÖRFÚRÓGÉP": "ÁRVÍZTŰRŐtükörfúrógép",
 	}
 
 	out := map[string]string{}


### PR DESCRIPTION
This reverts commit be170befda31a336a94d248ac1221fceeac834c8.

we **can't** support dashes in variables as this conflict with the [interpolation syntax](https://github.com/compose-spec/compose-spec/blob/main/12-interpolation.md) for default values

closes https://github.com/compose-spec/compose-go/issues/663