### PR TITLE
do not force project dir for remote configs

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -393,12 +393,11 @@ func (o *ProjectOptions) GetWorkingDir() (string, error) {
 	if o.WorkingDir != "" {
 		return filepath.Abs(o.WorkingDir)
 	}
-PATH:
 	for _, path := range o.ConfigPaths {
 		if path != "-" {
 			for _, l := range o.ResourceLoaders {
 				if l.Accept(path) {
-					break PATH
+					return l.Dir(path), nil
 				}
 			}
 			absPath, err := filepath.Abs(path)

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -293,16 +293,12 @@ func LoadConfigFiles(ctx context.Context, configFiles []string, workingDir strin
 		}
 
 		for _, loader := range opts.ResourceLoaders {
-			_, isLocalResourceLoader := loader.(localResourceLoader)
 			if !loader.Accept(p) {
 				continue
 			}
 			local, err := loader.Load(ctx, p)
 			if err != nil {
 				return nil, err
-			}
-			if config.WorkingDir == "" && !isLocalResourceLoader {
-				config.WorkingDir = filepath.Dir(local)
 			}
 			abs, err := filepath.Abs(local)
 			if err != nil {


### PR DESCRIPTION
see https://github.com/compose-spec/compose-go/pull/701/files#diff-8e9af1e483632eac17610237caaa5f879ea7bfb3e1e1ea228e45a17c770b9432R331

we used to force project directory to be set by a remote artifact, even if imperatively set by user (https://github.com/docker/compose/issues/13390).
ProjectOptions.GetWorkingDir already takes care setting project dir to match remote resource local cache.