### PR TITLE
types: add Options field to IPAMConfig

### DIFF
--- a/loader/tests/networks_test.go
+++ b/loader/tests/networks_test.go
@@ -68,7 +68,7 @@ networks:
     ipam:
       driver: overlay
       options:
-        foo: bar
+        ipam-opt-key: ipam-opt-value
       config:
         - subnet: 172.28.0.0/16
           ip_range: 172.28.5.0/24
@@ -99,7 +99,7 @@ networks:
 		assert.Equal(t, other.Driver, "overlay")
 		assert.DeepEqual(t, other.DriverOpts, types.Options{"foo": "bar", "baz": "1"})
 		assert.Equal(t, other.Ipam.Driver, "overlay")
-		assert.DeepEqual(t, other.Ipam.Options, types.Mapping{"foo": "bar"})
+		assert.DeepEqual(t, other.Ipam.Options, types.Mapping{"ipam-opt-key": "ipam-opt-value"})
 		assert.Equal(t, len(other.Ipam.Config), 2)
 		assert.Equal(t, other.Ipam.Config[0].Subnet, "172.28.0.0/16")
 		assert.Equal(t, other.Ipam.Config[0].IPRange, "172.28.5.0/24")
@@ -122,4 +122,8 @@ networks:
 	yamlP, jsonP := roundTrip(t, p)
 	expect(yamlP)
 	expect(jsonP)
+
+	copied, err := p.WithProfiles(nil)
+	assert.NilError(t, err)
+	expect(copied)
 }

--- a/loader/tests/networks_test.go
+++ b/loader/tests/networks_test.go
@@ -67,6 +67,8 @@ networks:
       baz: 1
     ipam:
       driver: overlay
+      options:
+        foo: bar
       config:
         - subnet: 172.28.0.0/16
           ip_range: 172.28.5.0/24
@@ -97,6 +99,7 @@ networks:
 		assert.Equal(t, other.Driver, "overlay")
 		assert.DeepEqual(t, other.DriverOpts, types.Options{"foo": "bar", "baz": "1"})
 		assert.Equal(t, other.Ipam.Driver, "overlay")
+		assert.DeepEqual(t, other.Ipam.Options, types.Mapping{"foo": "bar"})
 		assert.Equal(t, len(other.Ipam.Config), 2)
 		assert.Equal(t, other.Ipam.Config[0].Subnet, "172.28.0.0/16")
 		assert.Equal(t, other.Ipam.Config[0].IPRange, "172.28.5.0/24")

--- a/types/derived.gen.go
+++ b/types/derived.gen.go
@@ -2139,6 +2139,12 @@ func deriveDeepCopy_50(dst, src *IPAMConfig) {
 		}
 		deriveDeepCopy_60(dst.Config, src.Config)
 	}
+	if src.Options != nil {
+		dst.Options = make(map[string]string, len(src.Options))
+		deriveDeepCopy_5(dst.Options, src.Options)
+	} else {
+		dst.Options = nil
+	}
 	if src.Extensions != nil {
 		dst.Extensions = make(map[string]any, len(src.Extensions))
 		src.Extensions.DeepCopy(dst.Extensions)

--- a/types/types.go
+++ b/types/types.go
@@ -753,6 +753,7 @@ type NetworkConfig struct {
 type IPAMConfig struct {
 	Driver     string      `yaml:"driver,omitempty" json:"driver,omitempty"`
 	Config     []*IPAMPool `yaml:"config,omitempty" json:"config,omitempty"`
+	Options    Mapping     `yaml:"options,omitempty" json:"options,omitempty"`
 	Extensions Extensions  `yaml:"#extensions,inline,omitempty" json:"-"`
 }
 


### PR DESCRIPTION
The Compose spec has supported `ipam.options` (driver-specific IPAM options) for a while, and the JSON schema already defines it:

```json
"options": {
  "type": "object",
  "description": "Driver-specific options for the IPAM driver.",
  "patternProperties": {"^.+$": {"type": "string"}}
}
```

But `IPAMConfig` in Go was missing the `Options` field, so it silently dropped any options set in the compose file and they never made it to the Docker daemon (`"Options": null` in `docker network inspect`).

Three changes to fix this:
- Add `Options Mapping` to `IPAMConfig` struct in `types/types.go`
- Update the generated `deriveDeepCopy_50` in `derived.gen.go` to copy the new field (same pattern as other `map[string]string` fields)
- Add assertion to the existing `TestTopLevelNetworks` test that options are parsed and survive a round-trip

Related to docker/compose#13785 — this is the compose-go change needed before the docker/compose side can be fixed.