### PR TITLE
require go 1.23 a oldest stable go release

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM golang:1.21
+FROM golang:1.23
 
 WORKDIR /go/src
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/compose-spec/compose-go/v2
 
-go 1.21
+go 1.23
 
 require (
 	github.com/distribution/reference v0.5.0


### PR DESCRIPTION
go 1.24 has been released (https://go.dev/blog/go1.24) and supported version are now 1.23 and 1.24, so doesn't make sense we rely on 1.21 which blocks https://github.com/compose-spec/compose-go/pull/736