### PR TITLE
fix(variables): Add number suffix support to the variable extractor

### DIFF
--- a/template/variables.go
+++ b/template/variables.go
@@ -108,6 +108,9 @@ func extractVariable(value interface{}, pattern *regexp.Regexp) ([]Variable, boo
 			if r >= 'A' && r <= 'Z' {
 				return false
 			}
+			if r >= '0' && r <= '9' {
+				return false
+			}
 			if r == '_' {
 				return false
 			}

--- a/template/variables_test.go
+++ b/template/variables_test.go
@@ -51,6 +51,15 @@ func TestExtractVariables(t *testing.T) {
 			},
 		},
 		{
+			name: "variable-without-curly-braces-and-with-number-suffix",
+			dict: map[string]interface{}{
+				"foo": "$bar_1",
+			},
+			expected: map[string]Variable{
+				"bar_1": {Name: "bar_1"},
+			},
+		},
+		{
 			name: "variable",
 			dict: map[string]interface{}{
 				"foo": "${bar}",
@@ -66,6 +75,15 @@ func TestExtractVariables(t *testing.T) {
 			},
 			expected: map[string]Variable{
 				"bar": {Name: "bar", DefaultValue: "", Required: true},
+			},
+		},
+		{
+			name: "required-variable-with-number-suffix",
+			dict: map[string]interface{}{
+				"foo": "${bar_1?:foo}",
+			},
+			expected: map[string]Variable{
+				"bar_1": {Name: "bar_1", DefaultValue: "", Required: true},
 			},
 		},
 		{
@@ -93,6 +111,24 @@ func TestExtractVariables(t *testing.T) {
 			},
 			expected: map[string]Variable{
 				"bar": {Name: "bar", DefaultValue: "foo"},
+			},
+		},
+		{
+			name: "default-variable-with-number-suffix",
+			dict: map[string]interface{}{
+				"foo": "${bar_1:-foo}",
+			},
+			expected: map[string]Variable{
+				"bar_1": {Name: "bar_1", DefaultValue: "foo"},
+			},
+		},
+		{
+			name: "default-variable2-with-number-suffix",
+			dict: map[string]interface{}{
+				"foo": "${bar_1-foo}",
+			},
+			expected: map[string]Variable{
+				"bar_1": {Name: "bar_1", DefaultValue: "foo"},
 			},
 		},
 		{


### PR DESCRIPTION
Fixes https://github.com/docker/compose/issues/12285

Added support for suffix support in variable names, for example:
```
${FOO_1}
${BAR_1:-with-default}
```