### PR TITLE
Introduced ability to skip env_file parsing with include

### DIFF
--- a/loader/include.go
+++ b/loader/include.go
@@ -117,6 +117,9 @@ func ApplyInclude(ctx context.Context, workingDir string, environment types.Mapp
 		} else {
 			envFile := []string{}
 			for _, f := range r.EnvFile {
+				if f == "/dev/null" {
+					continue
+				}
 				if !filepath.IsAbs(f) {
 					f = filepath.Join(workingDir, f)
 					s, err := os.Stat(f)


### PR DESCRIPTION
This let user set:
```yaml
include:
  - path: docker-compose.base.yml
    env_file: /dev/null
```
including when client is running on Windows

closes https://github.com/docker/compose/issues/13128