### PR TITLE
create_host_path must not be omitted when set to false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ['1.23', '1.24']
+        go-version: ['1.24', '1.25']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 10

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/compose-spec/compose-go/v2
 
-go 1.23
+go 1.24
 
 require (
 	github.com/distribution/reference v0.5.0

--- a/loader/full-struct_test.go
+++ b/loader/full-struct_test.go
@@ -755,7 +755,7 @@ services:
       FOO: foo_from_env_file
       QUX: qux_from_environment
     env_file:
-      - %s
+      - path: %s
       - path: %s
         required: false
     expose:
@@ -949,24 +949,20 @@ services:
       - type: bind
         source: /opt/data
         target: /var/lib/data
-        bind:
-          create_host_path: true
+        bind: {}
       - type: bind
         source: %s
         target: /code
-        bind:
-          create_host_path: true
+        bind: {}
       - type: bind
         source: %s
         target: /var/www/html
-        bind:
-          create_host_path: true
+        bind: {}
       - type: bind
         source: %s
         target: /etc/configs
         read_only: true
-        bind:
-          create_host_path: true
+        bind: {}
       - type: volume
         source: datavolume
         target: /var/lib/volume
@@ -1370,7 +1366,9 @@ func fullExampleJSON(workingDir, homeDir string) string {
         "QUX": "qux_from_environment"
       },
       "env_file": [
-        "%s",
+        {
+          "path": "%s"
+        },
         {
           "path": "%s",
           "required": false
@@ -1640,34 +1638,26 @@ func fullExampleJSON(workingDir, homeDir string) string {
           "type": "bind",
           "source": "/opt/data",
           "target": "/var/lib/data",
-          "bind": {
-            "create_host_path": true
-          }
+          "bind": {}
         },
         {
           "type": "bind",
           "source": "%s",
           "target": "/code",
-          "bind": {
-            "create_host_path": true
-          }
+          "bind": {}
         },
         {
           "type": "bind",
           "source": "%s",
           "target": "/var/www/html",
-          "bind": {
-            "create_host_path": true
-          }
+          "bind": {}
         },
         {
           "type": "bind",
           "source": "%s",
           "target": "/etc/configs",
           "read_only": true,
-          "bind": {
-            "create_host_path": true
-          }
+          "bind": {}
         },
         {
           "type": "volume",

--- a/types/envfile.go
+++ b/types/envfile.go
@@ -16,32 +16,8 @@
 
 package types
 
-import (
-	"encoding/json"
-)
-
 type EnvFile struct {
 	Path     string `yaml:"path,omitempty" json:"path,omitempty"`
-	Required bool   `yaml:"required" json:"required"`
+	Required OptOut `yaml:"required,omitempty" json:"required,omitzero"`
 	Format   string `yaml:"format,omitempty" json:"format,omitempty"`
-}
-
-// MarshalYAML makes EnvFile implement yaml.Marshaler
-func (e EnvFile) MarshalYAML() (interface{}, error) {
-	if e.Required {
-		return e.Path, nil
-	}
-	return map[string]any{
-		"path":     e.Path,
-		"required": e.Required,
-	}, nil
-}
-
-// MarshalJSON makes EnvFile implement json.Marshaler
-func (e *EnvFile) MarshalJSON() ([]byte, error) {
-	if e.Required {
-		return json.Marshal(e.Path)
-	}
-	// Pass as a value to avoid re-entering this method and use the default implementation
-	return json.Marshal(*e)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -564,10 +564,18 @@ const (
 type ServiceVolumeBind struct {
 	SELinux        string `yaml:"selinux,omitempty" json:"selinux,omitempty"`
 	Propagation    string `yaml:"propagation,omitempty" json:"propagation,omitempty"`
-	CreateHostPath bool   `yaml:"create_host_path,omitempty" json:"create_host_path,omitempty"`
+	CreateHostPath OptOut `yaml:"create_host_path,omitempty" json:"create_host_path,omitzero"`
 	Recursive      string `yaml:"recursive,omitempty" json:"recursive,omitempty"`
 
 	Extensions Extensions `yaml:"#extensions,inline,omitempty" json:"-"`
+}
+
+// OptOut is a boolean which default value is 'true'
+type OptOut bool
+
+func (o OptOut) IsZero() bool {
+	// Attribute can be omitted if value is true
+	return bool(o)
 }
 
 // SELinux represents the SELinux re-labeling options.

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -380,3 +380,37 @@ func TestMappingValues(t *testing.T) {
 	})
 	assert.DeepEqual(t, mapping.Values(), values)
 }
+
+func TestMarhsall(t *testing.T) {
+	p := Project{
+		Services: Services{
+			"test": ServiceConfig{
+				Volumes: []ServiceVolumeConfig{
+					{
+						Type: "bind",
+						Bind: &ServiceVolumeBind{
+							CreateHostPath: true, // default
+						},
+					},
+					{
+						Type: "bind",
+						Bind: &ServiceVolumeBind{
+							CreateHostPath: false,
+						},
+					},
+				},
+			},
+		},
+	}
+	marshalYAML, err := p.MarshalYAML()
+	assert.NilError(t, err)
+	assert.Equal(t, string(marshalYAML), `services:
+  test:
+    volumes:
+      - type: bind
+        bind: {}
+      - type: bind
+        bind:
+          create_host_path: false
+`)
+}


### PR DESCRIPTION
When a user use `create_host_path` to opt-out to volume bind default behavior this value isn't marshaled by `docker compose config`. We _should_ not have used `true` as default value 😅

see https://github.com/docker/compose/issues/13310#issuecomment-3496579272