### PR TITLE
schema validate container_name with regex

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -206,7 +206,8 @@
         },
         "container_name": {
           "type": "string",
-          "description": "Specify a custom container name, rather than a generated default name."
+          "description": "Specify a custom container name, rather than a generated default name.",
+          "pattern": "[a-zA-Z0-9][a-zA-Z0-9_.-]+"
         },
         "cpu_count": {
           "oneOf": [


### PR DESCRIPTION
Provides a better editing experience

This pattern is already listed in the [documentation](https://docs.docker.com/reference/compose-file/services/#container_name) for Docker compose.

<img width="1670" height="645" alt="image" src="https://github.com/user-attachments/assets/eea989b5-3b55-4d65-bf8e-ac502c142b73" />
