### PR TITLE
Resolve dependent images (pre_start hooks, type: image volumes) in WithImagesResolved

### DIFF
--- a/types/project.go
+++ b/types/project.go
@@ -576,31 +576,52 @@ func (p *Project) WithServicesDisabled(names ...string) *Project {
 }
 
 // WithImagesResolved updates services images to include digest computed by a resolver function
-// It returns a new Project instance with the changes and keep the original Project unchanged
+// It returns a new Project instance with the changes and keep the original Project unchanged.
+// Besides the service image, this also resolves pre_start hook images, which run as ephemeral
+// init containers with their own image.
 func (p *Project) WithImagesResolved(resolver func(named reference.Named) (godigest.Digest, error)) (*Project, error) {
 	return p.WithServicesTransform(func(_ string, service ServiceConfig) (ServiceConfig, error) {
-		if service.Image == "" {
-			return service, nil
-		}
-		named, err := reference.ParseDockerRef(service.Image)
+		image, err := resolveImageDigest(service.Image, resolver)
 		if err != nil {
 			return service, err
 		}
+		service.Image = image
 
-		if _, ok := named.(reference.Canonical); !ok {
-			// image is named but not digested reference
-			digest, err := resolver(named)
+		for i, hook := range service.PreStart {
+			image, err := resolveImageDigest(hook.Image, resolver)
 			if err != nil {
 				return service, err
 			}
-			named, err = reference.WithDigest(named, digest)
-			if err != nil {
-				return service, err
-			}
+			service.PreStart[i].Image = image
 		}
-		service.Image = named.String()
 		return service, nil
 	})
+}
+
+// resolveImageDigest returns image with its digest resolved by resolver, unless
+// it is empty or already a canonical (digested) reference, in which case it is
+// returned unchanged.
+func resolveImageDigest(image string, resolver func(named reference.Named) (godigest.Digest, error)) (string, error) {
+	if image == "" {
+		return image, nil
+	}
+	named, err := reference.ParseDockerRef(image)
+	if err != nil {
+		return image, err
+	}
+
+	if _, ok := named.(reference.Canonical); !ok {
+		// image is named but not digested reference
+		digest, err := resolver(named)
+		if err != nil {
+			return image, err
+		}
+		named, err = reference.WithDigest(named, digest)
+		if err != nil {
+			return image, err
+		}
+	}
+	return named.String(), nil
 }
 
 type marshallOptions struct {

--- a/types/project.go
+++ b/types/project.go
@@ -34,6 +34,7 @@ import (
 	godigest "github.com/opencontainers/go-digest"
 	"go.yaml.in/yaml/v4"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 )
 
 // Project is the result of loading a set of compose files
@@ -577,22 +578,56 @@ func (p *Project) WithServicesDisabled(names ...string) *Project {
 
 // WithImagesResolved updates services images to include digest computed by a resolver function
 // It returns a new Project instance with the changes and keep the original Project unchanged.
-// Besides the service image, this also resolves pre_start hook images, which run as ephemeral
-// init containers with their own image.
+// Besides the service image, this also resolves the images services depend on:
+//   - pre_start hook images, which run as ephemeral init containers with their own image
+//   - `type: image` volume sources, unless they reference another service by name (those are
+//     resolved to a locally built image rather than a registry digest)
 func (p *Project) WithImagesResolved(resolver func(named reference.Named) (godigest.Digest, error)) (*Project, error) {
+	// Deduplicate resolutions per raw image string across the whole call: transforms run
+	// concurrently (one goroutine per service), so images shared by several services (or a
+	// hook image equal to its service image, which the loader copies at load time) would
+	// otherwise trigger duplicate registry round-trips. singleflight collapses concurrent
+	// resolutions of the same image into a single call, sharing the result.
+	var group singleflight.Group
+	resolve := func(image string) (string, error) {
+		r, err, _ := group.Do(image, func() (any, error) {
+			return resolveImageDigest(image, resolver)
+		})
+		if err != nil {
+			return image, err
+		}
+		return r.(string), nil
+	}
 	return p.WithServicesTransform(func(_ string, service ServiceConfig) (ServiceConfig, error) {
-		image, err := resolveImageDigest(service.Image, resolver)
+		image, err := resolve(service.Image)
 		if err != nil {
 			return service, err
 		}
 		service.Image = image
 
 		for i, hook := range service.PreStart {
-			image, err := resolveImageDigest(hook.Image, resolver)
+			image, err := resolve(hook.Image)
 			if err != nil {
 				return service, err
 			}
 			service.PreStart[i].Image = image
+		}
+
+		for i, vol := range service.Volumes {
+			if vol.Type != VolumeTypeImage {
+				continue
+			}
+			if _, ok := p.Services[vol.Source]; ok {
+				continue
+			}
+			if _, ok := p.DisabledServices[vol.Source]; ok {
+				continue
+			}
+			image, err := resolve(vol.Source)
+			if err != nil {
+				return service, err
+			}
+			service.Volumes[i].Source = image
 		}
 		return service, nil
 	})

--- a/types/project_test.go
+++ b/types/project_test.go
@@ -238,6 +238,89 @@ func Test_ResolveImages_preStartHooks(t *testing.T) {
 	assert.Equal(t, service.PreStart[1].Image, "")
 }
 
+func Test_ResolveImages_imageVolumes(t *testing.T) {
+	const digested = "sha256:1234567890123456789012345678901234567890123456789012345678901234"
+	resolver := func(_ reference.Named) (digest.Digest, error) {
+		return digested, nil
+	}
+	p := &Project{
+		Services: Services{
+			"builder": {
+				Name:  "builder",
+				Image: "docker.io/library/alpine:latest@" + digested,
+			},
+			"service_1": {
+				Name:  "service_1",
+				Image: "alpine:3.20",
+				Volumes: []ServiceVolumeConfig{
+					// external image reference: must be resolved to a digest
+					{Type: VolumeTypeImage, Source: "alpine:3.19", Target: "/data"},
+					// reference to another service: resolved to a local image, left untouched
+					{Type: VolumeTypeImage, Source: "builder", Target: "/from-builder"},
+					// regular named volume: left untouched
+					{Type: VolumeTypeVolume, Source: "vol", Target: "/vol"},
+				},
+			},
+		},
+	}
+
+	p, err := p.WithImagesResolved(resolver)
+	assert.NilError(t, err)
+
+	volumes := p.Services["service_1"].Volumes
+	assert.Equal(t, volumes[0].Source, "docker.io/library/alpine:3.19@"+digested)
+	assert.Equal(t, volumes[1].Source, "builder")
+	assert.Equal(t, volumes[2].Source, "vol")
+}
+
+func Test_ResolveImages_preStartHookError(t *testing.T) {
+	// A resolver failure on a pre_start hook image is fatal: hooks run as the
+	// service's own runtime images and must resolve.
+	resolver := func(_ reference.Named) (digest.Digest, error) {
+		return "", errors.New("registry unreachable")
+	}
+	p := &Project{
+		Services: Services{
+			"service_1": {
+				Name:  "service_1",
+				Image: "docker.io/library/alpine:3.20@sha256:1234567890123456789012345678901234567890123456789012345678901234",
+				PreStart: []ServiceHook{
+					{Image: "alpine:3.19", Command: ShellCommand{"echo", "init"}},
+				},
+			},
+		},
+	}
+
+	_, err := p.WithImagesResolved(resolver)
+	assert.Error(t, err, "registry unreachable")
+}
+
+func Test_ResolveImages_imageVolumeDisabledService(t *testing.T) {
+	// A `type: image` volume referencing a profile-disabled service is treated as a
+	// service reference: the resolver must never be called for it, and the source is
+	// left unchanged. The uppercase name would also trip reference.ParseDockerRef.
+	resolver := func(named reference.Named) (digest.Digest, error) {
+		return "", fmt.Errorf("resolver must not be called for %s", named)
+	}
+	p := &Project{
+		Services: Services{
+			"service_1": {
+				Name: "service_1",
+				Volumes: []ServiceVolumeConfig{
+					{Type: VolumeTypeImage, Source: "Builder", Target: "/from-builder"},
+				},
+			},
+		},
+		DisabledServices: Services{
+			"Builder": {Name: "Builder", Image: "alpine:3.19"},
+		},
+	}
+
+	p, err := p.WithImagesResolved(resolver)
+	assert.NilError(t, err)
+	assert.Equal(t, p.Services["service_1"].Volumes[0].Source, "Builder")
+}
+
 func Test_ResolveImages_concurrent(t *testing.T) {
 	const garfield = "sha256:1234567890123456789012345678901234567890123456789012345678901234"
 	resolver := func(_ reference.Named) (digest.Digest, error) {

--- a/types/project_test.go
+++ b/types/project_test.go
@@ -209,6 +209,35 @@ func Test_ResolveImages(t *testing.T) {
 	}
 }
 
+func Test_ResolveImages_preStartHooks(t *testing.T) {
+	const digested = "sha256:1234567890123456789012345678901234567890123456789012345678901234"
+	resolver := func(_ reference.Named) (digest.Digest, error) {
+		return digested, nil
+	}
+	p := &Project{
+		Services: Services{
+			"service_1": {
+				Name:  "service_1",
+				Image: "alpine:3.20",
+				PreStart: []ServiceHook{
+					{Image: "alpine:3.19", Command: ShellCommand{"echo", "init"}},
+					// hook without an explicit image falls back to the service
+					// image at runtime and must be left untouched here
+					{Command: ShellCommand{"echo", "noimage"}},
+				},
+			},
+		},
+	}
+
+	p, err := p.WithImagesResolved(resolver)
+	assert.NilError(t, err)
+
+	service := p.Services["service_1"]
+	assert.Equal(t, service.Image, "docker.io/library/alpine:3.20@"+digested)
+	assert.Equal(t, service.PreStart[0].Image, "docker.io/library/alpine:3.19@"+digested)
+	assert.Equal(t, service.PreStart[1].Image, "")
+}
+
 func Test_ResolveImages_concurrent(t *testing.T) {
 	const garfield = "sha256:1234567890123456789012345678901234567890123456789012345678901234"
 	resolver := func(_ reference.Named) (digest.Digest, error) {


### PR DESCRIPTION
## What I did

`Project.WithImagesResolved` only resolved the top-level `service.Image`, but a service can depend on other images that should be pinned by `docker compose config --resolve-image-digests` too:

- **`pre_start` hook images** — hooks run as ephemeral init containers with their own image (`ServiceHook.Image`)
- **`type: image` volume sources** — these mount an image referenced by the volume `source`

This PR extracts the single-image digest resolution into a `resolveImageDigest` helper and applies it to the service image, each `pre_start` hook image, and each `type: image` volume source.

- Hooks **without** an explicit image fall back to the service image at runtime, so they are left untouched (empty in → empty out).
- `type: image` volume sources that reference **another service by name** are resolved to a locally built image, not a registry digest, so they are skipped.
- Already-canonical (digested) references and empty images are returned unchanged, preserving the existing behaviour for the service image.
- The original `Project` stays unchanged: `WithServicesTransform` operates on a `deepCopy`, whose `PreStart`/`Volumes` slices have their own backing arrays, so the in-place updates never touch the caller's project.

## Motivation

Downstream in Docker Compose, `pre_start` hook images are otherwise ignored by image resolution (see docker/compose#13924 / docker/compose#13937). That PR handles `config --images`, `pull` and `up`, but digest resolution/locking has to be done here because `WithImagesResolved` is the single place where digests are computed. The `type: image` volume case is the same class of dependent-image resolution.

## Tests

- `Test_ResolveImages_preStartHooks`: a service with `image: alpine:3.20` and two `pre_start` hooks (one with `image: alpine:3.19`, one without an image) — asserts the service image and the explicit hook image are both resolved to `...@sha256:...`, and the image-less hook is left empty.
- `Test_ResolveImages_imageVolumes`: a service with three volumes — an external `type: image` source (`alpine:3.19`, resolved to a digest), a `type: image` source referencing another service (`builder`, left untouched), and a plain named volume (left untouched).
