### PR TITLE
Increment line count properly in dotenv parser when parsing inheritance syntax

### DIFF
--- a/dotenv/parser.go
+++ b/dotenv/parser.go
@@ -136,6 +136,10 @@ loop:
 		return "", "", inherited, errors.New("zero length string")
 	}
 
+	if inherited {
+		p.line++
+	}
+
 	// trim whitespace
 	key = strings.TrimRightFunc(key, unicode.IsSpace)
 	cutset := strings.TrimLeftFunc(src[offset:], isSpace)


### PR DESCRIPTION
Resolves: https://github.com/compose-spec/compose-go/issues/649