### PR TITLE
Revert dotenv/env.go to before 8da9902, update test

### DIFF
--- a/dotenv/env.go
+++ b/dotenv/env.go
@@ -19,6 +19,7 @@ package dotenv
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 )
@@ -56,7 +57,7 @@ func GetEnvFromFile(currentEnv map[string]string, filenames []string) (map[strin
 			return envMap, err
 		}
 
-		err = parseWithLookup(bytes.NewReader(b), envMap, func(k string) (string, bool) {
+		env, err := ParseWithLookup(bytes.NewReader(b), func(k string) (string, bool) {
 			v, ok := currentEnv[k]
 			if ok {
 				return v, true
@@ -67,6 +68,7 @@ func GetEnvFromFile(currentEnv map[string]string, filenames []string) (map[strin
 		if err != nil {
 			return envMap, fmt.Errorf("failed to read %s: %w", dotEnvFile, err)
 		}
+		maps.Copy(envMap, env)
 	}
 
 	return envMap, nil

--- a/dotenv/godotenv_test.go
+++ b/dotenv/godotenv_test.go
@@ -743,32 +743,29 @@ func TestLoadWithFormat(t *testing.T) {
 }
 
 func TestMultipleFiles(t *testing.T) {
-	base := filepath.Join(t.TempDir(), "base.env")
-	err := os.WriteFile(base, []byte(`
-ENV_HOSTNAME=localhost
-ENV_MY_URL="http://${ENV_HOSTNAME}"
-`), 0o600)
+	base := filepath.Join(t.TempDir(), ".local.env")
+	err := os.WriteFile(base, []byte(`TLD=local`), 0o600)
 	assert.NilError(t, err)
 
-	override := filepath.Join(t.TempDir(), "override.env")
+	override := filepath.Join(t.TempDir(), ".env")
 	err = os.WriteFile(override, []byte(`
-ENV_HOSTNAME=dev.my-company.com
-ENV_MY_URL="http://${ENV_HOSTNAME}"
+TLD=org
+URL="http://example.${TLD}"
 `), 0o600)
 	assert.NilError(t, err)
 
 	env, err := GetEnvFromFile(nil, []string{base, override})
 	assert.NilError(t, err)
 	assert.DeepEqual(t, env, map[string]string{
-		"ENV_HOSTNAME": "dev.my-company.com",
-		"ENV_MY_URL":   "http://dev.my-company.com",
+		"TLD": "org",
+		"URL": "http://example.local",
 	})
 
-	osEnv := map[string]string{"ENV_HOSTNAME": "host.local"}
+	osEnv := map[string]string{"TLD": "org"}
 	env, err = GetEnvFromFile(osEnv, []string{base, override})
 	assert.NilError(t, err)
 	assert.DeepEqual(t, env, map[string]string{
-		"ENV_HOSTNAME": "dev.my-company.com",
-		"ENV_MY_URL":   "http://host.local",
+		"TLD": "org",
+		"URL": "http://example.org",
 	})
 }


### PR DESCRIPTION
This is a companion PR to revert changes described in #813 while updating tests to keep them consistent with the expected usage.