### PR TITLE
doc: Add CasaOS to Used by

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,4 @@ make check_compose_spec
 * [compose2nix](https://github.com/aksiksi/compose2nix)
 * [Defang](https://github.com/DefangLabs/defang)
 * [score-compose](https://github.com/score-spec/score-compose)
+* [CasaOS](https://github.com/IceWhaleTech/CasaOS)


### PR DESCRIPTION
This library is used in [CasaOS-AppManagement](https://github.com/IceWhaleTech/CasaOS-AppManagement/blob/main/service/app.go) that is a part of [CasaOS](https://github.com/IceWhaleTech/CasaOS) .
Add [CasaOS](https://github.com/IceWhaleTech/CasaOS) to section `Used by` of `README.md`.