### PR TITLE
introduce sync+exec watch action

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -500,8 +500,9 @@
             "properties": {
               "ignore": {"type": "array", "items": {"type": "string"}},
               "path": {"type": "string"},
-              "action": {"type": "string", "enum": ["rebuild", "sync", "sync+restart"]},
-              "target": {"type": "string"}
+              "action": {"type": "string", "enum": ["rebuild", "sync", "sync+restart", "sync+exec"]},
+              "target": {"type": "string"},
+              "exec": {"$ref": "#/definitions/service_hook"}
             },
             "additionalProperties": false,
             "patternProperties": {"^x-": {}}

--- a/types/derived.gen.go
+++ b/types/derived.gen.go
@@ -2013,6 +2013,11 @@ func deriveDeepCopy_46(dst, src *Trigger) {
 	dst.Path = src.Path
 	dst.Action = src.Action
 	dst.Target = src.Target
+	func() {
+		field := new(ServiceHook)
+		deriveDeepCopy_44(field, &src.Exec)
+		dst.Exec = *field
+	}()
 	if src.Ignore == nil {
 		dst.Ignore = nil
 	} else {

--- a/types/develop.go
+++ b/types/develop.go
@@ -28,12 +28,14 @@ const (
 	WatchActionSync        WatchAction = "sync"
 	WatchActionRebuild     WatchAction = "rebuild"
 	WatchActionSyncRestart WatchAction = "sync+restart"
+	WatchActionSyncExec    WatchAction = "sync+exec"
 )
 
 type Trigger struct {
 	Path       string      `yaml:"path" json:"path"`
 	Action     WatchAction `yaml:"action" json:"action"`
 	Target     string      `yaml:"target,omitempty" json:"target,omitempty"`
+	Exec       ServiceHook `yaml:"exec,omitempty" json:"exec,omitempty"`
 	Ignore     []string    `yaml:"ignore,omitempty" json:"ignore,omitempty"`
 	Extensions Extensions  `yaml:"#extensions,inline,omitempty" json:"-"`
 }

--- a/types/mapping.go
+++ b/types/mapping.go
@@ -72,6 +72,16 @@ func (m MappingWithEquals) RemoveEmpty() MappingWithEquals {
 	return m
 }
 
+func (m MappingWithEquals) ToMapping() Mapping {
+	o := Mapping{}
+	for k, v := range m {
+		if v != nil {
+			o[k] = *v
+		}
+	}
+	return o
+}
+
 func (m *MappingWithEquals) DecodeMapstructure(value interface{}) error {
 	switch v := value.(type) {
 	case map[string]interface{}:


### PR DESCRIPTION
introduce ability to configure a sync+exec action, to execute arbitrary command after watch sync updated container

see https://github.com/docker/compose/issues/12318