### PR TITLE
allow additional_context to target another service

### DIFF
--- a/loader/validate.go
+++ b/loader/validate.go
@@ -28,7 +28,7 @@ import (
 
 // checkConsistency validate a compose model is consistent
 func checkConsistency(project *types.Project) error {
-	for _, s := range project.Services {
+	for name, s := range project.Services {
 		if s.Build == nil && s.Image == "" {
 			return fmt.Errorf("service %q has neither an image nor a build context specified: %w", s.Name, errdefs.ErrInvalid)
 		}
@@ -36,6 +36,18 @@ func checkConsistency(project *types.Project) error {
 		if s.Build != nil {
 			if s.Build.DockerfileInline != "" && s.Build.Dockerfile != "" {
 				return fmt.Errorf("service %q declares mutualy exclusive dockerfile and dockerfile_inline: %w", s.Name, errdefs.ErrInvalid)
+			}
+
+			for add, c := range s.Build.AdditionalContexts {
+				if target, ok := strings.CutPrefix(c, types.ServicePrefix); ok {
+					t, err := project.GetService(target)
+					if err != nil {
+						return fmt.Errorf("service %q declares unknown service %q as additional contexts %s", name, target, add)
+					}
+					if t.Build == nil {
+						return fmt.Errorf("service %q declares non-buildable service %q as additional contexts %s", name, target, add)
+					}
+				}
 			}
 
 			if len(s.Build.Platforms) > 0 && s.Platform != "" {

--- a/paths/context.go
+++ b/paths/context.go
@@ -16,11 +16,18 @@
 
 package paths
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/compose-spec/compose-go/v2/types"
+)
 
 func (r *relativePathsResolver) absContextPath(value any) (any, error) {
 	v := value.(string)
 	if strings.Contains(v, "://") { // `docker-image://` or any builder specific context type
+		return v, nil
+	}
+	if strings.HasPrefix(v, types.ServicePrefix) { // `docker-image://` or any builder specific context type
 		return v, nil
 	}
 	if isRemoteContext(v) {


### PR DESCRIPTION
Introduce support for `service:xx` syntax defining an additional context.

this will be used to explicitly request another service image being used as source for another service. This is a long term issue inherited from compose v1 sequential build logic: some users declare image built by another service as `FROM` instruction in another service's Dockerfile. They will be able to keep this working by adding an explicit additional_context as `service: baseapp` and let buildkit manage best possible execution of the build.

see https://github.com/docker/buildx/blob/v0.8.0-rc1/docs/reference/buildx_bake.md#using-a-result-of-one-target-as-a-base-image-in-another-target

illustration with docker/compose : https://github.com/docker/compose/pull/12485