### PR TITLE
Update readme example to use non-deprecated ProjectOptions.LoadProject

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	project, err := cli.ProjectFromOptions(ctx, options)
+	project, err := options.LoadProject(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
[From the docs:](https://pkg.go.dev/github.com/compose-spec/compose-go/v2@v2.4.6/cli#ProjectOptions.LoadProject)

> ProjectFromOptions load a compose project based on command line options 
> Deprecated: use ProjectOptions.LoadProject or ProjectOptions.LoadModel