### PR TITLE
extending a service, dependencies must be excluded

### DIFF
--- a/loader/extends.go
+++ b/loader/extends.go
@@ -27,6 +27,10 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 )
 
+// as we use another service definition by `extends`, we must exclude attributes which creates dependency to another service
+// see https://github.com/compose-spec/compose-spec/blob/main/05-services.md#restrictions
+var exclusions = []string{"extends", "depends_on", "volumes_from"}
+
 func ApplyExtends(ctx context.Context, dict map[string]any, opts *Options, tracker *cycleTracker, post ...PostProcessor) error {
 	a, ok := dict["services"]
 	if !ok {
@@ -123,7 +127,9 @@ func applyServiceExtends(ctx context.Context, name string, services map[string]a
 	if err != nil {
 		return nil, err
 	}
-	delete(merged, "extends")
+	for _, exclusion := range exclusions {
+		delete(merged, exclusion)
+	}
 	services[name] = merged
 	return merged, nil
 }

--- a/loader/extends_test.go
+++ b/loader/extends_test.go
@@ -322,7 +322,6 @@ services:
       file: ./testdata/extends/depends_on.yaml
       service: with_volumes_from
 `,
-			wantErr: `service "bar" depends on undefined service "zot"`,
 		},
 		{
 			name: "depends_on",
@@ -334,7 +333,6 @@ services:
       file: ./testdata/extends/depends_on.yaml
       service: with_depends_on
 `,
-			wantErr: `service "bar" depends on undefined service "zot"`,
 		},
 		{
 			name: "shared ipc",
@@ -369,8 +367,11 @@ services:
 					Content: []byte(tt.yaml),
 				}},
 			})
+			if tt.wantErr == "" {
+				assert.NilError(t, err)
+				return
+			}
 			assert.ErrorContains(t, err, tt.wantErr)
-
 			// Do the same but with a local `zot` service matching the imported reference
 			_, err = LoadWithContext(context.Background(), types.ConfigDetails{
 				ConfigFiles: []types.ConfigFile{{


### PR DESCRIPTION
exclude `depends_on` and `volumes_from` when extending a service, as documented by https://docs.docker.com/compose/how-tos/multiple-compose-files/extends/#exceptions-and-limitations

closes https://github.com/docker/compose/issues/12360