### PR TITLE
make x-initialSync part of the spec as initial_sync attribute

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -3050,7 +3050,7 @@ services:
         # sync static content
         - path: ./webapp/html
           action: sync
-          x-initialSync: true
+          initial_sync: true
           target: /var/www
           ignore:
             - node_modules/
@@ -3082,13 +3082,11 @@ services:
 	assert.DeepEqual(t, *frontend.Develop, types.DevelopConfig{
 		Watch: []types.Trigger{
 			{
-				Path:   "./webapp/html",
-				Action: types.WatchActionSync,
-				Target: "/var/www",
-				Ignore: []string{"node_modules/"},
-				Extensions: types.Extensions{
-					"x-initialSync": true,
-				},
+				Path:        "./webapp/html",
+				Action:      types.WatchActionSync,
+				Target:      "/var/www",
+				Ignore:      []string{"node_modules/"},
+				InitialSync: true,
 			},
 		},
 	})

--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -992,6 +992,10 @@
               "exec": {
                 "$ref": "#/definitions/service_hook",
                 "description": "Command to execute when a change is detected and action is sync+exec."
+              },
+              "initial_sync": {
+                "type": "boolean",
+                "description": "Ensure that an initial synchronization is done before starting watch mode for sync+x triggers"
               }
             },
             "additionalProperties": false,

--- a/types/derived.gen.go
+++ b/types/derived.gen.go
@@ -2175,6 +2175,7 @@ func deriveDeepCopy_51(dst, src *Trigger) {
 		}
 		copy(dst.Ignore, src.Ignore)
 	}
+	dst.InitialSync = src.InitialSync
 	if src.Extensions != nil {
 		dst.Extensions = make(map[string]any, len(src.Extensions))
 		src.Extensions.DeepCopy(dst.Extensions)

--- a/types/develop.go
+++ b/types/develop.go
@@ -33,11 +33,12 @@ const (
 )
 
 type Trigger struct {
-	Path       string      `yaml:"path" json:"path"`
-	Action     WatchAction `yaml:"action" json:"action"`
-	Target     string      `yaml:"target,omitempty" json:"target,omitempty"`
-	Exec       ServiceHook `yaml:"exec,omitempty" json:"exec,omitempty"`
-	Include    []string    `yaml:"include,omitempty" json:"include,omitempty"`
-	Ignore     []string    `yaml:"ignore,omitempty" json:"ignore,omitempty"`
-	Extensions Extensions  `yaml:"#extensions,inline,omitempty" json:"-"`
+	Path        string      `yaml:"path" json:"path"`
+	Action      WatchAction `yaml:"action" json:"action"`
+	Target      string      `yaml:"target,omitempty" json:"target,omitempty"`
+	Exec        ServiceHook `yaml:"exec,omitempty" json:"exec,omitempty"`
+	Include     []string    `yaml:"include,omitempty" json:"include,omitempty"`
+	Ignore      []string    `yaml:"ignore,omitempty" json:"ignore,omitempty"`
+	InitialSync bool        `yaml:"initial_sync,omitempty" json:"initial_sync,omitempty"`
+	Extensions  Extensions  `yaml:"#extensions,inline,omitempty" json:"-"`
 }


### PR DESCRIPTION
`x-initialSync` attribute was there for more than a year as an experimental feature to synchronize host content with services containers when `sync+x` triggers are setup, we think it could be now officially part of the specification

[Compose Specification PR](https://github.com/compose-spec/compose-spec/pull/614)

See https://github.com/docker/docs/issues/23345 