### PR TITLE
Introduce named mappings to template substitution

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -569,3 +569,38 @@ func partition(s, sep string) (string, string) {
 	}
 	return s, ""
 }
+
+// Merge stacks new mapping on top of current mapping, i.e. the merged mapping will:
+// 1. Lookup in current mapping first
+// 2. If not present in current mapping, then lookup in provided mapping
+func (m Mapping) Merge(other Mapping) Mapping {
+	return func(key string) (string, bool) {
+		if value, ok := m(key); ok {
+			return value, ok
+		}
+		return other(key)
+	}
+}
+
+func (m NamedMappings) Merge(other NamedMappings) NamedMappings {
+	if m == nil {
+		return other
+	}
+	if other == nil {
+		return m
+	}
+	merged := make(NamedMappings)
+	for name, mapping := range m {
+		if otherMapping, ok := other[name]; ok {
+			merged[name] = mapping.Merge(otherMapping)
+		} else {
+			merged[name] = mapping
+		}
+	}
+	for name, mapping := range other {
+		if _, ok := merged[name]; !ok {
+			merged[name] = mapping
+		}
+	}
+	return merged
+}

--- a/template/template.go
+++ b/template/template.go
@@ -29,22 +29,27 @@ import (
 var delimiter = "\\$"
 var substitutionNamed = "[_a-z][_a-z0-9]*"
 var substitutionBraced = "[_a-z][_a-z0-9]*(?::?[-+?](.*))?"
+var substitutionMapping = "[_a-z][_a-z0-9]*\\[(.*)\\]"
 
 var groupEscaped = "escaped"
 var groupNamed = "named"
 var groupBraced = "braced"
+var groupMapping = "mapping"
 var groupInvalid = "invalid"
 
 var patternString = fmt.Sprintf(
-	"%s(?i:(?P<%s>%s)|(?P<%s>%s)|{(?:(?P<%s>%s)}|(?P<%s>)))",
+	"%s(?i:(?P<%s>%s)|(?P<%s>%s)|{(?:(?P<%s>%s)}|(?P<%s>%s)}|(?P<%s>)))",
 	delimiter,
 	groupEscaped, delimiter,
 	groupNamed, substitutionNamed,
 	groupBraced, substitutionBraced,
+	groupMapping, substitutionMapping,
 	groupInvalid,
 )
 
 var DefaultPattern = regexp.MustCompile(patternString)
+
+var NamedMappingKeyPattern = regexp.MustCompile("^[_A-Za-z0-9.-]*$")
 
 // InvalidTemplateError is returned when a variable template is not in a valid
 // format
@@ -69,11 +74,25 @@ func (e MissingRequiredError) Error() string {
 	return fmt.Sprintf("required variable %s is missing a value", e.Variable)
 }
 
+// MissingNamedMappingError is returned when a specific named mapping is missing
+// Guaranteed to not return if `Config.namedMappings` is nil (named mappings not enabled)
+type MissingNamedMappingError struct {
+	Name string
+}
+
+func (e MissingNamedMappingError) Error() string {
+	return fmt.Sprintf("named mapping not found: %q", e.Name)
+}
+
 // Mapping is a user-supplied function which maps from variable names to values.
 // Returns the value as a string and a bool indicating whether
 // the value is present, to distinguish between an empty string
 // and the absence of a value.
 type Mapping func(string) (string, bool)
+
+// NamedMappings is a collection of mappings indexed by a name key.
+// It allows temporarily switching to other mappings other than default during interpolation
+type NamedMappings map[string]Mapping
 
 // SubstituteFunc is a user-supplied function that apply substitution.
 // Returns the value as a string, a bool indicating if the function could apply
@@ -88,6 +107,7 @@ type Config struct {
 	pattern         *regexp.Regexp
 	substituteFunc  SubstituteFunc
 	replacementFunc ReplacementFunc
+	namedMappings   NamedMappings
 	logging         bool
 }
 
@@ -108,6 +128,12 @@ func WithSubstitutionFunction(subsFunc SubstituteFunc) Option {
 func WithReplacementFunction(replacementFunc ReplacementFunc) Option {
 	return func(cfg *Config) {
 		cfg.replacementFunc = replacementFunc
+	}
+}
+
+func WithNamedMappings(namedMappings NamedMappings) Option {
+	return func(cfg *Config) {
+		cfg.namedMappings = namedMappings
 	}
 }
 
@@ -167,12 +193,9 @@ func DefaultReplacementFunc(substring string, mapping Mapping, cfg *Config) (str
 	return value, err
 }
 
-func DefaultReplacementAppliedFunc(substring string, mapping Mapping, cfg *Config) (string, bool, error) {
+func DefaultReplacementAppliedFunc(substring string, mapping Mapping, cfg *Config) (value string, applied bool, err error) {
+	template := substring
 	pattern := cfg.pattern
-	subsFunc := cfg.substituteFunc
-	if subsFunc == nil {
-		_, subsFunc = getSubstitutionFunctionForTemplate(substring, cfg)
-	}
 
 	closingBraceIndex := getFirstBraceClosingIndex(substring)
 	rest := ""
@@ -187,37 +210,50 @@ func DefaultReplacementAppliedFunc(substring string, mapping Mapping, cfg *Confi
 		return escaped, true, nil
 	}
 
-	braced := false
-	substitution := groups[groupNamed]
-	if substitution == "" {
+	substitution := ""
+	subsFunc := cfg.substituteFunc
+	switch {
+	case groups[groupNamed] != "":
+		substitution = groups[groupNamed]
+	case groups[groupBraced] != "":
 		substitution = groups[groupBraced]
-		braced = true
-	}
-
-	if substitution == "" {
+		if subsFunc == nil {
+			_, subsFunc = getSubstitutionFunctionForTemplate(template, cfg)
+		}
+	case groups[groupMapping] != "":
+		substitution = groups[groupMapping]
+		if subsFunc == nil {
+			subsFunc = getSubstitutionFunctionForNamedMapping(cfg)
+		}
+	default:
 		return "", false, &InvalidTemplateError{}
 	}
 
-	if braced {
-		value, applied, err := subsFunc(substitution, mapping)
+	if subsFunc != nil {
+		value, applied, err = subsFunc(substitution, mapping)
 		if err != nil {
 			return "", false, err
 		}
-		if applied {
-			interpolatedNested, err := substituteWithConfig(rest, mapping, cfg)
-			if err != nil {
-				return "", false, err
-			}
-			return value + interpolatedNested, true, nil
+		if !applied {
+			value = substring // Keep the original substring ${...} if not applied
+		}
+	} else {
+		value, applied = mapping(substitution)
+		if !applied && cfg.logging {
+			logrus.Warnf("The %q variable is not set. Defaulting to a blank string.", substitution)
 		}
 	}
 
-	value, ok := mapping(substitution)
-	if !ok && cfg.logging {
-		logrus.Warnf("The %q variable is not set. Defaulting to a blank string.", substitution)
+	if rest != "" {
+		interpolatedNested, err := substituteWithConfig(rest, mapping, cfg)
+		applied = applied || rest != interpolatedNested
+		if err != nil {
+			return "", false, err
+		}
+		value += interpolatedNested
 	}
 
-	return value, ok, nil
+	return value, applied, nil
 }
 
 // SubstituteWith substitute variables in the string with their values.
@@ -245,9 +281,22 @@ func getSubstitutionFunctionForTemplate(template string, cfg *Config) (string, S
 		{":+", defaultWhenNotEmpty},
 		{"+", defaultWhenSet},
 	}
+
+	mappingIndices := make(map[string]int)
+	hasInterpolationMapping := false
+	for _, m := range interpolationMapping {
+		mappingIndices[m.SubstituteType] = strings.Index(template, m.SubstituteType)
+		if mappingIndices[m.SubstituteType] >= 0 {
+			hasInterpolationMapping = true
+		}
+	}
+	if !hasInterpolationMapping {
+		return "", nil
+	}
+
 	sort.Slice(interpolationMapping, func(i, j int) bool {
-		idxI := strings.Index(template, interpolationMapping[i].SubstituteType)
-		idxJ := strings.Index(template, interpolationMapping[j].SubstituteType)
+		idxI := mappingIndices[interpolationMapping[i].SubstituteType]
+		idxJ := mappingIndices[interpolationMapping[j].SubstituteType]
 		if idxI < 0 {
 			return false
 		}
@@ -260,6 +309,79 @@ func getSubstitutionFunctionForTemplate(template string, cfg *Config) (string, S
 	return interpolationMapping[0].SubstituteType, func(s string, m Mapping) (string, bool, error) {
 		return interpolationMapping[0].SubstituteFunc(s, m, cfg)
 	}
+}
+
+func getSubstitutionFunctionForNamedMapping(cfg *Config) SubstituteFunc {
+	return func(substitution string, mapping Mapping) (string, bool, error) {
+		namedMapping, key, _, err := getNamedMapping(substitution, cfg)
+		if err != nil || namedMapping == nil {
+			return "", false, err
+		}
+
+		resolvedKey, err := getResolvedNamedMappingKey(key, mapping, cfg)
+		if err != nil {
+			return "", false, err
+		}
+
+		value, _ := namedMapping(resolvedKey)
+		return value, true, nil
+	}
+}
+
+func getNamedMapping(substitution string, cfg *Config) (Mapping, string, string, error) {
+	if cfg.namedMappings == nil { // Named mappings not enabled
+		return nil, "", "", nil
+	}
+
+	openBracketIndex := -1
+	closeBracketIndex := -1
+	openBrackets := 0
+	for i := 0; i < len(substitution); i++ {
+		if substitution[i] == '[' {
+			if openBrackets == 0 {
+				openBracketIndex = i
+			}
+			openBrackets += 1
+		} else if substitution[i] == ']' {
+			openBrackets -= 1
+			if openBrackets == 0 {
+				closeBracketIndex = i
+			}
+			if openBrackets <= 0 {
+				break
+			}
+		}
+	}
+	if openBracketIndex < 0 || closeBracketIndex < 0 {
+		return nil, "", "", nil
+	}
+	name := substitution[0:openBracketIndex]
+	key := substitution[openBracketIndex+1 : closeBracketIndex]
+	rest := substitution[closeBracketIndex+1:]
+
+	namedMapping, ok := cfg.namedMappings[name]
+	if !ok { // When namd mappings config provided, it must be able to resolve all mapping names in the template
+		return nil, "", "", &MissingNamedMappingError{Name: name}
+	}
+
+	return namedMapping, key, rest, nil
+}
+
+func getResolvedNamedMappingKey(key string, mapping Mapping, cfg *Config) (string, error) {
+	resolvedKey, err := substituteWithConfig(key, mapping, cfg)
+	if err != nil {
+		return "", err
+	}
+
+	if !NamedMappingKeyPattern.MatchString(resolvedKey) {
+		if resolvedKey != key {
+			return "", fmt.Errorf("invalid key in named mapping: %q (resolved to %q)", key, resolvedKey)
+		} else {
+			return "", fmt.Errorf("invalid key in named mapping: %q", key)
+		}
+	}
+
+	return resolvedKey, nil
 }
 
 func getFirstBraceClosingIndex(s string) int {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -908,3 +908,11 @@ func TestSubstituteWithCustomFuncWithNamedMappings(t *testing.T) {
 	_, err = SubstituteWith("ok ${NOTHERE}", defaultMapping, DefaultPattern, errIsMissing)
 	assert.Check(t, is.ErrorContains(err, "required variable"))
 }
+
+func TestPanicAsErrorInNamedMappings(t *testing.T) {
+	panicMapping := func(name string) (string, bool) {
+		panic("panic")
+	}
+	_, err := SubstituteWithOptions("${env[FOO]}", defaultMapping, WithNamedMappings(NamedMappings{"env": panicMapping}))
+	assert.ErrorContains(t, err, "panic")
+}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -506,7 +506,7 @@ func TestSubstitutionFunctionChoice(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			symbol, _ := getSubstitutionFunctionForTemplate(tc.input)
+			symbol, _ := getSubstitutionFunctionForTemplate(tc.input, nil)
 			assert.Equal(t, symbol, tc.symbol,
 				fmt.Sprintf("Wrong on output for: %s got symbol -> %#v", tc.input, symbol),
 			)


### PR DESCRIPTION
This PR adds support for named mappings's syntax `${name[key]}` in `template` package.

### Named Mappings

By `Mapping`, we mean a user-supplied function to lookup value from key: `type Mapping func(string) (string, bool)`. In compose it is provied with environment lookup.

A named mappings is a collection of `Mapping`, indexed by name key. It allows temporarily switching to other mappings other than default during interpolation.

### Template Syntax

Named mapping are used with syntax `${name[key]}`, where an alternative `Mapping` is retrieved by key `name`, and look it up using key `key`.

It supports all functions in default mappings: `${name[key]:-default}`, `${name[key]:+presence}`, `${name[key]?error}`.