### PR TITLE
loader: add WithSelectedServices and WithoutUnnecessaryResources options

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -383,6 +383,24 @@ func WithoutEnvironmentResolution(o *ProjectOptions) error {
 	return nil
 }
 
+// WithSelectedServices restricts the loaded project to the given services and their
+// dependencies. An empty list means "all services". When set, services not in the
+// list are dropped from the project before environment resolution, so their
+// `env_file` / `label_file` entries are not loaded from disk.
+func WithSelectedServices(services ...string) ProjectOptionsFn {
+	return func(o *ProjectOptions) error {
+		o.loadOptions = append(o.loadOptions, loader.WithSelectedServices(services))
+		return nil
+	}
+}
+
+// WithoutUnnecessaryResources drops networks/volumes/secrets/configs/models that
+// are not referenced by services remaining after selection.
+func WithoutUnnecessaryResources(o *ProjectOptions) error {
+	o.loadOptions = append(o.loadOptions, loader.WithoutUnnecessaryResources)
+	return nil
+}
+
 // DefaultFileNames defines the Compose file names for auto-discovery (in order of preference)
 var DefaultFileNames = []string{"compose.yaml", "compose.yml", "docker-compose.yml", "docker-compose.yaml"}
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -78,6 +78,14 @@ type Options struct {
 	projectNameImperativelySet bool
 	// Profiles set profiles to enable
 	Profiles []string
+	// SelectedServices restricts the project model to these services (and their dependencies)
+	// after parsing. An empty slice means "all services". When set, services not in the list
+	// are dropped from the project before environment resolution, so their env_file / label_file
+	// entries are not loaded.
+	SelectedServices []string
+	// PruneUnnecessaryResources drops networks/volumes/secrets/configs/models that are not
+	// referenced by active services after service selection.
+	PruneUnnecessaryResources bool
 	// ResourceLoaders manages support for remote resources
 	ResourceLoaders []ResourceLoader
 	// KnownExtensions manages x-* attribute we know and the corresponding go structs
@@ -187,6 +195,8 @@ func (o *Options) clone() *Options {
 		projectName:                o.projectName,
 		projectNameImperativelySet: o.projectNameImperativelySet,
 		Profiles:                   o.Profiles,
+		SelectedServices:           o.SelectedServices,
+		PruneUnnecessaryResources:  o.PruneUnnecessaryResources,
 		ResourceLoaders:            o.ResourceLoaders,
 		KnownExtensions:            o.KnownExtensions,
 		Listeners:                  o.Listeners,
@@ -258,6 +268,22 @@ func WithProfiles(profiles []string) func(*Options) {
 	return func(opts *Options) {
 		opts.Profiles = profiles
 	}
+}
+
+// WithSelectedServices restricts the loaded project to the given services and their
+// dependencies. An empty slice means "all services". When set, services not in the
+// list are dropped from the project before environment resolution: their `env_file`
+// and `label_file` entries will not be loaded from disk.
+func WithSelectedServices(services []string) func(*Options) {
+	return func(opts *Options) {
+		opts.SelectedServices = services
+	}
+}
+
+// WithoutUnnecessaryResources drops networks/volumes/secrets/configs/models that
+// are not referenced by services remaining after selection.
+func WithoutUnnecessaryResources(opts *Options) {
+	opts.PruneUnnecessaryResources = true
 }
 
 // PostProcessor is used to tweak compose model based on metadata extracted during yaml Unmarshal phase
@@ -601,6 +627,21 @@ func ModelToProject(dict map[string]interface{}, opts *Options, configDetails ty
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if len(opts.SelectedServices) > 0 {
+		project, err = project.WithServicesEnabled(opts.SelectedServices...)
+		if err != nil {
+			return nil, err
+		}
+		project, err = project.WithSelectedServices(opts.SelectedServices)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if opts.PruneUnnecessaryResources {
+		project = project.WithoutUnnecessaryResources()
 	}
 
 	if !opts.SkipResolveEnvironment {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2882,3 +2882,148 @@ services:
 	assert.NilError(t, err)
 	assert.Equal(t, p.Name, "test-with-empty-file")
 }
+
+func TestWithSelectedServicesOption(t *testing.T) {
+	yaml := `
+name: test
+services:
+  web:
+    image: nginx
+  api:
+    image: alpine
+  worker:
+    image: busybox
+`
+	t.Run("empty list keeps all services", func(t *testing.T) {
+		p, err := LoadWithContext(context.Background(), buildConfigDetails(yaml, nil),
+			WithSelectedServices(nil),
+		)
+		assert.NilError(t, err)
+		_, hasWeb := p.Services["web"]
+		_, hasAPI := p.Services["api"]
+		_, hasWorker := p.Services["worker"]
+		assert.Assert(t, hasWeb && hasAPI && hasWorker, "all services should remain when selection is empty")
+	})
+
+	t.Run("restricts project to selected services", func(t *testing.T) {
+		p, err := LoadWithContext(context.Background(), buildConfigDetails(yaml, nil),
+			WithSelectedServices([]string{"web"}),
+		)
+		assert.NilError(t, err)
+		_, hasWeb := p.Services["web"]
+		_, hasAPI := p.Services["api"]
+		_, hasWorker := p.Services["worker"]
+		assert.Assert(t, hasWeb, "web should be selected")
+		assert.Assert(t, !hasAPI, "api should have been filtered out")
+		assert.Assert(t, !hasWorker, "worker should have been filtered out")
+	})
+
+	t.Run("includes dependencies of selected services", func(t *testing.T) {
+		yamlWithDeps := `
+name: test
+services:
+  web:
+    image: nginx
+    depends_on:
+      - api
+  api:
+    image: alpine
+  worker:
+    image: busybox
+`
+		p, err := LoadWithContext(context.Background(), buildConfigDetails(yamlWithDeps, nil),
+			WithSelectedServices([]string{"web"}),
+		)
+		assert.NilError(t, err)
+		_, hasWeb := p.Services["web"]
+		_, hasAPI := p.Services["api"]
+		_, hasWorker := p.Services["worker"]
+		assert.Assert(t, hasWeb, "web should be selected")
+		assert.Assert(t, hasAPI, "api dependency should be kept")
+		assert.Assert(t, !hasWorker, "worker should have been filtered out")
+	})
+}
+
+// TestWithSelectedServicesOption_SkipsMissingEnvFile ensures that a `env_file`
+// required entry referencing a missing file on a service that is NOT in the
+// selection does not cause the load to fail: the loader must apply service
+// selection before resolving environment.
+func TestWithSelectedServicesOption_SkipsMissingEnvFile(t *testing.T) {
+	yaml := `
+name: test
+services:
+  web:
+    image: nginx
+  other:
+    image: alpine
+    env_file:
+      - path: this-file-does-not-exist.env
+        required: true
+`
+	t.Run("loading without selection fails on missing env_file", func(t *testing.T) {
+		_, err := LoadWithContext(context.Background(), buildConfigDetails(yaml, nil))
+		assert.ErrorContains(t, err, "this-file-does-not-exist.env")
+	})
+
+	t.Run("loading with selection ignores env_file of unselected services", func(t *testing.T) {
+		p, err := LoadWithContext(context.Background(), buildConfigDetails(yaml, nil),
+			WithSelectedServices([]string{"web"}),
+		)
+		assert.NilError(t, err)
+		_, hasWeb := p.Services["web"]
+		_, hasOther := p.Services["other"]
+		assert.Assert(t, hasWeb)
+		assert.Assert(t, !hasOther)
+	})
+}
+
+func TestWithoutUnnecessaryResourcesOption(t *testing.T) {
+	yaml := `
+name: test
+services:
+  web:
+    image: nginx
+    networks:
+      - frontnet
+    volumes:
+      - data:/data
+  worker:
+    image: busybox
+    networks:
+      - backnet
+    volumes:
+      - tmp:/tmp
+networks:
+  frontnet:
+  backnet:
+volumes:
+  data:
+  tmp:
+`
+	t.Run("keeps all resources without pruning", func(t *testing.T) {
+		p, err := LoadWithContext(context.Background(), buildConfigDetails(yaml, nil),
+			WithSelectedServices([]string{"web"}),
+		)
+		assert.NilError(t, err)
+		_, hasBackNet := p.Networks["backnet"]
+		_, hasTmpVol := p.Volumes["tmp"]
+		assert.Assert(t, hasBackNet, "backnet should be kept without WithoutUnnecessaryResources")
+		assert.Assert(t, hasTmpVol, "tmp volume should be kept without WithoutUnnecessaryResources")
+	})
+
+	t.Run("drops resources unreferenced by selected services", func(t *testing.T) {
+		p, err := LoadWithContext(context.Background(), buildConfigDetails(yaml, nil),
+			WithSelectedServices([]string{"web"}),
+			WithoutUnnecessaryResources,
+		)
+		assert.NilError(t, err)
+		_, hasFrontNet := p.Networks["frontnet"]
+		_, hasBackNet := p.Networks["backnet"]
+		_, hasDataVol := p.Volumes["data"]
+		_, hasTmpVol := p.Volumes["tmp"]
+		assert.Assert(t, hasFrontNet, "frontnet referenced by web should remain")
+		assert.Assert(t, !hasBackNet, "backnet referenced only by worker should be pruned")
+		assert.Assert(t, hasDataVol, "data volume referenced by web should remain")
+		assert.Assert(t, !hasTmpVol, "tmp volume referenced only by worker should be pruned")
+	})
+}


### PR DESCRIPTION
## Summary

Expose two new loader options so consumers can express service selection
and resource pruning as part of the standard parsing pipeline, without
having to disable environment resolution and re-invoke
`project.WithServicesEnvironmentResolved` manually after loading.

- `loader.WithSelectedServices([]string)` / `cli.WithSelectedServices(...string)`
  - empty slice keeps all services (no-op).
  - otherwise applies `project.WithServicesEnabled(...)` then
    `project.WithSelectedServices(...)`, restricting the project to the
    requested services and their dependencies.
- `loader.WithoutUnnecessaryResources` / `cli.WithoutUnnecessaryResources`
  - drops networks / volumes / secrets / configs / models that are not
    referenced by services remaining after selection.

Both transformations are applied **before**
`WithServicesEnvironmentResolved` (and the implicit
`WithServicesLabelsResolved`) in `ModelToProject`. Concretely, this means
the loader no longer reads `env_file` / `label_file` entries from disk
for services that have been filtered out -- a `required: true` `env_file`
on an unselected service is no longer fatal.

## Motivation

Today, callers that want to select a subset of services have to do:

```go
// load without resolving env
proj, _ := opts.LoadProject(ctx) // with cli.WithoutEnvironmentResolution
// filter services themselves (outside compose-go)
proj, _ = proj.WithSelectedServices(targets)
// resolve env after filtering
proj, _ = proj.WithServicesEnvironmentResolved(true)
```

This is what docker/compose currently does in
[`pkg/compose/loader.go::postProcessProject`](https://github.com/docker/compose/blob/main/pkg/compose/loader.go)
and in `cmd/compose/compose.go::WithServices`. The two-step approach is
needed to avoid reading `env_file` entries (or failing on missing ones)
for services the caller is not interested in. With this PR the same
result can be expressed in a single call:

```go
proj, _ := opts.LoadProject(ctx, cli.WithSelectedServices(targets...))
```

## Tests

- `TestWithSelectedServicesOption` — empty list keeps all services;
  non-empty restricts; dependencies of selected services are kept.
- `TestWithSelectedServicesOption_SkipsMissingEnvFile` — verifies that a
  `required: true` `env_file` pointing to a missing file on an
  unselected service does NOT fail the load.
- `TestWithoutUnnecessaryResourcesOption` — verifies networks / volumes
  referenced only by filtered-out services are pruned when the option
  is set, kept otherwise.

## Test plan

- [x] `go test ./...` passes locally
- [x] new tests cover the three behaviors above