### PR TITLE
feat(interpolate): Add cast to bool for 'depends_on' required and restart options

### DIFF
--- a/interpolation/interpolation_test.go
+++ b/interpolation/interpolation_test.go
@@ -27,9 +27,10 @@ import (
 )
 
 var defaults = map[string]string{
-	"USER":  "jenny",
-	"FOO":   "bar",
-	"count": "5",
+	"USER":     "jenny",
+	"FOO":      "bar",
+	"count":    "5",
+	"REQUIRED": "true",
 }
 
 func defaultMapping(name string) (string, bool) {
@@ -196,19 +197,27 @@ func TestInterpolateWithCast(t *testing.T) {
 	config := map[string]interface{}{
 		"foo": map[string]interface{}{
 			"replicas": "$count",
+			"required": "$REQUIRED",
 		},
 	}
 	toInt := func(value string) (interface{}, error) {
 		return strconv.Atoi(value)
 	}
+	toBoolean := func(value string) (interface{}, error) {
+		return strconv.ParseBool(value)
+	}
 	result, err := Interpolate(config, Options{
-		LookupValue:     defaultMapping,
-		TypeCastMapping: map[tree.Path]Cast{tree.NewPath(tree.PathMatchAll, "replicas"): toInt},
+		LookupValue: defaultMapping,
+		TypeCastMapping: map[tree.Path]Cast{
+			tree.NewPath(tree.PathMatchAll, "replicas"): toInt,
+			tree.NewPath(tree.PathMatchAll, "required"): toBoolean,
+		},
 	})
 	assert.NilError(t, err)
 	expected := map[string]interface{}{
 		"foo": map[string]interface{}{
 			"replicas": 5,
+			"required": true,
 		},
 	}
 	assert.Check(t, is.DeepEqual(expected, result))

--- a/loader/interpolate.go
+++ b/loader/interpolate.go
@@ -36,6 +36,8 @@ var interpolateTypeCastMapping = map[tree.Path]interp.Cast{
 	servicePath("cpus"):                                            toFloat32,
 	servicePath("cpu_shares"):                                      toInt64,
 	servicePath("init"):                                            toBoolean,
+	servicePath("depends_on", tree.PathMatchAll, "required"):       toBoolean,
+	servicePath("depends_on", tree.PathMatchAll, "restart"):        toBoolean,
 	servicePath("deploy", "replicas"):                              toInt,
 	servicePath("deploy", "update_config", "parallelism"):          toInt,
 	servicePath("deploy", "update_config", "max_failure_ratio"):    toFloat,


### PR DESCRIPTION
Added type casting support for the `required` and `restart` boolean fields in the `depends_on` service configuration. Previously, when these fields were specified using environment variable interpolation (e.g., `${DB_REQUIRED:-true}`), they would remain as strings instead of being converted to proper boolean values.

https://github.com/docker/compose/issues/13340