### PR TITLE
Apply `maybeUnixPath` to ssh path in build config

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2477,7 +2477,7 @@ services:
 	assert.NilError(t, err)
 	sshValue, err := svc.Build.SSH.Get("key1")
 	assert.NilError(t, err)
-	assert.Equal(t, "value1", sshValue)
+	assert.Equal(t, filepath.Join(os.Getenv("PWD"), "value1"), sshValue)
 }
 
 func TestLoadSSHWithKeysValuesInBuildConfig(t *testing.T) {
@@ -2490,6 +2490,7 @@ services:
       ssh:
         - key1=value1
         - key2=value2
+        - default
 `)
 	assert.NilError(t, err)
 	svc, err := actual.GetService("test")
@@ -2497,11 +2498,15 @@ services:
 
 	sshValue, err := svc.Build.SSH.Get("key1")
 	assert.NilError(t, err)
-	assert.Equal(t, "value1", sshValue)
+	assert.Equal(t, filepath.Join(os.Getenv("PWD"), "value1"), sshValue)
 
 	sshValue, err = svc.Build.SSH.Get("key2")
 	assert.NilError(t, err)
-	assert.Equal(t, "value2", sshValue)
+	assert.Equal(t, filepath.Join(os.Getenv("PWD"), "value2"), sshValue)
+
+	sshValue, err = svc.Build.SSH.Get("default")
+	assert.NilError(t, err)
+	assert.Equal(t, "", sshValue)
 }
 
 func TestProjectNameInterpolation(t *testing.T) {

--- a/paths/resolve.go
+++ b/paths/resolve.go
@@ -36,6 +36,7 @@ func ResolveRelativePaths(project map[string]any, base string, remotes []RemoteR
 	r.resolvers = map[tree.Path]resolver{
 		"services.*.build.context":               r.absContextPath,
 		"services.*.build.additional_contexts.*": r.absContextPath,
+		"services.*.build.ssh.*":                 r.maybeUnixPath,
 		"services.*.env_file.*.path":             r.absPath,
 		"services.*.label_file.*":                r.absPath,
 		"services.*.extends.file":                r.absExtendsPath,

--- a/paths/unix.go
+++ b/paths/unix.go
@@ -24,7 +24,10 @@ import (
 )
 
 func (r *relativePathsResolver) maybeUnixPath(a any) (any, error) {
-	p := a.(string)
+	p, ok := a.(string)
+	if !ok {
+		return a, nil
+	}
 	p = ExpandUser(p)
 	// Check if source is an absolute path (either Unix or Windows), to
 	// handle a Windows client with a Unix daemon or vice-versa.


### PR DESCRIPTION
According to build ssh config's document:

```
ssh property syntax can be either:

default: Let the builder connect to the SSH-agent.
ID=path: A key/value definition of an ID and the associated path. It can be either a [PEM](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail) file, or path to ssh-agent socket.

Using a custom id myproject with path to a local SSH key:

build:
  context: .
  ssh:
    - myproject=~/.ssh/myproject.pem
```

SSH config's value type is the path to the key, therefore should be resolved with `paths.ResolveRelativePaths`.