### PR TITLE
detect project dir is a symlink and warn user

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -502,8 +502,13 @@ func withNamePrecedenceLoad(absWorkingDir string, options *ProjectOptions) func(
 		} else if nameFromEnv, ok := options.Environment[consts.ComposeProjectName]; ok && nameFromEnv != "" {
 			opts.SetProjectName(nameFromEnv, true)
 		} else {
+			dirname := filepath.Base(absWorkingDir)
+			symlink, err := filepath.EvalSymlinks(absWorkingDir)
+			if err == nil && filepath.Base(symlink) != dirname {
+				logrus.Warnf("project has been loaded without an explicit name from a symlink. Using name %q", dirname)
+			}
 			opts.SetProjectName(
-				loader.NormalizeProjectName(filepath.Base(absWorkingDir)),
+				loader.NormalizeProjectName(dirname),
 				false,
 			)
 		}


### PR DESCRIPTION
when ran from a symlink, while we find compose.yaml we run with a distinct project_dir and project_name. This might be user intent but also can cause unexpected behavior. This PR adds a sanity-check for such circumstances to warn user

closes https://github.com/docker/compose/issues/12026