### PR TITLE
fix: add UnmarshalJSON and UnmarshalYAML to UnitBytes

### DIFF
--- a/types/bytes.go
+++ b/types/bytes.go
@@ -38,18 +38,17 @@ func (u UnitBytes) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf(`"%d"`, u)), nil
 }
 
-// parseBytes parses a UnitBytes value from a string, supporting plain
+// parseString parses a string into a UnitBytes value, supporting plain
 // integers, negative values (e.g., "-1"), and human-readable byte units
 // (e.g., "1g", "512m").
-func parseBytes(s string) (UnitBytes, error) {
+func (u *UnitBytes) parseString(s string) error {
 	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
-		return UnitBytes(n), nil
+		*u = UnitBytes(n)
+		return nil
 	}
 	b, err := units.RAMInBytes(s)
-	if err != nil {
-		return 0, err
-	}
-	return UnitBytes(b), nil
+	*u = UnitBytes(b)
+	return err
 }
 
 // UnmarshalJSON makes UnitBytes implement json.Unmarshaler
@@ -63,12 +62,7 @@ func (u *UnitBytes) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}
-	b, err := parseBytes(s)
-	if err != nil {
-		return err
-	}
-	*u = b
-	return nil
+	return u.parseString(s)
 }
 
 // UnmarshalYAML makes UnitBytes implement yaml.Unmarshaler
@@ -82,12 +76,7 @@ func (u *UnitBytes) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&s); err != nil {
 		return err
 	}
-	b, err := parseBytes(s)
-	if err != nil {
-		return err
-	}
-	*u = b
-	return nil
+	return u.parseString(s)
 }
 
 func (u *UnitBytes) DecodeMapstructure(value interface{}) error {
@@ -95,9 +84,7 @@ func (u *UnitBytes) DecodeMapstructure(value interface{}) error {
 	case int:
 		*u = UnitBytes(v)
 	case string:
-		b, err := units.RAMInBytes(fmt.Sprint(value))
-		*u = UnitBytes(b)
-		return err
+		return u.parseString(v)
 	}
 	return nil
 }

--- a/types/bytes.go
+++ b/types/bytes.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 
 	"github.com/docker/go-units"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // UnitBytes is the bytes type

--- a/types/bytes.go
+++ b/types/bytes.go
@@ -17,9 +17,12 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/docker/go-units"
+	"gopkg.in/yaml.v3"
 )
 
 // UnitBytes is the bytes type
@@ -33,6 +36,58 @@ func (u UnitBytes) MarshalYAML() (interface{}, error) {
 // MarshalJSON makes UnitBytes implement json.Marshaler
 func (u UnitBytes) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf(`"%d"`, u)), nil
+}
+
+// parseBytes parses a UnitBytes value from a string, supporting plain
+// integers, negative values (e.g., "-1"), and human-readable byte units
+// (e.g., "1g", "512m").
+func parseBytes(s string) (UnitBytes, error) {
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return UnitBytes(n), nil
+	}
+	b, err := units.RAMInBytes(s)
+	if err != nil {
+		return 0, err
+	}
+	return UnitBytes(b), nil
+}
+
+// UnmarshalJSON makes UnitBytes implement json.Unmarshaler
+func (u *UnitBytes) UnmarshalJSON(data []byte) error {
+	var v int64
+	if err := json.Unmarshal(data, &v); err == nil {
+		*u = UnitBytes(v)
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	b, err := parseBytes(s)
+	if err != nil {
+		return err
+	}
+	*u = b
+	return nil
+}
+
+// UnmarshalYAML makes UnitBytes implement yaml.Unmarshaler
+func (u *UnitBytes) UnmarshalYAML(value *yaml.Node) error {
+	var v int64
+	if err := value.Decode(&v); err == nil {
+		*u = UnitBytes(v)
+		return nil
+	}
+	var s string
+	if err := value.Decode(&s); err != nil {
+		return err
+	}
+	b, err := parseBytes(s)
+	if err != nil {
+		return err
+	}
+	*u = b
+	return nil
 }
 
 func (u *UnitBytes) DecodeMapstructure(value interface{}) error {

--- a/types/bytes_test.go
+++ b/types/bytes_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestUnitBytesUnmarshalJSON(t *testing.T) {

--- a/types/bytes_test.go
+++ b/types/bytes_test.go
@@ -1,0 +1,128 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestUnitBytesUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected UnitBytes
+	}{
+		{"plain integer", `655360`, UnitBytes(655360)},
+		{"string integer", `"655360"`, UnitBytes(655360)},
+		{"negative integer", `-1`, UnitBytes(-1)},
+		{"string negative", `"-1"`, UnitBytes(-1)},
+		{"human readable 1g", `"1g"`, UnitBytes(1073741824)},
+		{"human readable 512m", `"512m"`, UnitBytes(536870912)},
+		{"zero", `0`, UnitBytes(0)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result UnitBytes
+			err := json.Unmarshal([]byte(tt.input), &result)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestUnitBytesUnmarshalJSON_Invalid(t *testing.T) {
+	var result UnitBytes
+	err := json.Unmarshal([]byte(`"invalid"`), &result)
+	assert.Error(t, err)
+}
+
+func TestUnitBytesUnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected UnitBytes
+	}{
+		{"plain integer", `655360`, UnitBytes(655360)},
+		{"quoted string integer", `"655360"`, UnitBytes(655360)},
+		{"negative integer", `-1`, UnitBytes(-1)},
+		{"human readable 1g", `"1g"`, UnitBytes(1073741824)},
+		{"human readable 512m", `"512m"`, UnitBytes(536870912)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result UnitBytes
+			err := yaml.Unmarshal([]byte(tt.input), &result)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestUnitBytesUnmarshalYAML_Invalid(t *testing.T) {
+	var result UnitBytes
+	err := yaml.Unmarshal([]byte(`"invalid"`), &result)
+	assert.Error(t, err)
+}
+
+func TestUnitBytesJSONRoundTrip(t *testing.T) {
+	original := UnitBytes(655360)
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var result UnitBytes
+	err = json.Unmarshal(data, &result)
+	require.NoError(t, err)
+	assert.Equal(t, original, result)
+}
+
+func TestUnitBytesYAMLRoundTrip(t *testing.T) {
+	original := UnitBytes(655360)
+	data, err := yaml.Marshal(original)
+	require.NoError(t, err)
+
+	var result UnitBytes
+	err = yaml.Unmarshal(data, &result)
+	require.NoError(t, err)
+	assert.Equal(t, original, result)
+}
+
+func TestUnitBytesJSONRoundTripViaUntypedMap(t *testing.T) {
+	type wrapper struct {
+		Size UnitBytes `json:"size"`
+	}
+	original := wrapper{Size: UnitBytes(655360)}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var untyped map[string]interface{}
+	err = json.Unmarshal(data, &untyped)
+	require.NoError(t, err)
+
+	data2, err := json.Marshal(untyped)
+	require.NoError(t, err)
+
+	var result wrapper
+	err = json.Unmarshal(data2, &result)
+	require.NoError(t, err)
+	assert.Equal(t, original, result)
+}


### PR DESCRIPTION
#### Description

Adds `UnmarshalJSON` and `UnmarshalYAML` methods to `types.UnitBytes` so that JSON and YAML round-trips work correctly.

Fixes https://github.com/compose-spec/compose-go/issues/865

### What this PR does

`UnitBytes` has `MarshalJSON`/`MarshalYAML` that serialize the value as a string (e.g., `"655360"`), but no corresponding unmarshalers. Go's default `int64` unmarshaler rejects the string, so any `json.Unmarshal` or `yaml.Unmarshal` back into `UnitBytes` fails.

This PR adds `UnmarshalJSON` and `UnmarshalYAML` that accept both numeric values and string values (including human-readable units like `"1g"` via `units.RAMInBytes`), consistent with the existing `DecodeMapstructure` method.

### Testing evidence

Using the reproduction program from the issue:

**Before (main):**
```
Original value: 655360 (type: types.UnitBytes)

json.Marshal output: "655360"
json.Unmarshal error: json: cannot unmarshal string into Go value of type types.UnitBytes

yaml.Marshal output: "655360"
yaml.Unmarshal into interface{}: 655360 (type: string)

json.Marshal of untyped value: "655360"
json.Unmarshal back to UnitBytes error: json: cannot unmarshal string into Go value of type types.UnitBytes
```

**After (this PR):**
```
Original value: 655360 (type: types.UnitBytes)

json.Marshal output: "655360"
json.Unmarshal error: <nil>

yaml.Marshal output: "655360"
yaml.Unmarshal into interface{}: 655360 (type: string)

json.Marshal of untyped value: "655360"
json.Unmarshal back to UnitBytes error: <nil>
```

All existing tests pass (`go test ./...`).
