### PR TITLE
fix(loader): Add fix for stdin config read

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -414,7 +414,7 @@ func (o *ProjectOptions) ReadConfigFiles(ctx context.Context, workingDir string,
 	for i, c := range config.ConfigFiles {
 		var err error
 		var b []byte
-		if c.Filename == "-" {
+		if c.IsStdin() {
 			b, err = io.ReadAll(os.Stdin)
 			if err != nil {
 				return nil, err

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -318,6 +318,13 @@ func LoadConfigFiles(ctx context.Context, configFiles []string, workingDir strin
 	opts.ResourceLoaders = append(opts.ResourceLoaders, localResourceLoader{})
 
 	for i, p := range configFiles {
+		if p == "-" {
+			config.ConfigFiles[i] = types.ConfigFile{
+				Filename: p,
+			}
+			continue
+		}
+
 		for _, loader := range opts.ResourceLoaders {
 			_, isLocalResourceLoader := loader.(localResourceLoader)
 			if !loader.Accept(p) {

--- a/types/config.go
+++ b/types/config.go
@@ -67,6 +67,10 @@ type ConfigFile struct {
 	Config map[string]interface{}
 }
 
+func (cf ConfigFile) IsStdin() bool {
+	return cf.Filename == "-"
+}
+
 func ToConfigFiles(path []string) (f []ConfigFile) {
 	for _, p := range path {
 		f = append(f, ConfigFile{Filename: p})


### PR DESCRIPTION
Issue: https://github.com/docker/compose/issues/12248

This PR https://github.com/compose-spec/compose-go/pull/701 broke stdin config file read because it prepends working dir to the "-" and it tries to load the path.
