### PR TITLE
introduce ability to use custom env_file format

### DIFF
--- a/dotenv/fixtures/custom.format
+++ b/dotenv/fixtures/custom.format
@@ -1,0 +1,2 @@
+FOO:BAR
+ZOT:QIX

--- a/dotenv/format.go
+++ b/dotenv/format.go
@@ -1,0 +1,38 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package dotenv
+
+import (
+	"fmt"
+	"io"
+)
+
+var formats = map[string]Parser{}
+
+type Parser func(r io.Reader, filename string, lookup func(key string) (string, bool)) (map[string]string, error)
+
+func RegisterFormat(format string, p Parser) {
+	formats[format] = p
+}
+
+func ParseWithFormat(r io.Reader, filename string, resolve LookupFn, format string) (map[string]string, error) {
+	parser, ok := formats[format]
+	if !ok {
+		return nil, fmt.Errorf("unsupported env_file format %q", format)
+	}
+	return parser(r, filename, resolve)
+}

--- a/dotenv/godotenv.go
+++ b/dotenv/godotenv.go
@@ -86,7 +86,7 @@ func ReadWithLookup(lookupFn LookupFn, filenames ...string) (map[string]string, 
 	envMap := make(map[string]string)
 
 	for _, filename := range filenames {
-		individualEnvMap, individualErr := readFile(filename, lookupFn)
+		individualEnvMap, individualErr := ReadFile(filename, lookupFn)
 
 		if individualErr != nil {
 			return envMap, individualErr
@@ -129,7 +129,7 @@ func filenamesOrDefault(filenames []string) []string {
 }
 
 func loadFile(filename string, overload bool) error {
-	envMap, err := readFile(filename, nil)
+	envMap, err := ReadFile(filename, nil)
 	if err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func loadFile(filename string, overload bool) error {
 	return nil
 }
 
-func readFile(filename string, lookupFn LookupFn) (map[string]string, error) {
+func ReadFile(filename string, lookupFn LookupFn) (map[string]string, error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return nil, err

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -831,6 +831,9 @@
                   "path": {
                     "type": "string"
                   },
+                  "format": {
+                    "type": "string"
+                  },
                   "required": {
                     "type": ["boolean", "string"],
                     "default": true

--- a/types/envfile.go
+++ b/types/envfile.go
@@ -23,6 +23,7 @@ import (
 type EnvFile struct {
 	Path     string `yaml:"path,omitempty" json:"path,omitempty"`
 	Required bool   `yaml:"required" json:"required"`
+	Format   string `yaml:"format,omitempty" json:"format,omitempty"`
 }
 
 // MarshalYAML makes EnvFile implement yaml.Marshaler


### PR DESCRIPTION
This allows to register additional env_file format parser, so one can plug https://github.com/docker/cli/blob/master/opts/envfile.go as an alternate parser, to support reading "raw" env_file just like `docker run --env-file` does.