### PR TITLE
fix(reset): Add cycle detector in reset.go

### DIFF
--- a/loader/reset.go
+++ b/loader/reset.go
@@ -28,7 +28,7 @@ import (
 type ResetProcessor struct {
 	target       interface{}
 	paths        []tree.Path
-	visitedNodes map[*yaml.Node]bool
+	visitedNodes map[*yaml.Node]string
 }
 
 // UnmarshalYAML implement yaml.Unmarshaler
@@ -43,23 +43,27 @@ func (p *ResetProcessor) UnmarshalYAML(value *yaml.Node) error {
 
 // resolveReset detects `!reset` tag being set on yaml nodes and record position in the yaml tree
 func (p *ResetProcessor) resolveReset(node *yaml.Node, path tree.Path) (*yaml.Node, error) {
+	pathStr := path.String()
 	// If the path contains "<<", removing the "<<" element and merging the path
-	if strings.Contains(path.String(), ".<<") {
-		path = tree.NewPath(strings.Replace(path.String(), ".<<", "", 1))
+	if strings.Contains(pathStr, ".<<") {
+		path = tree.NewPath(strings.Replace(pathStr, ".<<", "", 1))
 	}
 
 	// Check for cycle
 	if p.visitedNodes == nil {
-		p.visitedNodes = make(map[*yaml.Node]bool)
+		p.visitedNodes = make(map[*yaml.Node]string)
 	}
 
-	// Check if the current node has been visited before (cycle detection)
-	if p.visitedNodes[node] {
-		return nil, fmt.Errorf("cycle detected at path: %s", path.String())
+	// Check for cycle by seeing if the node has already been visited at this path
+	if previousPath, found := p.visitedNodes[node]; found {
+		// If the current node has been visited, we have a cycle if the previous path is a prefix
+		if strings.HasPrefix(pathStr, previousPath) {
+			return nil, fmt.Errorf("cycle detected at path: %s", pathStr)
+		}
 	}
 
 	// Mark the current node as visited
-	p.visitedNodes[node] = true
+	p.visitedNodes[node] = pathStr
 
 	// If the node is an alias, We need to process the alias field in order to consider the !override and !reset tags
 	if node.Kind == yaml.AliasNode {

--- a/loader/reset_test.go
+++ b/loader/reset_test.go
@@ -81,3 +81,24 @@ networks:
 	assert.NilError(t, err)
 	assert.Check(t, p.Networks["test"].External == false)
 }
+
+func TestResetCycle(t *testing.T) {
+	_, err := Load(
+		types.ConfigDetails{
+			ConfigFiles: []types.ConfigFile{
+				{
+					Filename: "(inline)",
+					Content: []byte(`
+x-healthcheck: &healthcheck
+  egress-service:
+    <<: *healthcheck
+`),
+				},
+			},
+		}, func(options *Options) {
+			options.SkipNormalization = true
+			options.SkipConsistencyCheck = true
+		},
+	)
+	assert.Error(t, err, "cycle detected at path: x-healthcheck.egress-service")
+}


### PR DESCRIPTION
Issue: https://github.com/docker/compose/issues/12235
I added the cycle detector to `reset.go`.  
Example yaml to reproduce the issue:
```
x-healthcheck: &healthcheck
  healthcheck:
    test: [ "CMD", "wget", "--quiet", "--spider", "--timeout=1", "http://localhost:9000/health/live" ]
    start_period: 20s
    start_interval: 1s
    interval: 30s
    timeout: 2s
    retries: 5


  egress-service:
    <<: *healthcheck
```