### PR TITLE
Fix uniqueItems property defined on object

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -935,7 +935,9 @@
                 },
                 {
                   "type": "array",
-                  "items": {},
+                  "items": {
+                    "type": "string"
+                  },
                   "uniqueItems": false
                 }
               ]

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -929,9 +929,17 @@
           "type": "object",
           "patternProperties": {
             ".+": {
-              "type": ["string", "array"]
-            },
-            "uniqueItems": false
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {},
+                  "uniqueItems": false
+                }
+              ]
+            }
           },
           "additionalProperties": false
         },


### PR DESCRIPTION
The `uniqueItems` property is defined for an object, `extra_hosts`, instead of an array.