### PR TITLE
fix(reset): preserve path escaping in cycle detection

### DIFF
--- a/loader/reset.go
+++ b/loader/reset.go
@@ -40,7 +40,7 @@ type nodeCache struct {
 type ResetProcessor struct {
 	target        any
 	paths         []tree.Path
-	visitedNodes  map[*yaml.Node][]string
+	visitedNodes  map[*yaml.Node][]tree.Path
 	resolvedNodes map[*yaml.Node]nodeCache
 	visitCount    int
 	// maxNodeVisits is the per-document cap; when zero, defaultMaxNodeVisits is used.
@@ -49,7 +49,7 @@ type ResetProcessor struct {
 
 // UnmarshalYAML implement yaml.Unmarshaler
 func (p *ResetProcessor) UnmarshalYAML(value *yaml.Node) error {
-	p.visitedNodes = make(map[*yaml.Node][]string)
+	p.visitedNodes = make(map[*yaml.Node][]tree.Path)
 	p.resolvedNodes = make(map[*yaml.Node]nodeCache)
 	p.visitCount = 0
 	defer func() {
@@ -283,36 +283,41 @@ func (p *ResetProcessor) applyNullOverrides(target any, path tree.Path) error {
 
 func (p *ResetProcessor) checkForCycle(node *yaml.Node, path tree.Path) error {
 	paths := p.visitedNodes[node]
-	pathStr := path.String()
 
 	for _, prevPath := range paths {
 		// If we're visiting the exact same path, it's not a cycle
-		if pathStr == prevPath {
+		if path == prevPath {
 			continue
 		}
 
+		// Compare on the raw form so dots inside escaped segment names (e.g.
+		// service names containing ".") aren't conflated with path separators.
+		pathStr := string(path)
+		prevStr := string(prevPath)
+
 		// If either path is using a merge key, it's legitimate YAML merging
-		if strings.Contains(prevPath, "<<") || strings.Contains(pathStr, "<<") {
+		if strings.Contains(prevStr, "<<") || strings.Contains(pathStr, "<<") {
 			continue
 		}
 
 		// Only consider it a cycle if one path is contained within the other
 		// and they're not in different service definitions
-		if (strings.HasPrefix(pathStr, prevPath+".") ||
-			strings.HasPrefix(prevPath, pathStr+".")) &&
-			!areInDifferentServices(pathStr, prevPath) {
-			return fmt.Errorf("cycle detected: node at path %s references node at path %s", pathStr, prevPath)
+		if (strings.HasPrefix(pathStr, prevStr+".") ||
+			strings.HasPrefix(prevStr, pathStr+".")) &&
+			!areInDifferentServices(path, prevPath) {
+			return fmt.Errorf("cycle detected: node at path %s references node at path %s",
+				path.String(), prevPath.String())
 		}
 	}
 
-	p.visitedNodes[node] = append(paths, pathStr)
+	p.visitedNodes[node] = append(paths, path)
 	return nil
 }
 
 // areInDifferentServices checks if two paths are in different service definitions
-func areInDifferentServices(path1, path2 string) bool {
-	parts1 := strings.Split(path1, ".")
-	parts2 := strings.Split(path2, ".")
+func areInDifferentServices(path1, path2 tree.Path) bool {
+	parts1 := path1.Parts()
+	parts2 := path2.Parts()
 	for i := 0; i < len(parts1) && i < len(parts2); i++ {
 		if parts1[i] == "services" && i+1 < len(parts1) &&
 			parts2[i] == "services" && i+1 < len(parts2) {

--- a/loader/reset_test.go
+++ b/loader/reset_test.go
@@ -147,6 +147,18 @@ services:
 			expectError: false,
 		},
 		{
+			name: "dotted_service_names_prefix_no_cycle",
+			config: `
+name: test
+services:
+  test.unit: &shared
+    image: alpine
+  test: *shared
+  test.other: *shared
+`,
+			expectError: false,
+		},
+		{
 			name: "direct_self_reference_cycle",
 			config: `
 name: test


### PR DESCRIPTION
checkForCycle called path.String(), which un-escapes dots inside segment names. Service names containing "." (e.g. "test.other") were then misidentified as sub-paths of services with shorter prefix names (e.g. "test"), triggering a spurious "cycle detected" error.

Compare on the raw form and use Path.Parts() for the services check so segment boundaries stay intact. Only render via .String() in the error message.

Fixes docker/compose#13863