### PR TITLE
apply override during extend

### DIFF
--- a/loader/extends.go
+++ b/loader/extends.go
@@ -81,13 +81,12 @@ func applyServiceExtends(ctx context.Context, name string, services map[string]a
 
 	var (
 		base      any
-		processor PostProcessor
+		processor PostProcessor = NoopPostProcessor{}
 	)
 
 	if file != nil {
 		refFilename := file.(string)
 		services, processor, err = getExtendsBaseFromFile(ctx, name, ref, filename, refFilename, opts, tracker)
-		post = append(post, processor)
 		if err != nil {
 			return nil, err
 		}
@@ -105,7 +104,7 @@ func applyServiceExtends(ctx context.Context, name string, services map[string]a
 	}
 
 	// recursively apply `extends`
-	base, err = applyServiceExtends(ctx, ref, services, opts, tracker, post...)
+	base, err = applyServiceExtends(ctx, ref, services, opts, tracker, processor)
 	if err != nil {
 		return nil, err
 	}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -260,11 +260,13 @@ func WithProfiles(profiles []string) func(*Options) {
 // PostProcessor is used to tweak compose model based on metadata extracted during yaml Unmarshal phase
 // that hardly can be implemented using go-yaml and mapstructure
 type PostProcessor interface {
-	yaml.Unmarshaler
-
 	// Apply changes to compose model based on recorder metadata
 	Apply(interface{}) error
 }
+
+type NoopPostProcessor struct{}
+
+func (NoopPostProcessor) Apply(interface{}) error { return nil }
 
 // LoadConfigFiles ingests config files with ResourceLoader and returns config details with paths to local copies
 func LoadConfigFiles(ctx context.Context, configFiles []string, workingDir string, options ...func(*Options)) (*types.ConfigDetails, error) {


### PR DESCRIPTION
As `extends` is processed, `!override` must apply to the resulting extended service, but not propagated to a higher-level

fixes https://github.com/docker/compose/issues/13298