### PR TITLE
feat(types): add IPAMConfig.Options field

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -106,6 +106,8 @@ networks:
       driver: default
       config:
         - subnet: 172.28.0.0/16
+      options:
+        foo: bar
 `
 
 var samplePortsConfig = []types.ServicePortConfig{
@@ -207,6 +209,9 @@ var sampleConfig = types.Config{
 					{
 						Subnet: "172.28.0.0/16",
 					},
+				},
+				Options: types.Options{
+					"foo": "bar",
 				},
 			},
 		},

--- a/loader/tests/network_ipam_test.go
+++ b/loader/tests/network_ipam_test.go
@@ -1,0 +1,60 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"gotest.tools/v3/assert"
+)
+
+func TestNetworkIPAM(t *testing.T) {
+	p := load(t, `
+name: test
+services:
+  foo:
+    image: alpine
+networks:
+  net1:
+    ipam:
+      driver: default
+      options:
+        com.docker.network.ipam.foo: bar
+        com.docker.network.ipam.baz: "1"
+      config:
+        - subnet: 172.28.0.0/16
+          gateway: 172.28.0.1
+`)
+
+	expect := func(p *types.Project) {
+		ipam := p.Networks["net1"].Ipam
+		assert.Equal(t, ipam.Driver, "default")
+		assert.DeepEqual(t, ipam.Options, types.Options{
+			"com.docker.network.ipam.foo": "bar",
+			"com.docker.network.ipam.baz": "1",
+		})
+		assert.Equal(t, len(ipam.Config), 1)
+		assert.Equal(t, ipam.Config[0].Subnet, "172.28.0.0/16")
+		assert.Equal(t, ipam.Config[0].Gateway, "172.28.0.1")
+	}
+	expect(p)
+
+	yamlP, jsonP := roundTrip(t, p)
+	expect(yamlP)
+	expect(jsonP)
+}

--- a/types/derived.gen.go
+++ b/types/derived.gen.go
@@ -2139,6 +2139,12 @@ func deriveDeepCopy_50(dst, src *IPAMConfig) {
 		}
 		deriveDeepCopy_60(dst.Config, src.Config)
 	}
+	if src.Options != nil {
+		dst.Options = make(map[string]string, len(src.Options))
+		deriveDeepCopy_5(dst.Options, src.Options)
+	} else {
+		dst.Options = nil
+	}
 	if src.Extensions != nil {
 		dst.Extensions = make(map[string]any, len(src.Extensions))
 		src.Extensions.DeepCopy(dst.Extensions)

--- a/types/types.go
+++ b/types/types.go
@@ -753,6 +753,7 @@ type NetworkConfig struct {
 type IPAMConfig struct {
 	Driver     string      `yaml:"driver,omitempty" json:"driver,omitempty"`
 	Config     []*IPAMPool `yaml:"config,omitempty" json:"config,omitempty"`
+	Options    Options     `yaml:"options,omitempty" json:"options,omitempty"`
 	Extensions Extensions  `yaml:"#extensions,inline,omitempty" json:"-"`
 }
 


### PR DESCRIPTION
## Summary
- Add an `Options` field of type `Options` (a.k.a. `map[string]string`) to `types.IPAMConfig`, with yaml/json tag `options`
- Regenerate `types/derived.gen.go` to deep-copy the new field
- Add a dedicated loader test (`loader/tests/network_ipam_test.go`) covering `ipam.driver`, `ipam.options` and `ipam.config` round-trip
- Extend the existing `TestLoadV2` fixture with `options` under `with_ipam`

## Why
The Compose spec schema (`schema/compose-spec.json`) already allows `networks.<x>.ipam.options` as a driver-specific options map (analogous to `options:` under `logging:` or `driver_opts:` under a network). However, the Go `IPAMConfig` struct didn't expose this field, so entries provided under `ipam.options` were silently dropped on load and never reached consumers (e.g. docker/compose, which currently can't forward them to the daemon).

This makes `IPAMConfig` consistent with the JSON schema, and with sibling structures like `NetworkConfig.DriverOpts` or `LoggingConfig.Options`.

Reported downstream as docker/compose#13785.

## Test plan
- [x] `go test ./loader/...` — all tests pass, including the new `TestNetworkIPAM`
- [x] New test exercises both YAML and JSON round-trip (via the existing `roundTrip` helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)