### PR TITLE
Fix interpolation priorities

### DIFF
--- a/dotenv/format.go
+++ b/dotenv/format.go
@@ -24,28 +24,28 @@ import (
 const DotEnv = ".env"
 
 var formats = map[string]Parser{
-	DotEnv: func(r io.Reader, filename string, lookup func(key string) (string, bool)) (map[string]string, error) {
-		m, err := ParseWithLookup(r, lookup)
+	DotEnv: func(r io.Reader, filename string, vars map[string]string, lookup func(key string) (string, bool)) error {
+		err := parseWithLookup(r, vars, lookup)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read %s: %w", filename, err)
+			return fmt.Errorf("failed to read %s: %w", filename, err)
 		}
-		return m, nil
+		return nil
 	},
 }
 
-type Parser func(r io.Reader, filename string, lookup func(key string) (string, bool)) (map[string]string, error)
+type Parser func(r io.Reader, filename string, vars map[string]string, lookup func(key string) (string, bool)) error
 
 func RegisterFormat(format string, p Parser) {
 	formats[format] = p
 }
 
-func ParseWithFormat(r io.Reader, filename string, resolve LookupFn, format string) (map[string]string, error) {
+func ParseWithFormat(r io.Reader, filename string, vars map[string]string, resolve LookupFn, format string) error {
 	if format == "" {
 		format = DotEnv
 	}
 	fn, ok := formats[format]
 	if !ok {
-		return nil, fmt.Errorf("unsupported env_file format %q", format)
+		return fmt.Errorf("unsupported env_file format %q", format)
 	}
-	return fn(r, filename, resolve)
+	return fn(r, filename, vars, resolve)
 }

--- a/dotenv/godotenv.go
+++ b/dotenv/godotenv.go
@@ -41,16 +41,23 @@ func Parse(r io.Reader) (map[string]string, error) {
 
 // ParseWithLookup reads an env file from io.Reader, returning a map of keys and values.
 func ParseWithLookup(r io.Reader, lookupFn LookupFn) (map[string]string, error) {
+	vars := map[string]string{}
+	err := parseWithLookup(r, vars, lookupFn)
+	return vars, err
+}
+
+// ParseWithLookup reads an env file from io.Reader, returning a map of keys and values.
+func parseWithLookup(r io.Reader, vars map[string]string, lookupFn LookupFn) error {
 	data, err := io.ReadAll(r)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// seek past the UTF-8 BOM if it exists (particularly on Windows, some
 	// editors tend to add it, and it'll cause parsing to fail)
 	data = bytes.TrimPrefix(data, utf8BOM)
 
-	return UnmarshalBytesWithLookup(data, lookupFn)
+	return newParser().parse(string(data), vars, lookupFn)
 }
 
 // Load will read your env file(s) and load them into ENV for this process.

--- a/dotenv/godotenv_test.go
+++ b/dotenv/godotenv_test.go
@@ -717,8 +717,7 @@ func TestLoadWithFormat(t *testing.T) {
 		"ZOT": "QIX",
 	}
 
-	custom := func(r io.Reader, _ string, lookup func(key string) (string, bool)) (map[string]string, error) {
-		vars := map[string]string{}
+	custom := func(r io.Reader, _ string, vars map[string]string, lookup func(key string) (string, bool)) error {
 		scanner := bufio.NewScanner(r)
 		for scanner.Scan() {
 			key, value, found := strings.Cut(scanner.Text(), ":")
@@ -730,14 +729,15 @@ func TestLoadWithFormat(t *testing.T) {
 			}
 			vars[key] = value
 		}
-		return vars, nil
+		return nil
 	}
 
 	RegisterFormat("custom", custom)
 
 	f, err := os.Open(envFileName)
 	assert.NilError(t, err)
-	env, err := ParseWithFormat(f, envFileName, nil, "custom")
+	env := map[string]string{}
+	err = ParseWithFormat(f, envFileName, env, nil, "custom")
 	assert.NilError(t, err)
 	assert.DeepEqual(t, expectedValues, env)
 }

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -596,7 +596,6 @@ services:
 		"BAR": strPtr("2"),
 		"GA":  strPtr("2.5"),
 		"BU":  strPtr(""),
-		"ZO":  nil,
 		"MEU": strPtr("Shadoks"),
 	}
 

--- a/types/fixtures/base.env
+++ b/types/fixtures/base.env
@@ -1,0 +1,6 @@
+FOO=foo_from_base.env
+INTERPOLATED_FOO=${FOO}
+BAR=bar_from_base.env
+INTERPOLATED_BAR=${BAR}
+ZOT=zot_from_base.env
+INTERPOLATED_ZOT=${ZOT}

--- a/types/fixtures/override.env
+++ b/types/fixtures/override.env
@@ -1,0 +1,4 @@
+FOO=foo_from_override.env
+INTERPOLATED_FOO=${FOO}
+BAR=bar_from_override.env
+INTERPOLATED_BAR=${BAR}


### PR DESCRIPTION
resolving service's environment, `service.environment` has precedence over `service.env_file`

doing interpolation:
- os.Env (project.Environment) has highest precendence
- then comes service.environment
- values read from service.env_file, maybe overriding value from a file previously parsed (see https://github.com/docker/compose/issues/12655)

added a test to cover those combinations


closes https://github.com/docker/compose/issues/12655
