### PR TITLE
Pin image mount digests in WithImagesResolved

### DIFF
--- a/types/project.go
+++ b/types/project.go
@@ -579,28 +579,50 @@ func (p *Project) WithServicesDisabled(names ...string) *Project {
 // It returns a new Project instance with the changes and keep the original Project unchanged
 func (p *Project) WithImagesResolved(resolver func(named reference.Named) (godigest.Digest, error)) (*Project, error) {
 	return p.WithServicesTransform(func(_ string, service ServiceConfig) (ServiceConfig, error) {
-		if service.Image == "" {
-			return service, nil
-		}
-		named, err := reference.ParseDockerRef(service.Image)
-		if err != nil {
-			return service, err
+		if service.Image != "" {
+			resolved, err := resolveImageDigest(service.Image, resolver)
+			if err != nil {
+				return service, err
+			}
+			service.Image = resolved
 		}
 
-		if _, ok := named.(reference.Canonical); !ok {
-			// image is named but not digested reference
-			digest, err := resolver(named)
+		for i, volume := range service.Volumes {
+			if volume.Type != VolumeTypeImage || volume.Source == "" {
+				continue
+			}
+			resolved, err := resolveImageDigest(volume.Source, resolver)
 			if err != nil {
 				return service, err
 			}
-			named, err = reference.WithDigest(named, digest)
-			if err != nil {
-				return service, err
-			}
+			volume.Source = resolved
+			service.Volumes[i] = volume
 		}
-		service.Image = named.String()
+
 		return service, nil
 	})
+}
+
+// resolveImageDigest returns image pinned to a digest. If image is not already a
+// digested (canonical) reference, the digest is obtained from resolver.
+func resolveImageDigest(image string, resolver func(named reference.Named) (godigest.Digest, error)) (string, error) {
+	named, err := reference.ParseDockerRef(image)
+	if err != nil {
+		return image, err
+	}
+
+	if _, ok := named.(reference.Canonical); !ok {
+		// image is named but not digested reference
+		digest, err := resolver(named)
+		if err != nil {
+			return image, err
+		}
+		named, err = reference.WithDigest(named, digest)
+		if err != nil {
+			return image, err
+		}
+	}
+	return named.String(), nil
 }
 
 type marshallOptions struct {

--- a/types/project.go
+++ b/types/project.go
@@ -575,12 +575,29 @@ func (p *Project) WithServicesDisabled(names ...string) *Project {
 	return newProject
 }
 
-// WithImagesResolved updates services images to include digest computed by a resolver function
-// It returns a new Project instance with the changes and keep the original Project unchanged
+// WithImagesResolved updates services to pin both service.Image and image-mount
+// volume sources (type=image) to digests computed by the resolver. It returns a
+// new Project with the changes and keeps the original Project unchanged. Within
+// each service, repeated lookups for the same image reference are deduplicated
+// so callers that hit a registry per resolve aren't charged twice when the
+// service image and an image-mount volume reference the same tag.
 func (p *Project) WithImagesResolved(resolver func(named reference.Named) (godigest.Digest, error)) (*Project, error) {
 	return p.WithServicesTransform(func(_ string, service ServiceConfig) (ServiceConfig, error) {
+		cache := map[string]string{}
+		resolve := func(img string) (string, error) {
+			if r, ok := cache[img]; ok {
+				return r, nil
+			}
+			r, err := resolveImageDigest(img, resolver)
+			if err != nil {
+				return img, err
+			}
+			cache[img] = r
+			return r, nil
+		}
+
 		if service.Image != "" {
-			resolved, err := resolveImageDigest(service.Image, resolver)
+			resolved, err := resolve(service.Image)
 			if err != nil {
 				return service, err
 			}
@@ -591,7 +608,7 @@ func (p *Project) WithImagesResolved(resolver func(named reference.Named) (godig
 			if volume.Type != VolumeTypeImage || volume.Source == "" {
 				continue
 			}
-			resolved, err := resolveImageDigest(volume.Source, resolver)
+			resolved, err := resolve(volume.Source)
 			if err != nil {
 				return service, err
 			}

--- a/types/project.go
+++ b/types/project.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"sync"
 
 	"github.com/compose-spec/compose-go/v2/dotenv"
 	"github.com/compose-spec/compose-go/v2/errdefs"
@@ -34,6 +35,7 @@ import (
 	godigest "github.com/opencontainers/go-digest"
 	"go.yaml.in/yaml/v4"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 )
 
 // Project is the result of loading a set of compose files
@@ -577,23 +579,30 @@ func (p *Project) WithServicesDisabled(names ...string) *Project {
 
 // WithImagesResolved updates services to pin both service.Image and image-mount
 // volume sources (type=image) to digests computed by the resolver. It returns a
-// new Project with the changes and keeps the original Project unchanged. Within
-// each service, repeated lookups for the same image reference are deduplicated
-// so callers that hit a registry per resolve aren't charged twice when the
-// service image and an image-mount volume reference the same tag.
+// new Project with the changes and keeps the original Project unchanged.
+// Repeated lookups for the same image reference are deduplicated across the
+// whole project, so callers that hit a registry per resolve are charged once
+// per distinct reference even when several services or image-mount volumes
+// share the same tag.
 func (p *Project) WithImagesResolved(resolver func(named reference.Named) (godigest.Digest, error)) (*Project, error) {
+	var cache sync.Map // map[string]string
+	var flight singleflight.Group
 	return p.WithServicesTransform(func(_ string, service ServiceConfig) (ServiceConfig, error) {
-		cache := map[string]string{}
 		resolve := func(img string) (string, error) {
-			if r, ok := cache[img]; ok {
+			// singleflight collapses concurrent lookups for the same reference
+			// so services transformed in parallel don't race past the cache
+			r, err, _ := flight.Do(img, func() (interface{}, error) {
+				if r, ok := cache.Load(img); ok {
+					return r, nil
+				}
+				r, err := resolveImageDigest(img, resolver)
+				if err != nil {
+					return img, err
+				}
+				cache.Store(img, r)
 				return r, nil
-			}
-			r, err := resolveImageDigest(img, resolver)
-			if err != nil {
-				return img, err
-			}
-			cache[img] = r
-			return r, nil
+			})
+			return r.(string), err
 		}
 
 		if service.Image != "" {
@@ -622,7 +631,7 @@ func (p *Project) WithImagesResolved(resolver func(named reference.Named) (godig
 
 // resolveImageDigest returns image pinned to a digest. If image is not already a
 // digested (canonical) reference, the digest is obtained from resolver.
-func resolveImageDigest(image string, resolver func(named reference.Named) (godigest.Digest, error)) (string, error) {
+func resolveImageDigest(image string, resolver func(reference.Named) (godigest.Digest, error)) (string, error) {
 	named, err := reference.ParseDockerRef(image)
 	if err != nil {
 		return image, err

--- a/types/project_test.go
+++ b/types/project_test.go
@@ -209,6 +209,44 @@ func Test_ResolveImages(t *testing.T) {
 	}
 }
 
+func Test_ResolveImages_imageMount(t *testing.T) {
+	const dgst = "sha256:1234567890123456789012345678901234567890123456789012345678901234"
+	resolver := func(_ reference.Named) (digest.Digest, error) {
+		return dgst, nil
+	}
+	p := &Project{
+		Services: Services{
+			"app": ServiceConfig{
+				Name:  "app",
+				Image: "busybox:latest",
+				Volumes: []ServiceVolumeConfig{
+					{
+						Type:   VolumeTypeImage,
+						Source: "busybox:latest",
+						Target: "/test_mount",
+					},
+					{
+						// non-image volumes must be left untouched
+						Type:   VolumeTypeBind,
+						Source: "/host/path",
+						Target: "/bind_mount",
+					},
+				},
+			},
+		},
+	}
+
+	p, err := p.WithImagesResolved(resolver)
+	assert.NilError(t, err)
+
+	app := p.Services["app"]
+	assert.Equal(t, app.Image, "docker.io/library/busybox:latest@"+dgst)
+	// image mount source is pinned to a digest just like the service image
+	assert.Equal(t, app.Volumes[0].Source, "docker.io/library/busybox:latest@"+dgst)
+	// non-image (bind) mount source is left untouched
+	assert.Equal(t, app.Volumes[1].Source, "/host/path")
+}
+
 func Test_ResolveImages_concurrent(t *testing.T) {
 	const garfield = "sha256:1234567890123456789012345678901234567890123456789012345678901234"
 	resolver := func(_ reference.Named) (digest.Digest, error) {

--- a/types/project_test.go
+++ b/types/project_test.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/utils"
@@ -286,8 +287,7 @@ func Test_ResolveImages_imageMount_alreadyCanonical(t *testing.T) {
 	p := &Project{
 		Services: Services{
 			"app": ServiceConfig{
-				Name:  "app",
-				Image: pinned,
+				Name: "app",
 				Volumes: []ServiceVolumeConfig{
 					{
 						Type:   VolumeTypeImage,
@@ -303,9 +303,49 @@ func Test_ResolveImages_imageMount_alreadyCanonical(t *testing.T) {
 	assert.NilError(t, err)
 
 	app := p.Services["app"]
-	assert.Equal(t, app.Image, pinned)
 	assert.Equal(t, app.Volumes[0].Source, pinned)
 	assert.Equal(t, resolverCalls, 0)
+}
+
+func Test_ResolveImages_imageMount_sharedAcrossServices(t *testing.T) {
+	const dgst = "sha256:1234567890123456789012345678901234567890123456789012345678901234"
+	var resolverCalls atomic.Int32
+	resolver := func(_ reference.Named) (digest.Digest, error) {
+		resolverCalls.Add(1)
+		return dgst, nil
+	}
+	service := func(name string) ServiceConfig {
+		return ServiceConfig{
+			Name:  name,
+			Image: "busybox:latest",
+			Volumes: []ServiceVolumeConfig{
+				{
+					Type:   VolumeTypeImage,
+					Source: "busybox:latest",
+					Target: "/test_mount",
+				},
+			},
+		}
+	}
+	p := &Project{
+		Services: Services{
+			"app1": service("app1"),
+			"app2": service("app2"),
+			"app3": service("app3"),
+		},
+	}
+
+	p, err := p.WithImagesResolved(resolver)
+	assert.NilError(t, err)
+
+	pinned := "docker.io/library/busybox:latest@" + dgst
+	for _, name := range []string{"app1", "app2", "app3"} {
+		assert.Equal(t, p.Services[name].Image, pinned)
+		assert.Equal(t, p.Services[name].Volumes[0].Source, pinned)
+	}
+	// the cache is project-wide, so a reference shared by several services is
+	// resolved only once
+	assert.Equal(t, resolverCalls.Load(), int32(1))
 }
 
 func Test_ResolveImages_imageMount_unresolvable(t *testing.T) {
@@ -328,7 +368,7 @@ func Test_ResolveImages_imageMount_unresolvable(t *testing.T) {
 	}
 
 	_, err := p.WithImagesResolved(resolver)
-	assert.Error(t, err, "manifest unknown")
+	assert.ErrorContains(t, err, "manifest unknown")
 }
 
 func Test_ResolveImages_concurrent(t *testing.T) {

--- a/types/project_test.go
+++ b/types/project_test.go
@@ -247,6 +247,90 @@ func Test_ResolveImages_imageMount(t *testing.T) {
 	assert.Equal(t, app.Volumes[1].Source, "/host/path")
 }
 
+func Test_ResolveImages_imageMount_noServiceImage(t *testing.T) {
+	const dgst = "sha256:1234567890123456789012345678901234567890123456789012345678901234"
+	resolver := func(_ reference.Named) (digest.Digest, error) {
+		return dgst, nil
+	}
+	p := &Project{
+		Services: Services{
+			"app": ServiceConfig{
+				Name: "app",
+				Volumes: []ServiceVolumeConfig{
+					{
+						Type:   VolumeTypeImage,
+						Source: "busybox:latest",
+						Target: "/test_mount",
+					},
+				},
+			},
+		},
+	}
+
+	p, err := p.WithImagesResolved(resolver)
+	assert.NilError(t, err)
+
+	app := p.Services["app"]
+	assert.Equal(t, app.Image, "")
+	assert.Equal(t, app.Volumes[0].Source, "docker.io/library/busybox:latest@"+dgst)
+}
+
+func Test_ResolveImages_imageMount_alreadyCanonical(t *testing.T) {
+	const dgst = "sha256:1234567890123456789012345678901234567890123456789012345678901234"
+	resolverCalls := 0
+	resolver := func(_ reference.Named) (digest.Digest, error) {
+		resolverCalls++
+		return dgst, nil
+	}
+	pinned := "docker.io/library/busybox@" + dgst
+	p := &Project{
+		Services: Services{
+			"app": ServiceConfig{
+				Name:  "app",
+				Image: pinned,
+				Volumes: []ServiceVolumeConfig{
+					{
+						Type:   VolumeTypeImage,
+						Source: pinned,
+						Target: "/test_mount",
+					},
+				},
+			},
+		},
+	}
+
+	p, err := p.WithImagesResolved(resolver)
+	assert.NilError(t, err)
+
+	app := p.Services["app"]
+	assert.Equal(t, app.Image, pinned)
+	assert.Equal(t, app.Volumes[0].Source, pinned)
+	assert.Equal(t, resolverCalls, 0)
+}
+
+func Test_ResolveImages_imageMount_unresolvable(t *testing.T) {
+	resolver := func(_ reference.Named) (digest.Digest, error) {
+		return "", errors.New("manifest unknown")
+	}
+	p := &Project{
+		Services: Services{
+			"app": ServiceConfig{
+				Name: "app",
+				Volumes: []ServiceVolumeConfig{
+					{
+						Type:   VolumeTypeImage,
+						Source: "registry.example/missing:1.0",
+						Target: "/test_mount",
+					},
+				},
+			},
+		},
+	}
+
+	_, err := p.WithImagesResolved(resolver)
+	assert.Error(t, err, "manifest unknown")
+}
+
 func Test_ResolveImages_concurrent(t *testing.T) {
 	const garfield = "sha256:1234567890123456789012345678901234567890123456789012345678901234"
 	resolver := func(_ reference.Named) (digest.Digest, error) {


### PR DESCRIPTION
docker compose config --resolve-image-digests pins service image tags to digests but leaves image mounts untouched, so a volume of type image keeps a floating tag. This extends WithImagesResolved so it also pins the source of image mounts the same way it pins the service image. The per image resolution moved into a small helper that is reused for both cases, with a test covering an image mount alongside a bind mount that stays untouched. Reported in docker/compose#13827.
