### PR TITLE
fix subpath in ServiceVolumeConfig#String

### DIFF
--- a/format/volume.go
+++ b/format/volume.go
@@ -95,7 +95,7 @@ func populateFieldFromBuffer(char rune, buffer []rune, volume *types.ServiceVolu
 			if isBindOption(option) {
 				setBindOption(volume, option)
 			}
-			// ignore unknown options
+			// ignore unknown options FIXME why not report an error here?
 		}
 	}
 	return nil

--- a/format/volume_test.go
+++ b/format/volume_test.go
@@ -177,14 +177,6 @@ func TestParseVolumeWithVolumeOptions(t *testing.T) {
 	assert.Check(t, is.DeepEqual(expected, volume))
 }
 
-func TestParseVolumeWithVolumeOptionsSubpath(t *testing.T) {
-	volume, err := ParseVolume("name:/target:nocopy,subpath=etc")
-	assert.NilError(t, err)
-
-	// subpath option is not supported in the short syntax
-	assert.Check(t, is.Equal(volume.Volume.Subpath, ""))
-}
-
 func TestParseVolumeWithReadOnly(t *testing.T) {
 	for _, path := range []string{"./foo", "/home/user"} {
 		volume, err := ParseVolume(path + ":/target:ro")

--- a/types/types.go
+++ b/types/types.go
@@ -552,9 +552,6 @@ func (s ServiceVolumeConfig) String() string {
 	if s.Volume != nil && s.Volume.NoCopy {
 		options = append(options, "nocopy")
 	}
-	if s.Volume != nil && s.Volume.Subpath != "" {
-		options = append(options, s.Volume.Subpath)
-	}
 	return fmt.Sprintf("%s:%s:%s", s.Source, s.Target, strings.Join(options, ","))
 }
 


### PR DESCRIPTION
quick fix as subpath option is malformed

To be debated: as this option is actually not supported in the string format, why not just exclude it 
_or_ why don't we also include createHostPath then ? #inconsistency
