### PR TITLE
fix extraction of variables

### DIFF
--- a/template/variables.go
+++ b/template/variables.go
@@ -57,10 +57,9 @@ func recurseExtract(value interface{}, pattern *regexp.Regexp) map[string]Variab
 
 	case []interface{}:
 		for _, elem := range value {
-			if values, is := extractVariable(elem, pattern); is {
-				for _, v := range values {
-					m[v.Name] = v
-				}
+			submap := recurseExtract(elem, pattern)
+			for key, value := range submap {
+				m[key] = value
 			}
 		}
 	}

--- a/template/variables_test.go
+++ b/template/variables_test.go
@@ -191,6 +191,22 @@ func TestExtractVariables(t *testing.T) {
 				"SUBDOMAIN":  {Name: "SUBDOMAIN", DefaultValue: "$ROOTDOMAIN"},
 			},
 		},
+		{
+			name: "nested-array-of-maps",
+			dict: map[string]interface{}{
+				"volumes": []interface{}{
+					map[string]interface{}{
+						"source": "${SOURCE_LOCATION}",
+						"target": "/location",
+						"type":   "volume",
+						"volume": map[string]interface{}{},
+					},
+				},
+			},
+			expected: map[string]Variable{
+				"SOURCE_LOCATION": {Name: "SOURCE_LOCATION"},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This fixes the problem of extracting variables from a list of maps. Currently, variables from such an entity would be ignored. A simple way of reproduce this is to execute the following command:

```shell
docker compose -f docker-compose.volumes.yml config --variables
```

The content of `docker-compose.volumes.yml` is:
```yaml
services:
    postgres:
        environment:
            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
            POSTGRES_USER: postgres
        image: postgres
        volumes:
            - ${CERT_FILE}:/certs/server.crt:ro
```

The output will be:
```shell
NAME                REQUIRED            DEFAULT VALUE       ALTERNATE VALUE
POSTGRES_PASSWORD   false               postgres            
```

`CERT_FILE` is missing. Internally, the volumes will be represented as `volumes:[map[read_only:true source:${CERT_FILE} target:/certs/server.crt type:volume volume:map[]]] `.