### PR TITLE
template: preserve replacement config for nested substitutions

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -196,7 +196,19 @@ func DefaultReplacementAppliedFunc(substring string, mapping Mapping, cfg *Confi
 			return "", false, err
 		}
 		if applied {
-			interpolatedNested, err := SubstituteWith(rest, mapping, pattern)
+			nestedOptions := []Option{
+				WithPattern(pattern),
+			}
+			if cfg.replacementFunc != nil {
+				nestedOptions = append(nestedOptions, WithReplacementFunction(cfg.replacementFunc))
+			}
+			if cfg.substituteFunc != nil {
+				nestedOptions = append(nestedOptions, WithSubstitutionFunction(cfg.substituteFunc))
+			}
+			if !cfg.logging {
+				nestedOptions = append(nestedOptions, WithoutLogging)
+			}
+			interpolatedNested, err := SubstituteWithOptions(rest, mapping, nestedOptions...)
 			if err != nil {
 				return "", false, err
 			}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -478,31 +478,6 @@ func TestSubstituteWithReplacementAppliedFunc(t *testing.T) {
 	assert.Check(t, is.ErrorContains(err, "bad choice"))
 }
 
-func TestSubstituteWithReplacementAppliedFuncKeepsConfigForRest(t *testing.T) {
-	hook, restore := captureWarnings(t)
-	defer restore()
-
-	options := []Option{
-		WithReplacementFunction(func(s string, m Mapping, c *Config) (string, error) {
-			r, applied, err := DefaultReplacementAppliedFunc(s, m, c)
-			if err == nil && !applied {
-				return s, nil
-			}
-			return r, err
-		}),
-		WithoutLogging,
-	}
-
-	missingMapping := func(string) (string, bool) {
-		return "", false
-	}
-
-	result, err := SubstituteWithOptions("ok ${FILE:-/tmp/file.jpg} --entry_id ${ENTRY_ID}", missingMapping, options...)
-	assert.NilError(t, err)
-	assert.Equal(t, "ok /tmp/file.jpg --entry_id ${ENTRY_ID}", result)
-	assert.Equal(t, 0, len(hook.Entries))
-}
-
 // TestPrecedence tests is the precedence on '-' and '?' is of the first match
 func TestPrecedence(t *testing.T) {
 	testCases := []struct {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -478,6 +478,31 @@ func TestSubstituteWithReplacementAppliedFunc(t *testing.T) {
 	assert.Check(t, is.ErrorContains(err, "bad choice"))
 }
 
+func TestSubstituteWithReplacementAppliedFuncKeepsConfigForRest(t *testing.T) {
+	hook, restore := captureWarnings(t)
+	defer restore()
+
+	options := []Option{
+		WithReplacementFunction(func(s string, m Mapping, c *Config) (string, error) {
+			r, applied, err := DefaultReplacementAppliedFunc(s, m, c)
+			if err == nil && !applied {
+				return s, nil
+			}
+			return r, err
+		}),
+		WithoutLogging,
+	}
+
+	missingMapping := func(string) (string, bool) {
+		return "", false
+	}
+
+	result, err := SubstituteWithOptions("ok ${FILE:-/tmp/file.jpg} --entry_id ${ENTRY_ID}", missingMapping, options...)
+	assert.NilError(t, err)
+	assert.Equal(t, "ok /tmp/file.jpg --entry_id ${ENTRY_ID}", result)
+	assert.Equal(t, 0, len(hook.Entries))
+}
+
 // TestPrecedence tests is the precedence on '-' and '?' is of the first match
 func TestPrecedence(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
## Summary

Preserve interpolation config when recursively substituting the `rest` portion of braced expressions in `DefaultReplacementAppliedFunc`.

Before this change, the recursive call used `SubstituteWith(rest, mapping, pattern)`, which dropped caller-provided options such as custom `ReplacementFunc` and `WithoutLogging`. This caused mixed expressions like `${FILE:-...} ${ENTRY_ID}` to incorrectly process `${ENTRY_ID}` with default behavior.

## What changed

- Pass the current config context to nested substitution by using `SubstituteWithOptions` with:
  - `WithPattern(cfg.pattern)`
  - `WithReplacementFunction(cfg.replacementFunc)` when set
  - `WithSubstitutionFunction(cfg.substituteFunc)` when set
  - `WithoutLogging` when logging is disabled

## Verification

- `go test ./template -count=1`
- `go test ./... -count=1`

Fixes #856
