### PR TITLE
types/project: collect service results in local map to avoid race

### DIFF
--- a/types/project.go
+++ b/types/project.go
@@ -796,19 +796,18 @@ func (p *Project) WithServicesTransform(fn func(name string, s ServiceConfig) (S
 	newProject := p.deepCopy()
 
 	eg, ctx := errgroup.WithContext(context.Background())
+	collected := Services{}
 	eg.Go(func() error {
-		s := Services{}
 		for expect > 0 {
 			select {
 			case <-ctx.Done():
 				// interrupted as some goroutine returned an error
 				return nil
 			case r := <-resultCh:
-				s[r.name] = r.service
+				collected[r.name] = r.service
 				expect--
 			}
 		}
-		newProject.Services = s
 		return nil
 	})
 	for n, s := range newProject.Services {
@@ -826,7 +825,11 @@ func (p *Project) WithServicesTransform(fn func(name string, s ServiceConfig) (S
 			return nil
 		})
 	}
-	return newProject, eg.Wait()
+	if err := eg.Wait(); err != nil {
+		return newProject, err
+	}
+	newProject.Services = collected
+	return newProject, nil
 }
 
 // CheckContainerNameUnicity validate project doesn't have services declaring the same container_name

--- a/types/project_test.go
+++ b/types/project_test.go
@@ -517,8 +517,8 @@ func TestWithServicesTransform_concurrent(t *testing.T) {
 		p.Services[fmt.Sprintf("svc_%d", i)] = ServiceConfig{Image: fmt.Sprintf("img_%d", i)}
 	}
 
-	got, err := p.WithServicesTransform(func(name string, s ServiceConfig) (ServiceConfig, error) {
-		s.Image = s.Image + "-transformed"
+	got, err := p.WithServicesTransform(func(_ string, s ServiceConfig) (ServiceConfig, error) {
+		s.Image += "-transformed"
 		return s, nil
 	})
 	assert.NilError(t, err)

--- a/types/project_test.go
+++ b/types/project_test.go
@@ -509,3 +509,23 @@ func TestProject_WithServicesEnvironmentResolved(t *testing.T) {
 func ptr[T any](s T) *T {
 	return &s
 }
+
+func TestWithServicesTransform_concurrent(t *testing.T) {
+	const n = 100
+	p := &Project{Services: Services{}}
+	for i := 0; i < n; i++ {
+		p.Services[fmt.Sprintf("svc_%d", i)] = ServiceConfig{Image: fmt.Sprintf("img_%d", i)}
+	}
+
+	got, err := p.WithServicesTransform(func(name string, s ServiceConfig) (ServiceConfig, error) {
+		s.Image = s.Image + "-transformed"
+		return s, nil
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, len(got.Services), n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("svc_%d", i)
+		want := fmt.Sprintf("img_%d-transformed", i)
+		assert.Equal(t, got.Services[name].Image, want)
+	}
+}


### PR DESCRIPTION
Closes #852. Collector goroutine wrote `newProject.Services` while the dispatch loop read it. Use a local map and assign after `eg.Wait()`.