### PR TITLE
introduce ability to define image reference as {name,tag,digest}

### DIFF
--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -211,7 +211,7 @@ func TestProjectFromSetOfFiles(t *testing.T) {
 	assert.NilError(t, err)
 	service, err := p.GetService("simple")
 	assert.NilError(t, err)
-	assert.Equal(t, service.Image, "haproxy")
+	assert.Equal(t, service.Image, types.Image("haproxy"))
 }
 
 func TestProjectComposefilesFromSetOfFiles(t *testing.T) {

--- a/loader/include_test.go
+++ b/loader/include_test.go
@@ -221,7 +221,7 @@ services:
 		options.SetProjectName("project", true)
 	})
 	assert.NilError(t, err)
-	assert.Equal(t, p.Services["included"].Image, "alpine")
+	assert.Equal(t, p.Services["included"].Image, types.Image("alpine"))
 }
 
 func createFile(t *testing.T, rootDir, content, fileName string) string {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -333,7 +333,7 @@ services:
 	}, actual.Extensions))
 	assert.Check(t, is.Len(actual.Services, 2))
 	service := actual.Services["foo"]
-	assert.Check(t, is.Equal("busybox", service.Image))
+	assert.Check(t, is.Equal(service.Image, types.Image("busybox")))
 
 	assert.Check(t, is.DeepEqual(types.Extensions{
 		"x-foo": "bar",
@@ -2720,7 +2720,7 @@ services:
 		options.ResolvePaths = true
 	})
 	assert.NilError(t, err)
-	assert.Equal(t, p.Services["imported"].Image, "overridden")
+	assert.Equal(t, p.Services["imported"].Image, types.Image("overridden"))
 }
 
 func TestLoadDependsOnCycle(t *testing.T) {
@@ -2921,7 +2921,7 @@ services:
 
 `)
 	assert.NilError(t, err)
-	assert.Equal(t, project.Services["test"].Image, "nginx:override")
+	assert.Equal(t, project.Services["test"].Image, types.Image("nginx:override"))
 }
 
 func TestLoadDevelopConfig(t *testing.T) {
@@ -3554,4 +3554,18 @@ services:
 			},
 		},
 	})
+}
+
+func TestLoadImageReference(t *testing.T) {
+	p, err := loadYAML(`
+name: load-image-reference
+services:
+  test:
+    image:
+      name: registry.com/foo
+      tag: bar
+      digest: sha256:1234567890123456789012345678901234567890123456789012345678901234
+`)
+	assert.NilError(t, err)
+	assert.Equal(t, p.Services["test"].Image, types.Image("registry.com/foo:bar@sha256:1234567890123456789012345678901234567890123456789012345678901234"))
 }

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -276,7 +276,7 @@
         },
         "healthcheck": {"$ref": "#/definitions/healthcheck"},
         "hostname": {"type": "string"},
-        "image": {"type": "string"},
+        "image": {"$ref": "#/definitions/imageReference"},
         "init": {"type": ["boolean", "string"]},
         "ipc": {"type": "string"},
         "isolation": {"type": "string"},
@@ -463,6 +463,24 @@
       },
       "patternProperties": {"^x-": {}},
       "additionalProperties": false
+    },
+
+    "imageReference": {
+      "id": "#/definitions/imageReference",
+      "oneOf": [
+        {"type": "string"},
+        {
+          "type": "object",
+          "properties": {
+            "name": {"type": "string"},
+            "tag": {"type": "string"},
+            "digest": {"type": "string"}
+          },
+          "required": ["name"],
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        }
+      ]
     },
 
     "healthcheck": {

--- a/types/project.go
+++ b/types/project.go
@@ -539,7 +539,7 @@ func (p *Project) WithImagesResolved(resolver func(named reference.Named) (godig
 		if service.Image == "" {
 			return service, nil
 		}
-		named, err := reference.ParseDockerRef(service.Image)
+		named, err := reference.ParseDockerRef(string(service.Image))
 		if err != nil {
 			return service, err
 		}
@@ -555,7 +555,7 @@ func (p *Project) WithImagesResolved(resolver func(named reference.Named) (godig
 				return service, err
 			}
 		}
-		service.Image = named.String()
+		service.Image = Image(named.String())
 		return service, nil
 	})
 }

--- a/types/project_test.go
+++ b/types/project_test.go
@@ -200,11 +200,11 @@ func Test_ResolveImages(t *testing.T) {
 
 	for _, test := range tests {
 		service := p.Services["service_1"]
-		service.Image = test.image
+		service.Image = Image(test.image)
 		p.Services["service_1"] = service
 		p, err := p.WithImagesResolved(resolver)
 		assert.NilError(t, err)
-		assert.Equal(t, p.Services["service_1"].Image, test.resolved)
+		assert.Equal(t, p.Services["service_1"].Image, Image(test.resolved))
 	}
 }
 
@@ -218,14 +218,15 @@ func Test_ResolveImages_concurrent(t *testing.T) {
 	}
 	for i := 0; i < 1000; i++ {
 		p.Services[fmt.Sprintf("service_%d", i)] = ServiceConfig{
-			Image: fmt.Sprintf("image_%d", i),
+			Image: Image(fmt.Sprintf("image_%d", i)),
 		}
 	}
 	p, err := p.WithImagesResolved(resolver)
 	assert.NilError(t, err)
 	for i := 0; i < 1000; i++ {
+		expected := fmt.Sprintf("docker.io/library/image_%d:latest@%s", i, garfield)
 		assert.Equal(t, p.Services[fmt.Sprintf("service_%d", i)].Image,
-			fmt.Sprintf("docker.io/library/image_%d:latest@%s", i, garfield))
+			Image(expected))
 	}
 }
 
@@ -238,7 +239,7 @@ func Test_ResolveImages_concurrent_interrupted(t *testing.T) {
 	}
 	for i := 0; i < 10; i++ {
 		p.Services[fmt.Sprintf("service_%d", i)] = ServiceConfig{
-			Image: fmt.Sprintf("image_%d", i),
+			Image: Image(fmt.Sprintf("image_%d", i)),
 		}
 	}
 	_, err := p.WithImagesResolved(resolver)


### PR DESCRIPTION
introduce ability to define a service image as a combination of `name`, `tag` and `digest` (aligned with https://github.com/distribution/reference terminology)

```yaml
services:
  test:
    image:
      name: registry.com/foo
      tag: bar
      digest: sha256:1234...
```

__to be debated:__
Shall we also split name as `registry`+`repository` (see https://github.com/opencontainers/distribution-spec/blob/main/spec.md) ?


closes https://github.com/docker/compose/issues/11743