### PR TITLE
Fix JSON tag for ServiceProviderConfig type field

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -145,7 +145,7 @@ type ServiceConfig struct {
 }
 
 type ServiceProviderConfig struct {
-	Type       string       `yaml:"type,omitempty" json:"driver,omitempty"`
+	Type       string       `yaml:"type,omitempty" json:"type,omitempty"`
 	Options    MultiOptions `yaml:"options,omitempty" json:"options,omitempty"`
 	Extensions Extensions   `yaml:"#extensions,inline,omitempty" json:"-"`
 }


### PR DESCRIPTION
Fix JSON tag for ServiceProviderConfig type field.

I think this is a typo, since it was created there: https://github.com/compose-spec/compose-go/pull/758.

Just for context, with this snippet of my Compose file:
```yaml
...
services:
    my-model:
        provider:
            type: model
            options:
                model:
                    - ai/smollm2
```
When doing this https://github.com/score-spec/score-compose/blob/main/internal/patching/patching.go#L131, getting this error when doing a JSON decode/validation:
```none
json: unknown field "type"
```
While not getting any error when running `docker compose up` on this file (which is successfully doing the YAML decode/validation way).