### PR TITLE
add (missing) deploy.resources.devices.options

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -3481,3 +3481,31 @@ services:
 		},
 	})
 }
+
+func TestLoadDeviceReservation(t *testing.T) {
+	config, err := loadYAML(`
+name: load-device-reservation
+services:
+  test:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: richard_feynman
+              capabilities: ["quantic"]
+              count: all
+              options:
+                q_bits: 42
+`)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, config.Services["test"].Deploy.Resources.Reservations.Devices, []types.DeviceRequest{
+		{
+			Capabilities: []string{"quantic"},
+			Driver:       "richard_feynman",
+			Count:        -1,
+			Options: types.Mapping{
+				"q_bits": "42",
+			},
+		},
+	})
+}

--- a/types/derived.gen.go
+++ b/types/derived.gen.go
@@ -279,7 +279,7 @@ func deriveDeepCopyService(dst, src *ServiceConfig) {
 		} else {
 			dst.Devices = make([]DeviceMapping, len(src.Devices))
 		}
-		copy(dst.Devices, src.Devices)
+		deriveDeepCopy_12(dst.Devices, src.Devices)
 	}
 	if src.DNS == nil {
 		dst.DNS = nil
@@ -357,7 +357,7 @@ func deriveDeepCopyService(dst, src *ServiceConfig) {
 	}
 	if src.Environment != nil {
 		dst.Environment = make(map[string]*string, len(src.Environment))
-		deriveDeepCopy_12(dst.Environment, src.Environment)
+		deriveDeepCopy_13(dst.Environment, src.Environment)
 	} else {
 		dst.Environment = nil
 	}
@@ -423,7 +423,7 @@ func deriveDeepCopyService(dst, src *ServiceConfig) {
 	}
 	if src.ExtraHosts != nil {
 		dst.ExtraHosts = make(map[string][]string, len(src.ExtraHosts))
-		deriveDeepCopy_13(dst.ExtraHosts, src.ExtraHosts)
+		deriveDeepCopy_14(dst.ExtraHosts, src.ExtraHosts)
 	} else {
 		dst.ExtraHosts = nil
 	}
@@ -450,7 +450,7 @@ func deriveDeepCopyService(dst, src *ServiceConfig) {
 		dst.HealthCheck = nil
 	} else {
 		dst.HealthCheck = new(HealthCheckConfig)
-		deriveDeepCopy_14(dst.HealthCheck, src.HealthCheck)
+		deriveDeepCopy_15(dst.HealthCheck, src.HealthCheck)
 	}
 	dst.Image = src.Image
 	if src.Init == nil {
@@ -495,7 +495,7 @@ func deriveDeepCopyService(dst, src *ServiceConfig) {
 		dst.Logging = nil
 	} else {
 		dst.Logging = new(LoggingConfig)
-		deriveDeepCopy_15(dst.Logging, src.Logging)
+		deriveDeepCopy_16(dst.Logging, src.Logging)
 	}
 	dst.LogDriver = src.LogDriver
 	if src.LogOpt != nil {
@@ -513,7 +513,7 @@ func deriveDeepCopyService(dst, src *ServiceConfig) {
 	dst.NetworkMode = src.NetworkMode
 	if src.Networks != nil {
 		dst.Networks = make(map[string]*ServiceNetworkConfig, len(src.Networks))
-		deriveDeepCopy_16(dst.Networks, src.Networks)
+		deriveDeepCopy_17(dst.Networks, src.Networks)
 	} else {
 		dst.Networks = nil
 	}
@@ -538,7 +538,7 @@ func deriveDeepCopyService(dst, src *ServiceConfig) {
 		} else {
 			dst.Ports = make([]ServicePortConfig, len(src.Ports))
 		}
-		deriveDeepCopy_17(dst.Ports, src.Ports)
+		deriveDeepCopy_18(dst.Ports, src.Ports)
 	}
 	dst.Privileged = src.Privileged
 	dst.PullPolicy = src.PullPolicy
@@ -567,7 +567,7 @@ func deriveDeepCopyService(dst, src *ServiceConfig) {
 		} else {
 			dst.Secrets = make([]ServiceSecretConfig, len(src.Secrets))
 		}
-		deriveDeepCopy_18(dst.Secrets, src.Secrets)
+		deriveDeepCopy_19(dst.Secrets, src.Secrets)
 	}
 	if src.SecurityOpt == nil {
 		dst.SecurityOpt = nil
@@ -629,7 +629,7 @@ func deriveDeepCopyService(dst, src *ServiceConfig) {
 	dst.Tty = src.Tty
 	if src.Ulimits != nil {
 		dst.Ulimits = make(map[string]*UlimitsConfig, len(src.Ulimits))
-		deriveDeepCopy_19(dst.Ulimits, src.Ulimits)
+		deriveDeepCopy_20(dst.Ulimits, src.Ulimits)
 	} else {
 		dst.Ulimits = nil
 	}
@@ -653,7 +653,7 @@ func deriveDeepCopyService(dst, src *ServiceConfig) {
 		} else {
 			dst.Volumes = make([]ServiceVolumeConfig, len(src.Volumes))
 		}
-		deriveDeepCopy_20(dst.Volumes, src.Volumes)
+		deriveDeepCopy_21(dst.Volumes, src.Volumes)
 	}
 	if src.VolumesFrom == nil {
 		dst.VolumesFrom = nil
@@ -698,7 +698,7 @@ func deriveDeepCopy_(dst, src map[string]NetworkConfig) {
 	for src_key, src_value := range src {
 		func() {
 			field := new(NetworkConfig)
-			deriveDeepCopy_21(field, &src_value)
+			deriveDeepCopy_22(field, &src_value)
 			dst[src_key] = *field
 		}()
 	}
@@ -709,7 +709,7 @@ func deriveDeepCopy_1(dst, src map[string]VolumeConfig) {
 	for src_key, src_value := range src {
 		func() {
 			field := new(VolumeConfig)
-			deriveDeepCopy_22(field, &src_value)
+			deriveDeepCopy_23(field, &src_value)
 			dst[src_key] = *field
 		}()
 	}
@@ -720,7 +720,7 @@ func deriveDeepCopy_2(dst, src map[string]SecretConfig) {
 	for src_key, src_value := range src {
 		func() {
 			field := new(SecretConfig)
-			deriveDeepCopy_23(field, &src_value)
+			deriveDeepCopy_24(field, &src_value)
 			dst[src_key] = *field
 		}()
 	}
@@ -731,7 +731,7 @@ func deriveDeepCopy_3(dst, src map[string]ConfigObjConfig) {
 	for src_key, src_value := range src {
 		func() {
 			field := new(ConfigObjConfig)
-			deriveDeepCopy_24(field, &src_value)
+			deriveDeepCopy_25(field, &src_value)
 			dst[src_key] = *field
 		}()
 	}
@@ -769,7 +769,7 @@ func deriveDeepCopy_5(dst, src *BuildConfig) {
 	}
 	if src.Args != nil {
 		dst.Args = make(map[string]*string, len(src.Args))
-		deriveDeepCopy_12(dst.Args, src.Args)
+		deriveDeepCopy_13(dst.Args, src.Args)
 	} else {
 		dst.Args = nil
 	}
@@ -843,7 +843,7 @@ func deriveDeepCopy_5(dst, src *BuildConfig) {
 	dst.Pull = src.Pull
 	if src.ExtraHosts != nil {
 		dst.ExtraHosts = make(map[string][]string, len(src.ExtraHosts))
-		deriveDeepCopy_13(dst.ExtraHosts, src.ExtraHosts)
+		deriveDeepCopy_14(dst.ExtraHosts, src.ExtraHosts)
 	} else {
 		dst.ExtraHosts = nil
 	}
@@ -866,7 +866,7 @@ func deriveDeepCopy_5(dst, src *BuildConfig) {
 		} else {
 			dst.Secrets = make([]ServiceSecretConfig, len(src.Secrets))
 		}
-		deriveDeepCopy_18(dst.Secrets, src.Secrets)
+		deriveDeepCopy_19(dst.Secrets, src.Secrets)
 	}
 	dst.ShmSize = src.ShmSize
 	if src.Tags == nil {
@@ -889,7 +889,7 @@ func deriveDeepCopy_5(dst, src *BuildConfig) {
 	}
 	if src.Ulimits != nil {
 		dst.Ulimits = make(map[string]*UlimitsConfig, len(src.Ulimits))
-		deriveDeepCopy_19(dst.Ulimits, src.Ulimits)
+		deriveDeepCopy_20(dst.Ulimits, src.Ulimits)
 	} else {
 		dst.Ulimits = nil
 	}
@@ -938,7 +938,7 @@ func deriveDeepCopy_6(dst, src *DevelopConfig) {
 		} else {
 			dst.Watch = make([]Trigger, len(src.Watch))
 		}
-		deriveDeepCopy_25(dst.Watch, src.Watch)
+		deriveDeepCopy_26(dst.Watch, src.Watch)
 	}
 	if src.Extensions != nil {
 		dst.Extensions = make(map[string]any, len(src.Extensions))
@@ -967,7 +967,7 @@ func deriveDeepCopy_7(dst, src *BlkioConfig) {
 		} else {
 			dst.WeightDevice = make([]WeightDevice, len(src.WeightDevice))
 		}
-		deriveDeepCopy_26(dst.WeightDevice, src.WeightDevice)
+		deriveDeepCopy_27(dst.WeightDevice, src.WeightDevice)
 	}
 	if src.DeviceReadBps == nil {
 		dst.DeviceReadBps = nil
@@ -985,7 +985,7 @@ func deriveDeepCopy_7(dst, src *BlkioConfig) {
 		} else {
 			dst.DeviceReadBps = make([]ThrottleDevice, len(src.DeviceReadBps))
 		}
-		deriveDeepCopy_27(dst.DeviceReadBps, src.DeviceReadBps)
+		deriveDeepCopy_28(dst.DeviceReadBps, src.DeviceReadBps)
 	}
 	if src.DeviceReadIOps == nil {
 		dst.DeviceReadIOps = nil
@@ -1003,7 +1003,7 @@ func deriveDeepCopy_7(dst, src *BlkioConfig) {
 		} else {
 			dst.DeviceReadIOps = make([]ThrottleDevice, len(src.DeviceReadIOps))
 		}
-		deriveDeepCopy_27(dst.DeviceReadIOps, src.DeviceReadIOps)
+		deriveDeepCopy_28(dst.DeviceReadIOps, src.DeviceReadIOps)
 	}
 	if src.DeviceWriteBps == nil {
 		dst.DeviceWriteBps = nil
@@ -1021,7 +1021,7 @@ func deriveDeepCopy_7(dst, src *BlkioConfig) {
 		} else {
 			dst.DeviceWriteBps = make([]ThrottleDevice, len(src.DeviceWriteBps))
 		}
-		deriveDeepCopy_27(dst.DeviceWriteBps, src.DeviceWriteBps)
+		deriveDeepCopy_28(dst.DeviceWriteBps, src.DeviceWriteBps)
 	}
 	if src.DeviceWriteIOps == nil {
 		dst.DeviceWriteIOps = nil
@@ -1039,7 +1039,7 @@ func deriveDeepCopy_7(dst, src *BlkioConfig) {
 		} else {
 			dst.DeviceWriteIOps = make([]ThrottleDevice, len(src.DeviceWriteIOps))
 		}
-		deriveDeepCopy_27(dst.DeviceWriteIOps, src.DeviceWriteIOps)
+		deriveDeepCopy_28(dst.DeviceWriteIOps, src.DeviceWriteIOps)
 	}
 	if src.Extensions != nil {
 		dst.Extensions = make(map[string]any, len(src.Extensions))
@@ -1054,7 +1054,7 @@ func deriveDeepCopy_8(dst, src []ServiceConfigObjConfig) {
 	for src_i, src_value := range src {
 		func() {
 			field := new(ServiceConfigObjConfig)
-			deriveDeepCopy_28(field, &src_value)
+			deriveDeepCopy_29(field, &src_value)
 			dst[src_i] = *field
 		}()
 	}
@@ -1078,7 +1078,7 @@ func deriveDeepCopy_10(dst, src map[string]ServiceDependency) {
 	for src_key, src_value := range src {
 		func() {
 			field := new(ServiceDependency)
-			deriveDeepCopy_29(field, &src_value)
+			deriveDeepCopy_30(field, &src_value)
 			dst[src_key] = *field
 		}()
 	}
@@ -1103,28 +1103,28 @@ func deriveDeepCopy_11(dst, src *DeployConfig) {
 		dst.UpdateConfig = nil
 	} else {
 		dst.UpdateConfig = new(UpdateConfig)
-		deriveDeepCopy_30(dst.UpdateConfig, src.UpdateConfig)
+		deriveDeepCopy_31(dst.UpdateConfig, src.UpdateConfig)
 	}
 	if src.RollbackConfig == nil {
 		dst.RollbackConfig = nil
 	} else {
 		dst.RollbackConfig = new(UpdateConfig)
-		deriveDeepCopy_30(dst.RollbackConfig, src.RollbackConfig)
+		deriveDeepCopy_31(dst.RollbackConfig, src.RollbackConfig)
 	}
 	func() {
 		field := new(Resources)
-		deriveDeepCopy_31(field, &src.Resources)
+		deriveDeepCopy_32(field, &src.Resources)
 		dst.Resources = *field
 	}()
 	if src.RestartPolicy == nil {
 		dst.RestartPolicy = nil
 	} else {
 		dst.RestartPolicy = new(RestartPolicy)
-		deriveDeepCopy_32(dst.RestartPolicy, src.RestartPolicy)
+		deriveDeepCopy_33(dst.RestartPolicy, src.RestartPolicy)
 	}
 	func() {
 		field := new(Placement)
-		deriveDeepCopy_33(field, &src.Placement)
+		deriveDeepCopy_34(field, &src.Placement)
 		dst.Placement = *field
 	}()
 	dst.EndpointMode = src.EndpointMode
@@ -1137,7 +1137,18 @@ func deriveDeepCopy_11(dst, src *DeployConfig) {
 }
 
 // deriveDeepCopy_12 recursively copies the contents of src into dst.
-func deriveDeepCopy_12(dst, src map[string]*string) {
+func deriveDeepCopy_12(dst, src []DeviceMapping) {
+	for src_i, src_value := range src {
+		func() {
+			field := new(DeviceMapping)
+			deriveDeepCopy_35(field, &src_value)
+			dst[src_i] = *field
+		}()
+	}
+}
+
+// deriveDeepCopy_13 recursively copies the contents of src into dst.
+func deriveDeepCopy_13(dst, src map[string]*string) {
 	for src_key, src_value := range src {
 		if src_value == nil {
 			dst[src_key] = nil
@@ -1151,8 +1162,8 @@ func deriveDeepCopy_12(dst, src map[string]*string) {
 	}
 }
 
-// deriveDeepCopy_13 recursively copies the contents of src into dst.
-func deriveDeepCopy_13(dst, src map[string][]string) {
+// deriveDeepCopy_14 recursively copies the contents of src into dst.
+func deriveDeepCopy_14(dst, src map[string][]string) {
 	for src_key, src_value := range src {
 		if src_value == nil {
 			dst[src_key] = nil
@@ -1178,8 +1189,8 @@ func deriveDeepCopy_13(dst, src map[string][]string) {
 	}
 }
 
-// deriveDeepCopy_14 recursively copies the contents of src into dst.
-func deriveDeepCopy_14(dst, src *HealthCheckConfig) {
+// deriveDeepCopy_15 recursively copies the contents of src into dst.
+func deriveDeepCopy_15(dst, src *HealthCheckConfig) {
 	if src.Test == nil {
 		dst.Test = nil
 	} else {
@@ -1237,8 +1248,8 @@ func deriveDeepCopy_14(dst, src *HealthCheckConfig) {
 	}
 }
 
-// deriveDeepCopy_15 recursively copies the contents of src into dst.
-func deriveDeepCopy_15(dst, src *LoggingConfig) {
+// deriveDeepCopy_16 recursively copies the contents of src into dst.
+func deriveDeepCopy_16(dst, src *LoggingConfig) {
 	dst.Driver = src.Driver
 	if src.Options != nil {
 		dst.Options = make(map[string]string, len(src.Options))
@@ -1254,8 +1265,8 @@ func deriveDeepCopy_15(dst, src *LoggingConfig) {
 	}
 }
 
-// deriveDeepCopy_16 recursively copies the contents of src into dst.
-func deriveDeepCopy_16(dst, src map[string]*ServiceNetworkConfig) {
+// deriveDeepCopy_17 recursively copies the contents of src into dst.
+func deriveDeepCopy_17(dst, src map[string]*ServiceNetworkConfig) {
 	for src_key, src_value := range src {
 		if src_value == nil {
 			dst[src_key] = nil
@@ -1264,35 +1275,35 @@ func deriveDeepCopy_16(dst, src map[string]*ServiceNetworkConfig) {
 			dst[src_key] = nil
 		} else {
 			dst[src_key] = new(ServiceNetworkConfig)
-			deriveDeepCopy_34(dst[src_key], src_value)
+			deriveDeepCopy_36(dst[src_key], src_value)
 		}
 	}
 }
 
-// deriveDeepCopy_17 recursively copies the contents of src into dst.
-func deriveDeepCopy_17(dst, src []ServicePortConfig) {
+// deriveDeepCopy_18 recursively copies the contents of src into dst.
+func deriveDeepCopy_18(dst, src []ServicePortConfig) {
 	for src_i, src_value := range src {
 		func() {
 			field := new(ServicePortConfig)
-			deriveDeepCopy_35(field, &src_value)
-			dst[src_i] = *field
-		}()
-	}
-}
-
-// deriveDeepCopy_18 recursively copies the contents of src into dst.
-func deriveDeepCopy_18(dst, src []ServiceSecretConfig) {
-	for src_i, src_value := range src {
-		func() {
-			field := new(ServiceSecretConfig)
-			deriveDeepCopy_36(field, &src_value)
+			deriveDeepCopy_37(field, &src_value)
 			dst[src_i] = *field
 		}()
 	}
 }
 
 // deriveDeepCopy_19 recursively copies the contents of src into dst.
-func deriveDeepCopy_19(dst, src map[string]*UlimitsConfig) {
+func deriveDeepCopy_19(dst, src []ServiceSecretConfig) {
+	for src_i, src_value := range src {
+		func() {
+			field := new(ServiceSecretConfig)
+			deriveDeepCopy_38(field, &src_value)
+			dst[src_i] = *field
+		}()
+	}
+}
+
+// deriveDeepCopy_20 recursively copies the contents of src into dst.
+func deriveDeepCopy_20(dst, src map[string]*UlimitsConfig) {
 	for src_key, src_value := range src {
 		if src_value == nil {
 			dst[src_key] = nil
@@ -1301,24 +1312,24 @@ func deriveDeepCopy_19(dst, src map[string]*UlimitsConfig) {
 			dst[src_key] = nil
 		} else {
 			dst[src_key] = new(UlimitsConfig)
-			deriveDeepCopy_37(dst[src_key], src_value)
+			deriveDeepCopy_39(dst[src_key], src_value)
 		}
 	}
 }
 
-// deriveDeepCopy_20 recursively copies the contents of src into dst.
-func deriveDeepCopy_20(dst, src []ServiceVolumeConfig) {
+// deriveDeepCopy_21 recursively copies the contents of src into dst.
+func deriveDeepCopy_21(dst, src []ServiceVolumeConfig) {
 	for src_i, src_value := range src {
 		func() {
 			field := new(ServiceVolumeConfig)
-			deriveDeepCopy_38(field, &src_value)
+			deriveDeepCopy_40(field, &src_value)
 			dst[src_i] = *field
 		}()
 	}
 }
 
-// deriveDeepCopy_21 recursively copies the contents of src into dst.
-func deriveDeepCopy_21(dst, src *NetworkConfig) {
+// deriveDeepCopy_22 recursively copies the contents of src into dst.
+func deriveDeepCopy_22(dst, src *NetworkConfig) {
 	dst.Name = src.Name
 	dst.Driver = src.Driver
 	if src.DriverOpts != nil {
@@ -1329,7 +1340,7 @@ func deriveDeepCopy_21(dst, src *NetworkConfig) {
 	}
 	func() {
 		field := new(IPAMConfig)
-		deriveDeepCopy_39(field, &src.Ipam)
+		deriveDeepCopy_41(field, &src.Ipam)
 		dst.Ipam = *field
 	}()
 	dst.External = src.External
@@ -1355,44 +1366,9 @@ func deriveDeepCopy_21(dst, src *NetworkConfig) {
 	}
 }
 
-// deriveDeepCopy_22 recursively copies the contents of src into dst.
-func deriveDeepCopy_22(dst, src *VolumeConfig) {
-	dst.Name = src.Name
-	dst.Driver = src.Driver
-	if src.DriverOpts != nil {
-		dst.DriverOpts = make(map[string]string, len(src.DriverOpts))
-		deriveDeepCopy_4(dst.DriverOpts, src.DriverOpts)
-	} else {
-		dst.DriverOpts = nil
-	}
-	dst.External = src.External
-	if src.Labels != nil {
-		dst.Labels = make(map[string]string, len(src.Labels))
-		deriveDeepCopy_4(dst.Labels, src.Labels)
-	} else {
-		dst.Labels = nil
-	}
-	if src.Extensions != nil {
-		dst.Extensions = make(map[string]any, len(src.Extensions))
-		src.Extensions.DeepCopy(dst.Extensions)
-	} else {
-		dst.Extensions = nil
-	}
-}
-
 // deriveDeepCopy_23 recursively copies the contents of src into dst.
-func deriveDeepCopy_23(dst, src *SecretConfig) {
+func deriveDeepCopy_23(dst, src *VolumeConfig) {
 	dst.Name = src.Name
-	dst.File = src.File
-	dst.Environment = src.Environment
-	dst.Content = src.Content
-	dst.External = src.External
-	if src.Labels != nil {
-		dst.Labels = make(map[string]string, len(src.Labels))
-		deriveDeepCopy_4(dst.Labels, src.Labels)
-	} else {
-		dst.Labels = nil
-	}
 	dst.Driver = src.Driver
 	if src.DriverOpts != nil {
 		dst.DriverOpts = make(map[string]string, len(src.DriverOpts))
@@ -1400,7 +1376,13 @@ func deriveDeepCopy_23(dst, src *SecretConfig) {
 	} else {
 		dst.DriverOpts = nil
 	}
-	dst.TemplateDriver = src.TemplateDriver
+	dst.External = src.External
+	if src.Labels != nil {
+		dst.Labels = make(map[string]string, len(src.Labels))
+		deriveDeepCopy_4(dst.Labels, src.Labels)
+	} else {
+		dst.Labels = nil
+	}
 	if src.Extensions != nil {
 		dst.Extensions = make(map[string]any, len(src.Extensions))
 		src.Extensions.DeepCopy(dst.Extensions)
@@ -1410,7 +1392,7 @@ func deriveDeepCopy_23(dst, src *SecretConfig) {
 }
 
 // deriveDeepCopy_24 recursively copies the contents of src into dst.
-func deriveDeepCopy_24(dst, src *ConfigObjConfig) {
+func deriveDeepCopy_24(dst, src *SecretConfig) {
 	dst.Name = src.Name
 	dst.File = src.File
 	dst.Environment = src.Environment
@@ -1439,40 +1421,69 @@ func deriveDeepCopy_24(dst, src *ConfigObjConfig) {
 }
 
 // deriveDeepCopy_25 recursively copies the contents of src into dst.
-func deriveDeepCopy_25(dst, src []Trigger) {
-	for src_i, src_value := range src {
-		func() {
-			field := new(Trigger)
-			deriveDeepCopy_40(field, &src_value)
-			dst[src_i] = *field
-		}()
+func deriveDeepCopy_25(dst, src *ConfigObjConfig) {
+	dst.Name = src.Name
+	dst.File = src.File
+	dst.Environment = src.Environment
+	dst.Content = src.Content
+	dst.External = src.External
+	if src.Labels != nil {
+		dst.Labels = make(map[string]string, len(src.Labels))
+		deriveDeepCopy_4(dst.Labels, src.Labels)
+	} else {
+		dst.Labels = nil
+	}
+	dst.Driver = src.Driver
+	if src.DriverOpts != nil {
+		dst.DriverOpts = make(map[string]string, len(src.DriverOpts))
+		deriveDeepCopy_4(dst.DriverOpts, src.DriverOpts)
+	} else {
+		dst.DriverOpts = nil
+	}
+	dst.TemplateDriver = src.TemplateDriver
+	if src.Extensions != nil {
+		dst.Extensions = make(map[string]any, len(src.Extensions))
+		src.Extensions.DeepCopy(dst.Extensions)
+	} else {
+		dst.Extensions = nil
 	}
 }
 
 // deriveDeepCopy_26 recursively copies the contents of src into dst.
-func deriveDeepCopy_26(dst, src []WeightDevice) {
+func deriveDeepCopy_26(dst, src []Trigger) {
 	for src_i, src_value := range src {
 		func() {
-			field := new(WeightDevice)
-			deriveDeepCopy_41(field, &src_value)
-			dst[src_i] = *field
-		}()
-	}
-}
-
-// deriveDeepCopy_27 recursively copies the contents of src into dst.
-func deriveDeepCopy_27(dst, src []ThrottleDevice) {
-	for src_i, src_value := range src {
-		func() {
-			field := new(ThrottleDevice)
+			field := new(Trigger)
 			deriveDeepCopy_42(field, &src_value)
 			dst[src_i] = *field
 		}()
 	}
 }
 
+// deriveDeepCopy_27 recursively copies the contents of src into dst.
+func deriveDeepCopy_27(dst, src []WeightDevice) {
+	for src_i, src_value := range src {
+		func() {
+			field := new(WeightDevice)
+			deriveDeepCopy_43(field, &src_value)
+			dst[src_i] = *field
+		}()
+	}
+}
+
 // deriveDeepCopy_28 recursively copies the contents of src into dst.
-func deriveDeepCopy_28(dst, src *ServiceConfigObjConfig) {
+func deriveDeepCopy_28(dst, src []ThrottleDevice) {
+	for src_i, src_value := range src {
+		func() {
+			field := new(ThrottleDevice)
+			deriveDeepCopy_44(field, &src_value)
+			dst[src_i] = *field
+		}()
+	}
+}
+
+// deriveDeepCopy_29 recursively copies the contents of src into dst.
+func deriveDeepCopy_29(dst, src *ServiceConfigObjConfig) {
 	dst.Source = src.Source
 	dst.Target = src.Target
 	dst.UID = src.UID
@@ -1491,8 +1502,8 @@ func deriveDeepCopy_28(dst, src *ServiceConfigObjConfig) {
 	}
 }
 
-// deriveDeepCopy_29 recursively copies the contents of src into dst.
-func deriveDeepCopy_29(dst, src *ServiceDependency) {
+// deriveDeepCopy_30 recursively copies the contents of src into dst.
+func deriveDeepCopy_30(dst, src *ServiceDependency) {
 	dst.Condition = src.Condition
 	dst.Restart = src.Restart
 	if src.Extensions != nil {
@@ -1504,8 +1515,8 @@ func deriveDeepCopy_29(dst, src *ServiceDependency) {
 	dst.Required = src.Required
 }
 
-// deriveDeepCopy_30 recursively copies the contents of src into dst.
-func deriveDeepCopy_30(dst, src *UpdateConfig) {
+// deriveDeepCopy_31 recursively copies the contents of src into dst.
+func deriveDeepCopy_31(dst, src *UpdateConfig) {
 	if src.Parallelism == nil {
 		dst.Parallelism = nil
 	} else {
@@ -1525,19 +1536,19 @@ func deriveDeepCopy_30(dst, src *UpdateConfig) {
 	}
 }
 
-// deriveDeepCopy_31 recursively copies the contents of src into dst.
-func deriveDeepCopy_31(dst, src *Resources) {
+// deriveDeepCopy_32 recursively copies the contents of src into dst.
+func deriveDeepCopy_32(dst, src *Resources) {
 	if src.Limits == nil {
 		dst.Limits = nil
 	} else {
 		dst.Limits = new(Resource)
-		deriveDeepCopy_43(dst.Limits, src.Limits)
+		deriveDeepCopy_45(dst.Limits, src.Limits)
 	}
 	if src.Reservations == nil {
 		dst.Reservations = nil
 	} else {
 		dst.Reservations = new(Resource)
-		deriveDeepCopy_43(dst.Reservations, src.Reservations)
+		deriveDeepCopy_45(dst.Reservations, src.Reservations)
 	}
 	if src.Extensions != nil {
 		dst.Extensions = make(map[string]any, len(src.Extensions))
@@ -1547,8 +1558,8 @@ func deriveDeepCopy_31(dst, src *Resources) {
 	}
 }
 
-// deriveDeepCopy_32 recursively copies the contents of src into dst.
-func deriveDeepCopy_32(dst, src *RestartPolicy) {
+// deriveDeepCopy_33 recursively copies the contents of src into dst.
+func deriveDeepCopy_33(dst, src *RestartPolicy) {
 	dst.Condition = src.Condition
 	if src.Delay == nil {
 		dst.Delay = nil
@@ -1576,8 +1587,8 @@ func deriveDeepCopy_32(dst, src *RestartPolicy) {
 	}
 }
 
-// deriveDeepCopy_33 recursively copies the contents of src into dst.
-func deriveDeepCopy_33(dst, src *Placement) {
+// deriveDeepCopy_34 recursively copies the contents of src into dst.
+func deriveDeepCopy_34(dst, src *Placement) {
 	if src.Constraints == nil {
 		dst.Constraints = nil
 	} else {
@@ -1612,7 +1623,7 @@ func deriveDeepCopy_33(dst, src *Placement) {
 		} else {
 			dst.Preferences = make([]PlacementPreferences, len(src.Preferences))
 		}
-		deriveDeepCopy_44(dst.Preferences, src.Preferences)
+		deriveDeepCopy_46(dst.Preferences, src.Preferences)
 	}
 	dst.MaxReplicas = src.MaxReplicas
 	if src.Extensions != nil {
@@ -1623,8 +1634,21 @@ func deriveDeepCopy_33(dst, src *Placement) {
 	}
 }
 
-// deriveDeepCopy_34 recursively copies the contents of src into dst.
-func deriveDeepCopy_34(dst, src *ServiceNetworkConfig) {
+// deriveDeepCopy_35 recursively copies the contents of src into dst.
+func deriveDeepCopy_35(dst, src *DeviceMapping) {
+	dst.Source = src.Source
+	dst.Target = src.Target
+	dst.Permissions = src.Permissions
+	if src.Extensions != nil {
+		dst.Extensions = make(map[string]any, len(src.Extensions))
+		src.Extensions.DeepCopy(dst.Extensions)
+	} else {
+		dst.Extensions = nil
+	}
+}
+
+// deriveDeepCopy_36 recursively copies the contents of src into dst.
+func deriveDeepCopy_36(dst, src *ServiceNetworkConfig) {
 	dst.Priority = src.Priority
 	if src.Aliases == nil {
 		dst.Aliases = nil
@@ -1679,8 +1703,8 @@ func deriveDeepCopy_34(dst, src *ServiceNetworkConfig) {
 	}
 }
 
-// deriveDeepCopy_35 recursively copies the contents of src into dst.
-func deriveDeepCopy_35(dst, src *ServicePortConfig) {
+// deriveDeepCopy_37 recursively copies the contents of src into dst.
+func deriveDeepCopy_37(dst, src *ServicePortConfig) {
 	dst.Name = src.Name
 	dst.Mode = src.Mode
 	dst.HostIP = src.HostIP
@@ -1696,8 +1720,8 @@ func deriveDeepCopy_35(dst, src *ServicePortConfig) {
 	}
 }
 
-// deriveDeepCopy_36 recursively copies the contents of src into dst.
-func deriveDeepCopy_36(dst, src *ServiceSecretConfig) {
+// deriveDeepCopy_38 recursively copies the contents of src into dst.
+func deriveDeepCopy_38(dst, src *ServiceSecretConfig) {
 	dst.Source = src.Source
 	dst.Target = src.Target
 	dst.UID = src.UID
@@ -1716,8 +1740,8 @@ func deriveDeepCopy_36(dst, src *ServiceSecretConfig) {
 	}
 }
 
-// deriveDeepCopy_37 recursively copies the contents of src into dst.
-func deriveDeepCopy_37(dst, src *UlimitsConfig) {
+// deriveDeepCopy_39 recursively copies the contents of src into dst.
+func deriveDeepCopy_39(dst, src *UlimitsConfig) {
 	dst.Single = src.Single
 	dst.Soft = src.Soft
 	dst.Hard = src.Hard
@@ -1729,8 +1753,8 @@ func deriveDeepCopy_37(dst, src *UlimitsConfig) {
 	}
 }
 
-// deriveDeepCopy_38 recursively copies the contents of src into dst.
-func deriveDeepCopy_38(dst, src *ServiceVolumeConfig) {
+// deriveDeepCopy_40 recursively copies the contents of src into dst.
+func deriveDeepCopy_40(dst, src *ServiceVolumeConfig) {
 	dst.Type = src.Type
 	dst.Source = src.Source
 	dst.Target = src.Target
@@ -1740,19 +1764,19 @@ func deriveDeepCopy_38(dst, src *ServiceVolumeConfig) {
 		dst.Bind = nil
 	} else {
 		dst.Bind = new(ServiceVolumeBind)
-		deriveDeepCopy_45(dst.Bind, src.Bind)
+		deriveDeepCopy_47(dst.Bind, src.Bind)
 	}
 	if src.Volume == nil {
 		dst.Volume = nil
 	} else {
 		dst.Volume = new(ServiceVolumeVolume)
-		deriveDeepCopy_46(dst.Volume, src.Volume)
+		deriveDeepCopy_48(dst.Volume, src.Volume)
 	}
 	if src.Tmpfs == nil {
 		dst.Tmpfs = nil
 	} else {
 		dst.Tmpfs = new(ServiceVolumeTmpfs)
-		deriveDeepCopy_47(dst.Tmpfs, src.Tmpfs)
+		deriveDeepCopy_49(dst.Tmpfs, src.Tmpfs)
 	}
 	if src.Extensions != nil {
 		dst.Extensions = make(map[string]any, len(src.Extensions))
@@ -1762,8 +1786,8 @@ func deriveDeepCopy_38(dst, src *ServiceVolumeConfig) {
 	}
 }
 
-// deriveDeepCopy_39 recursively copies the contents of src into dst.
-func deriveDeepCopy_39(dst, src *IPAMConfig) {
+// deriveDeepCopy_41 recursively copies the contents of src into dst.
+func deriveDeepCopy_41(dst, src *IPAMConfig) {
 	dst.Driver = src.Driver
 	if src.Config == nil {
 		dst.Config = nil
@@ -1781,7 +1805,7 @@ func deriveDeepCopy_39(dst, src *IPAMConfig) {
 		} else {
 			dst.Config = make([]*IPAMPool, len(src.Config))
 		}
-		deriveDeepCopy_48(dst.Config, src.Config)
+		deriveDeepCopy_50(dst.Config, src.Config)
 	}
 	if src.Extensions != nil {
 		dst.Extensions = make(map[string]any, len(src.Extensions))
@@ -1791,8 +1815,8 @@ func deriveDeepCopy_39(dst, src *IPAMConfig) {
 	}
 }
 
-// deriveDeepCopy_40 recursively copies the contents of src into dst.
-func deriveDeepCopy_40(dst, src *Trigger) {
+// deriveDeepCopy_42 recursively copies the contents of src into dst.
+func deriveDeepCopy_42(dst, src *Trigger) {
 	dst.Path = src.Path
 	dst.Action = src.Action
 	dst.Target = src.Target
@@ -1822,8 +1846,8 @@ func deriveDeepCopy_40(dst, src *Trigger) {
 	}
 }
 
-// deriveDeepCopy_41 recursively copies the contents of src into dst.
-func deriveDeepCopy_41(dst, src *WeightDevice) {
+// deriveDeepCopy_43 recursively copies the contents of src into dst.
+func deriveDeepCopy_43(dst, src *WeightDevice) {
 	dst.Path = src.Path
 	dst.Weight = src.Weight
 	if src.Extensions != nil {
@@ -1834,8 +1858,8 @@ func deriveDeepCopy_41(dst, src *WeightDevice) {
 	}
 }
 
-// deriveDeepCopy_42 recursively copies the contents of src into dst.
-func deriveDeepCopy_42(dst, src *ThrottleDevice) {
+// deriveDeepCopy_44 recursively copies the contents of src into dst.
+func deriveDeepCopy_44(dst, src *ThrottleDevice) {
 	dst.Path = src.Path
 	dst.Rate = src.Rate
 	if src.Extensions != nil {
@@ -1846,8 +1870,8 @@ func deriveDeepCopy_42(dst, src *ThrottleDevice) {
 	}
 }
 
-// deriveDeepCopy_43 recursively copies the contents of src into dst.
-func deriveDeepCopy_43(dst, src *Resource) {
+// deriveDeepCopy_45 recursively copies the contents of src into dst.
+func deriveDeepCopy_45(dst, src *Resource) {
 	dst.NanoCPUs = src.NanoCPUs
 	dst.MemoryBytes = src.MemoryBytes
 	dst.Pids = src.Pids
@@ -1867,7 +1891,7 @@ func deriveDeepCopy_43(dst, src *Resource) {
 		} else {
 			dst.Devices = make([]DeviceRequest, len(src.Devices))
 		}
-		deriveDeepCopy_49(dst.Devices, src.Devices)
+		deriveDeepCopy_51(dst.Devices, src.Devices)
 	}
 	if src.GenericResources == nil {
 		dst.GenericResources = nil
@@ -1885,7 +1909,7 @@ func deriveDeepCopy_43(dst, src *Resource) {
 		} else {
 			dst.GenericResources = make([]GenericResource, len(src.GenericResources))
 		}
-		deriveDeepCopy_50(dst.GenericResources, src.GenericResources)
+		deriveDeepCopy_52(dst.GenericResources, src.GenericResources)
 	}
 	if src.Extensions != nil {
 		dst.Extensions = make(map[string]any, len(src.Extensions))
@@ -1895,19 +1919,19 @@ func deriveDeepCopy_43(dst, src *Resource) {
 	}
 }
 
-// deriveDeepCopy_44 recursively copies the contents of src into dst.
-func deriveDeepCopy_44(dst, src []PlacementPreferences) {
+// deriveDeepCopy_46 recursively copies the contents of src into dst.
+func deriveDeepCopy_46(dst, src []PlacementPreferences) {
 	for src_i, src_value := range src {
 		func() {
 			field := new(PlacementPreferences)
-			deriveDeepCopy_51(field, &src_value)
+			deriveDeepCopy_53(field, &src_value)
 			dst[src_i] = *field
 		}()
 	}
 }
 
-// deriveDeepCopy_45 recursively copies the contents of src into dst.
-func deriveDeepCopy_45(dst, src *ServiceVolumeBind) {
+// deriveDeepCopy_47 recursively copies the contents of src into dst.
+func deriveDeepCopy_47(dst, src *ServiceVolumeBind) {
 	dst.SELinux = src.SELinux
 	dst.Propagation = src.Propagation
 	dst.CreateHostPath = src.CreateHostPath
@@ -1919,8 +1943,8 @@ func deriveDeepCopy_45(dst, src *ServiceVolumeBind) {
 	}
 }
 
-// deriveDeepCopy_46 recursively copies the contents of src into dst.
-func deriveDeepCopy_46(dst, src *ServiceVolumeVolume) {
+// deriveDeepCopy_48 recursively copies the contents of src into dst.
+func deriveDeepCopy_48(dst, src *ServiceVolumeVolume) {
 	dst.NoCopy = src.NoCopy
 	dst.Subpath = src.Subpath
 	if src.Extensions != nil {
@@ -1931,8 +1955,8 @@ func deriveDeepCopy_46(dst, src *ServiceVolumeVolume) {
 	}
 }
 
-// deriveDeepCopy_47 recursively copies the contents of src into dst.
-func deriveDeepCopy_47(dst, src *ServiceVolumeTmpfs) {
+// deriveDeepCopy_49 recursively copies the contents of src into dst.
+func deriveDeepCopy_49(dst, src *ServiceVolumeTmpfs) {
 	dst.Size = src.Size
 	dst.Mode = src.Mode
 	if src.Extensions != nil {
@@ -1943,42 +1967,42 @@ func deriveDeepCopy_47(dst, src *ServiceVolumeTmpfs) {
 	}
 }
 
-// deriveDeepCopy_48 recursively copies the contents of src into dst.
-func deriveDeepCopy_48(dst, src []*IPAMPool) {
+// deriveDeepCopy_50 recursively copies the contents of src into dst.
+func deriveDeepCopy_50(dst, src []*IPAMPool) {
 	for src_i, src_value := range src {
 		if src_value == nil {
 			dst[src_i] = nil
 		} else {
 			dst[src_i] = new(IPAMPool)
-			deriveDeepCopy_52(dst[src_i], src_value)
+			deriveDeepCopy_54(dst[src_i], src_value)
 		}
 	}
 }
 
-// deriveDeepCopy_49 recursively copies the contents of src into dst.
-func deriveDeepCopy_49(dst, src []DeviceRequest) {
+// deriveDeepCopy_51 recursively copies the contents of src into dst.
+func deriveDeepCopy_51(dst, src []DeviceRequest) {
 	for src_i, src_value := range src {
 		func() {
 			field := new(DeviceRequest)
-			deriveDeepCopy_53(field, &src_value)
+			deriveDeepCopy_55(field, &src_value)
 			dst[src_i] = *field
 		}()
 	}
 }
 
-// deriveDeepCopy_50 recursively copies the contents of src into dst.
-func deriveDeepCopy_50(dst, src []GenericResource) {
+// deriveDeepCopy_52 recursively copies the contents of src into dst.
+func deriveDeepCopy_52(dst, src []GenericResource) {
 	for src_i, src_value := range src {
 		func() {
 			field := new(GenericResource)
-			deriveDeepCopy_54(field, &src_value)
+			deriveDeepCopy_56(field, &src_value)
 			dst[src_i] = *field
 		}()
 	}
 }
 
-// deriveDeepCopy_51 recursively copies the contents of src into dst.
-func deriveDeepCopy_51(dst, src *PlacementPreferences) {
+// deriveDeepCopy_53 recursively copies the contents of src into dst.
+func deriveDeepCopy_53(dst, src *PlacementPreferences) {
 	dst.Spread = src.Spread
 	if src.Extensions != nil {
 		dst.Extensions = make(map[string]any, len(src.Extensions))
@@ -1988,8 +2012,8 @@ func deriveDeepCopy_51(dst, src *PlacementPreferences) {
 	}
 }
 
-// deriveDeepCopy_52 recursively copies the contents of src into dst.
-func deriveDeepCopy_52(dst, src *IPAMPool) {
+// deriveDeepCopy_54 recursively copies the contents of src into dst.
+func deriveDeepCopy_54(dst, src *IPAMPool) {
 	dst.Subnet = src.Subnet
 	dst.Gateway = src.Gateway
 	dst.IPRange = src.IPRange
@@ -2007,8 +2031,8 @@ func deriveDeepCopy_52(dst, src *IPAMPool) {
 	}
 }
 
-// deriveDeepCopy_53 recursively copies the contents of src into dst.
-func deriveDeepCopy_53(dst, src *DeviceRequest) {
+// deriveDeepCopy_55 recursively copies the contents of src into dst.
+func deriveDeepCopy_55(dst, src *DeviceRequest) {
 	if src.Capabilities == nil {
 		dst.Capabilities = nil
 	} else {
@@ -2047,15 +2071,21 @@ func deriveDeepCopy_53(dst, src *DeviceRequest) {
 		}
 		copy(dst.IDs, src.IDs)
 	}
+	if src.Options != nil {
+		dst.Options = make(map[string]string, len(src.Options))
+		deriveDeepCopy_4(dst.Options, src.Options)
+	} else {
+		dst.Options = nil
+	}
 }
 
-// deriveDeepCopy_54 recursively copies the contents of src into dst.
-func deriveDeepCopy_54(dst, src *GenericResource) {
+// deriveDeepCopy_56 recursively copies the contents of src into dst.
+func deriveDeepCopy_56(dst, src *GenericResource) {
 	if src.DiscreteResourceSpec == nil {
 		dst.DiscreteResourceSpec = nil
 	} else {
 		dst.DiscreteResourceSpec = new(DiscreteGenericResource)
-		deriveDeepCopy_55(dst.DiscreteResourceSpec, src.DiscreteResourceSpec)
+		deriveDeepCopy_57(dst.DiscreteResourceSpec, src.DiscreteResourceSpec)
 	}
 	if src.Extensions != nil {
 		dst.Extensions = make(map[string]any, len(src.Extensions))
@@ -2065,8 +2095,8 @@ func deriveDeepCopy_54(dst, src *GenericResource) {
 	}
 }
 
-// deriveDeepCopy_55 recursively copies the contents of src into dst.
-func deriveDeepCopy_55(dst, src *DiscreteGenericResource) {
+// deriveDeepCopy_57 recursively copies the contents of src into dst.
+func deriveDeepCopy_57(dst, src *DiscreteGenericResource) {
 	dst.Kind = src.Kind
 	dst.Value = src.Value
 	if src.Extensions != nil {

--- a/types/device.go
+++ b/types/device.go
@@ -27,6 +27,7 @@ type DeviceRequest struct {
 	Driver       string      `yaml:"driver,omitempty" json:"driver,omitempty"`
 	Count        DeviceCount `yaml:"count,omitempty" json:"count,omitempty"`
 	IDs          []string    `yaml:"device_ids,omitempty" json:"device_ids,omitempty"`
+	Options      Mapping     `yaml:"options,omitempty" json:"options,omitempty"`
 }
 
 type DeviceCount int64
@@ -91,6 +92,13 @@ func (d *DeviceRequest) DecodeMapstructure(value interface{}) error {
 		}
 		d.IDs = ids
 		d.Count = DeviceCount(len(ids))
+	}
+
+	d.Options = Mapping{}
+	if options, ok := v["options"].(map[string]any); ok {
+		for k, v := range options {
+			d.Options[k] = fmt.Sprint(v)
+		}
 	}
 	return nil
 


### PR DESCRIPTION
defined by the spec but missing in go struct for some legacy reasons