### PR TITLE
use go.yaml.in/yaml/v4

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 
 	"github.com/compose-spec/compose-go/v2/consts"
 	"github.com/compose-spec/compose-go/v2/dotenv"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,7 +24,7 @@ import (
 	"os"
 
 	"github.com/compose-spec/compose-go/v2/cli"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.4
 	github.com/xhit/go-str2duration/v2 v2.1.0
-	go.yaml.in/yaml/v3 v3.0.4
+	go.yaml.in/yaml/v4 v4.0.0-rc.3
 	golang.org/x/sync v0.3.0
 	golang.org/x/text v0.14.0
 	gotest.tools/v3 v3.4.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
-go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+go.yaml.in/yaml/v4 v4.0.0-rc.3 h1:3h1fjsh1CTAPjW7q/EMe+C8shx5d8ctzZTrLcs/j8Go=
+go.yaml.in/yaml/v4 v4.0.0-rc.3/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -43,7 +43,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/validation"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/sirupsen/logrus"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Options supported by Load

--- a/loader/merge_reset_test.go
+++ b/loader/merge_reset_test.go
@@ -79,5 +79,5 @@ func Test_DuplicateReset(t *testing.T) {
 	}, func(options *Options) {
 		options.SkipNormalization = true
 	})
-	assert.Error(t, err, "failed to parse duplicate.yml: line 6: mapping key \"command\" already defined at line 5")
+	assert.ErrorContains(t, err, "line 6: mapping key \"command\" already defined at line 5")
 }

--- a/loader/normalize_test.go
+++ b/loader/normalize_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/types"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 	"gotest.tools/v3/assert"
 )
 

--- a/loader/reset.go
+++ b/loader/reset.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/tree"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type ResetProcessor struct {

--- a/loader/reset_test.go
+++ b/loader/reset_test.go
@@ -163,7 +163,7 @@ x-healthcheck: &healthcheck
     <<: *healthcheck
 `,
 			expectError: true,
-			errorMsg:    "failed to parse (inline): cycle detected: node at path x-healthcheck.egress-service.egress-service references node at path x-healthcheck.egress-service",
+			errorMsg:    "cycle detected: node at path x-healthcheck.egress-service.egress-service references node at path x-healthcheck.egress-service",
 		},
 	}
 
@@ -185,7 +185,7 @@ x-healthcheck: &healthcheck
 				)
 
 				if tt.expectError {
-					assert.Error(t, err, tt.errorMsg)
+					assert.ErrorContains(t, err, tt.errorMsg)
 				} else {
 					assert.NilError(t, err)
 				}

--- a/override/merge_test.go
+++ b/override/merge_test.go
@@ -19,7 +19,7 @@ package override
 import (
 	"testing"
 
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 	"gotest.tools/v3/assert"
 )
 

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 	"gotest.tools/v3/assert"
 )
 

--- a/transform/defaults_test.go
+++ b/transform/defaults_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/tree"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 	"gotest.tools/v3/assert"
 )
 

--- a/transform/envfile_test.go
+++ b/transform/envfile_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/tree"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 	"gotest.tools/v3/assert"
 )
 

--- a/types/command.go
+++ b/types/command.go
@@ -34,7 +34,7 @@ import "github.com/mattn/go-shellwords"
 // preserved so that it can override any base value (e.g. container entrypoint).
 //
 // The different semantics between YAML and JSON are due to limitations with
-// JSON marshaling + `omitempty` in the Go stdlib, while go.yaml.in/yaml/v3 gives
+// JSON marshaling + `omitempty` in the Go stdlib, while go.yaml.in/yaml/v4 gives
 // us more flexibility via the yaml.IsZeroer interface.
 //
 // In the future, it might make sense to make fields of this type be
@@ -58,7 +58,7 @@ func (s ShellCommand) IsZero() bool {
 // accurately if the `omitempty` struct tag is omitted/forgotten.
 //
 // A similar MarshalJSON() implementation is not needed because the Go stdlib
-// already serializes nil slices to `null`, whereas go.yaml.in/yaml/v3 by default
+// already serializes nil slices to `null`, whereas go.yaml.in/yaml/v4 by default
 // serializes nil slices to `[]`.
 func (s ShellCommand) MarshalYAML() (interface{}, error) {
 	if s == nil {

--- a/types/project.go
+++ b/types/project.go
@@ -32,7 +32,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/utils"
 	"github.com/distribution/reference"
 	godigest "github.com/opencontainers/go-digest"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/tree"
-	"go.yaml.in/yaml/v3"
+	"go.yaml.in/yaml/v4"
 	"gotest.tools/v3/assert"
 )
 


### PR DESCRIPTION
see https://github.com/yaml/go-yaml

> All ongoing work, including new features and routine bug-fixes, will happen in v4. If you’re starting a new project or upgrading an existing one, please use the go.yaml.in/yaml/v4 import path.