### PR TITLE
fix: Prevent panic when merging IPAM config

### DIFF
--- a/override/merge.go
+++ b/override/merge.go
@@ -226,6 +226,13 @@ func mergeUlimit(_ any, o any, p tree.Path) (any, error) {
 }
 
 func mergeIPAMConfig(c any, o any, path tree.Path) (any, error) {
+	if _, ok := c.([]any); !ok {
+		return nil, fmt.Errorf("cannot merge IPAM config at %s: base value is not a list", path)
+	}
+	if _, ok := o.([]any); !ok {
+		return nil, fmt.Errorf("cannot merge IPAM config at %s: override value is not a list", path)
+	}
+
 	var ipamConfigs []any
 	for _, original := range c.([]any) {
 		right := convertIntoMapping(original, nil)


### PR DESCRIPTION
Prevents a panic by adding type checks to ensure both base and override IPAM configs are lists. Returns a clear error if the input types are invalid.

Fixes: https://github.com/docker/compose/issues/12709