### PR TITLE
fix(reset): Add cycle detection fix for services that are prefixed with the name of a preceding service

### DIFF
--- a/loader/reset.go
+++ b/loader/reset.go
@@ -63,7 +63,7 @@ func (p *ResetProcessor) resolveReset(node *yaml.Node, path tree.Path) (*yaml.No
 	}
 
 	// Mark the current node as visited
-	p.visitedNodes[node] = pathStr
+	p.visitedNodes[node] = pathStr + "."
 
 	// If the node is an alias, We need to process the alias field in order to consider the !override and !reset tags
 	if node.Kind == yaml.AliasNode {


### PR DESCRIPTION
Fixed the cycle detector https://github.com/compose-spec/compose-go/pull/703  

It detects cycle for services that are prefixed with the name of a preceding service
https://github.com/docker/compose/issues/12235#issuecomment-2445030390