### PR TITLE
interpolation: sort map keys for deterministic error reporting

### DIFF
--- a/interpolation/interpolation.go
+++ b/interpolation/interpolation.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/compose-spec/compose-go/v2/template"
 	"github.com/compose-spec/compose-go/v2/tree"
@@ -58,8 +59,8 @@ func Interpolate(config map[string]interface{}, opts Options) (map[string]interf
 
 	out := map[string]interface{}{}
 
-	for key, value := range config {
-		interpolatedValue, err := recursiveInterpolate(value, tree.NewPath(key), opts)
+	for _, key := range sortedKeys(config) {
+		interpolatedValue, err := recursiveInterpolate(config[key], tree.NewPath(key), opts)
 		if err != nil {
 			return out, err
 		}
@@ -88,8 +89,8 @@ func recursiveInterpolate(value interface{}, path tree.Path, opts Options) (inte
 
 	case map[string]interface{}:
 		out := map[string]interface{}{}
-		for key, elem := range value {
-			interpolatedElem, err := recursiveInterpolate(elem, path.Next(key), opts)
+		for _, key := range sortedKeys(value) {
+			interpolatedElem, err := recursiveInterpolate(value[key], path.Next(key), opts)
 			if err != nil {
 				return nil, err
 			}
@@ -125,6 +126,15 @@ func newPathError(path tree.Path, err error) error {
 	default:
 		return fmt.Errorf("error while interpolating %s: %w", path, err)
 	}
+}
+
+func sortedKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func (o Options) getCasterForPath(path tree.Path) (Cast, bool) {

--- a/interpolation/interpolation_test.go
+++ b/interpolation/interpolation_test.go
@@ -19,6 +19,7 @@ package interpolation
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/tree"
@@ -221,6 +222,34 @@ func TestInterpolateWithCast(t *testing.T) {
 		},
 	}
 	assert.Check(t, is.DeepEqual(expected, result))
+}
+
+func TestInterpolateRequiredErrorIsDeterministic(t *testing.T) {
+	// Two map keys with missing required variables: "zzz" sorts after "aaa",
+	// so the error must always reference "aaa" regardless of map iteration order.
+	config := map[string]interface{}{
+		"service": map[string]interface{}{
+			"zzz": "${MISSING:?required}",
+			"aaa": "${MISSING:?required}",
+		},
+	}
+
+	var firstErr string
+	for range 100 {
+		_, err := Interpolate(config, Options{})
+		if err == nil {
+			t.Fatal("expected an interpolation error, got nil")
+		}
+		if firstErr == "" {
+			firstErr = err.Error()
+		} else if err.Error() != firstErr {
+			t.Fatalf("non-deterministic error: got %q, want %q", err.Error(), firstErr)
+		}
+	}
+	// Alphabetically first key ("aaa") must appear in the path.
+	if !strings.Contains(firstErr, "service.aaa") {
+		t.Fatalf("expected error path to contain 'service.aaa', got: %s", firstErr)
+	}
 }
 
 func TestPathMatches(t *testing.T) {


### PR DESCRIPTION
## Problem

`docker compose config --quiet` (and `docker compose up`) can report a different
missing-required-variable error on each run when multiple config sections reference
absent required variables. For example, one run may report:

```
error while interpolating services.traefik.environment.[]: required variable TIMEZONE is missing a value
```

and the next may report:

```
error while interpolating services.traefik.volumes.[].source: required variable TRAEFIK_ACME_PATH is missing a value
```

Root cause: `recursiveInterpolate` and `Interpolate` iterate over
`map[string]interface{}` directly. Go randomises map iteration order, so the
first missing variable encountered varies between runs.

## Fix

Sort the map keys alphabetically before iterating in both `Interpolate` and
`recursiveInterpolate`. This adds a small `sortedKeys` helper and changes two
`range` loops to range over a sorted key slice instead.

The output `map[string]interface{}` is unchanged — only the order in which errors
are encountered becomes deterministic. With alphabetical traversal the error now
always identifies the lexicographically first problematic path, giving users
a stable, reproducible message to act on.

## Test

A new `TestInterpolateRequiredErrorIsDeterministic` test invokes `Interpolate`
100 times on a config with two map keys (`"aaa"` and `"zzz"`) both referencing
a missing required variable, and asserts that every run reports the same error
and that the path contains `"aaa"` (the alphabetically first key).

Fixes docker/compose#13712