### PR TITLE
keep empty variables in service.environment list

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -597,6 +597,7 @@ services:
 		"GA":  strPtr("2.5"),
 		"BU":  strPtr(""),
 		"MEU": strPtr("Shadoks"),
+		"ZO":  nil,
 	}
 
 	assert.Check(t, is.Equal(2, len(config.Services)))

--- a/types/project.go
+++ b/types/project.go
@@ -639,7 +639,7 @@ func (p *Project) MarshalJSON(options ...func(*marshallOptions)) ([]byte, error)
 func (p Project) WithServicesEnvironmentResolved(discardEnvFiles bool) (*Project, error) {
 	newProject := p.deepCopy()
 	for i, service := range newProject.Services {
-		service.Environment = service.Environment.Resolve(newProject.Environment.Resolve).RemoveEmpty()
+		service.Environment = service.Environment.Resolve(newProject.Environment.Resolve)
 
 		environment := service.Environment.ToMapping()
 		for _, envFile := range service.EnvFiles {


### PR DESCRIPTION
those variables could be used to unset variables in the container

The issue was detected by Docker Compose CI
https://github.com/docker/compose/actions/runs/14223750088/job/39858067378?pr=12692

```
=== Failed
=== FAIL: pkg/e2e TestUnsetEnv/unset_env_variable (0.71s)
    compose_environment_test.go:241: Running command: docker compose -f ./fixtures/environment/empty-variable/compose.yaml run --rm empty-variable
    compose_environment_test.go:243: assertion failed: 
        Command:  docker compose -f ./fixtures/environment/empty-variable/compose.yaml run --rm empty-variable
        ExitCode: 0
        Stdout:   =not_empty=
        
        Stderr:   
        
        Failures:
        Expected stdout to contain "=="
    --- FAIL: TestUnsetEnv/unset_env_variable (0.71s)
```