### PR TITLE
Update compose-spec.json: remove invalid fields from array

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -500,9 +500,7 @@
             },
             "additionalProperties": false,
             "patternProperties": {"^x-": {}}
-          },
-          "additionalProperties": false,
-          "patternProperties": {"^x-": {}}
+          }
         }
       }
     },

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -502,7 +502,9 @@
             "patternProperties": {"^x-": {}}
           }
         }
-      }
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
     },
     "deployment": {
       "id": "#/definitions/deployment",


### PR DESCRIPTION


The 'additionalProperties' and 'patternProperties' are being declared for an array type, which is invalid. They are also declared for the items of the array, so they can be removed. Their presence is causing issues converting this jsonschema to its cuelang representation.


Fixes https://github.com/compose-spec/compose-spec/issues/534