### PR TITLE
exclude remote config paths while computing a default workingdir

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -81,6 +81,8 @@ type ProjectOptions struct {
 	// Callbacks to retrieve metadata information during parse defined before
 	// creating the project
 	Listeners []loader.Listener
+	// ResourceLoaders manages support for remote resources
+	ResourceLoaders []loader.ResourceLoader
 }
 
 type ProjectOptionsFn func(*ProjectOptions) error
@@ -347,8 +349,9 @@ func WithResolvedPaths(resolve bool) ProjectOptionsFn {
 // WithResourceLoader register support for ResourceLoader to manage remote resources
 func WithResourceLoader(r loader.ResourceLoader) ProjectOptionsFn {
 	return func(o *ProjectOptions) error {
+		o.ResourceLoaders = append(o.ResourceLoaders, r)
 		o.loadOptions = append(o.loadOptions, func(options *loader.Options) {
-			options.ResourceLoaders = append(options.ResourceLoaders, r)
+			options.ResourceLoaders = o.ResourceLoaders
 		})
 		return nil
 	}
@@ -390,8 +393,14 @@ func (o *ProjectOptions) GetWorkingDir() (string, error) {
 	if o.WorkingDir != "" {
 		return filepath.Abs(o.WorkingDir)
 	}
+PATH:
 	for _, path := range o.ConfigPaths {
 		if path != "-" {
+			for _, l := range o.ResourceLoaders {
+				if l.Accept(path) {
+					break PATH
+				}
+			}
 			absPath, err := filepath.Abs(path)
 			if err != nil {
 				return "", err


### PR DESCRIPTION
when Compose is configured to run a remote compose model (`docker compose -f oci://xxx`) default working directory must exclude the remote resource path

fix https://github.com/docker/compose/issues/12779