### PR TITLE
introduce pull policy "refresh"

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -3744,3 +3744,16 @@ services:
 	assert.Equal(t, len(p.Services["test"].Gpus), 1)
 	assert.Equal(t, p.Services["test"].Gpus[0].Count, types.DeviceCount(-1))
 }
+
+func TestPullRefresh(t *testing.T) {
+	p, err := loadYAML(`
+name: load-all-gpus
+services:
+  test:
+    pull_policy: refresh
+    pull_refresh_after: 1h
+`)
+	assert.NilError(t, err)
+	assert.Equal(t, p.Services["test"].PullPolicy, types.PullPolicyRefresh)
+	assert.Equal(t, *p.Services["test"].PullRefresh, types.Duration(1*time.Hour))
+}

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -371,8 +371,9 @@
         "privileged": {"type": ["boolean", "string"]},
         "profiles": {"$ref": "#/definitions/list_of_strings"},
         "pull_policy": {"type": "string", "enum": [
-          "always", "never", "if_not_present", "build", "missing"
+          "always", "never", "if_not_present", "build", "missing", "refresh"
         ]},
+        "pull_refresh_after": {"type": "string"},
         "read_only": {"type": ["boolean", "string"]},
         "restart": {"type": "string"},
         "runtime": {

--- a/types/derived.gen.go
+++ b/types/derived.gen.go
@@ -578,6 +578,12 @@ func deriveDeepCopyService(dst, src *ServiceConfig) {
 	}
 	dst.Privileged = src.Privileged
 	dst.PullPolicy = src.PullPolicy
+	if src.PullRefresh == nil {
+		dst.PullRefresh = nil
+	} else {
+		dst.PullRefresh = new(Duration)
+		*dst.PullRefresh = *src.PullRefresh
+	}
 	dst.ReadOnly = src.ReadOnly
 	dst.Restart = src.Restart
 	dst.Runtime = src.Runtime
@@ -1812,6 +1818,7 @@ func deriveDeepCopy_38(dst, src *DeviceRequest) {
 // deriveDeepCopy_39 recursively copies the contents of src into dst.
 func deriveDeepCopy_39(dst, src *ServiceNetworkConfig) {
 	dst.Priority = src.Priority
+	dst.GatewayPriority = src.GatewayPriority
 	if src.Aliases == nil {
 		dst.Aliases = nil
 	} else {

--- a/types/types.go
+++ b/types/types.go
@@ -111,6 +111,7 @@ type ServiceConfig struct {
 	Ports           []ServicePortConfig              `yaml:"ports,omitempty" json:"ports,omitempty"`
 	Privileged      bool                             `yaml:"privileged,omitempty" json:"privileged,omitempty"`
 	PullPolicy      string                           `yaml:"pull_policy,omitempty" json:"pull_policy,omitempty"`
+	PullRefresh     *Duration                        `yaml:"pull_refresh_after,omitempty" json:"pull_refresh_after,omitempty"`
 	ReadOnly        bool                             `yaml:"read_only,omitempty" json:"read_only,omitempty"`
 	Restart         string                           `yaml:"restart,omitempty" json:"restart,omitempty"`
 	Runtime         string                           `yaml:"runtime,omitempty" json:"runtime,omitempty"`
@@ -215,6 +216,8 @@ const (
 	PullPolicyMissing = "missing"
 	// PullPolicyBuild force building images
 	PullPolicyBuild = "build"
+	// PullPolicyRefresh checks image needs to be updatedq
+	PullPolicyRefresh = "refresh"
 )
 
 const (


### PR DESCRIPTION
introduce a new pull policy to refresh image based on last pulled time

to be debated: I selected `refresh` but this might not be the best verb for this feature, I'm open to your proposals :)

see https://github.com/docker/compose/issues/12563