### PR TITLE
Apply `transformStringOrList` to `services.*.label_file`

### DIFF
--- a/transform/canonical.go
+++ b/transform/canonical.go
@@ -30,6 +30,7 @@ func init() {
 	transformers["services.*.build.additional_contexts"] = transformKeyValue
 	transformers["services.*.depends_on"] = transformDependsOn
 	transformers["services.*.env_file"] = transformEnvFile
+	transformers["services.*.label_file"] = transformStringOrList
 	transformers["services.*.extends"] = transformExtends
 	transformers["services.*.networks"] = transformServiceNetworks
 	transformers["services.*.volumes.*"] = transformVolumeMount


### PR DESCRIPTION
According to label_file's spec: https://github.com/compose-spec/compose-spec/pull/546, it supports string or a list:

```yaml label_file by ndeloof · Pull Request #546 · compose-spec/compose-spec
services:
  one:
    label_file: ./app.labels
  two:
    label_file: 
      - ./app.labels
      - ./additional.labels
```

But without applying `transform.Canonical` it only supports list format. This PR applies `transformStringOrList` to it to fix this.