### PR TITLE
loader: apply service selection to the raw yaml model path

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -362,7 +362,11 @@ func LoadWithContext(ctx context.Context, configDetails types.ConfigDetails, opt
 // LoadModelWithContext reads a ConfigDetails and returns a fully loaded configuration as a yaml dictionary
 func LoadModelWithContext(ctx context.Context, configDetails types.ConfigDetails, options ...func(*Options)) (map[string]any, error) {
 	opts := ToOptions(&configDetails, options)
-	return loadModelWithContext(ctx, &configDetails, opts)
+	dict, err := loadModelWithContext(ctx, &configDetails, opts)
+	if err != nil {
+		return nil, err
+	}
+	return SelectModelServices(dict, opts.SelectedServices)
 }
 
 // LoadModelWithContext reads a ConfigDetails and returns a fully loaded configuration as a yaml dictionary

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2923,6 +2923,21 @@ services:
 		assert.Assert(t, !hasWorker, "worker should have been filtered out")
 	})
 
+	t.Run("unselected services are disabled, not deleted", func(t *testing.T) {
+		// Unlike the model path, which deletes unselected services from the
+		// dict, the typed path keeps them in DisabledServices.
+		p, err := LoadWithContext(context.Background(), buildConfigDetails(yaml, nil),
+			WithSelectedServices([]string{"web"}),
+		)
+		assert.NilError(t, err)
+		_, disabledAPI := p.DisabledServices["api"]
+		_, disabledWorker := p.DisabledServices["worker"]
+		assert.Assert(t, disabledAPI, "api should be disabled, not deleted")
+		assert.Assert(t, disabledWorker, "worker should be disabled, not deleted")
+		_, disabledWeb := p.DisabledServices["web"]
+		assert.Assert(t, !disabledWeb, "selected web must not be disabled")
+	})
+
 	t.Run("includes dependencies of selected services", func(t *testing.T) {
 		yamlWithDeps := `
 name: test
@@ -3004,6 +3019,169 @@ services:
 		_, hasOther := p.Services["other"]
 		assert.Assert(t, hasWeb)
 		assert.Assert(t, !hasOther)
+	})
+}
+
+// TestLoadModelWithSelectedServices exercises WithSelectedServices through the
+// raw-dict LoadModelWithContext entry point, which never goes through ModelToProject.
+func TestLoadModelWithSelectedServices(t *testing.T) {
+	modelServices := func(t *testing.T, model map[string]any) map[string]any {
+		t.Helper()
+		services, ok := model["services"].(map[string]any)
+		assert.Assert(t, ok, "model[\"services\"] should be a map[string]any")
+		return services
+	}
+
+	t.Run("basic selection with no dependencies", func(t *testing.T) {
+		yaml := `
+name: test
+services:
+  web:
+    image: nginx
+  api:
+    image: alpine
+  worker:
+    image: busybox
+`
+		model, err := LoadModelWithContext(context.Background(), buildConfigDetails(yaml, nil),
+			WithSelectedServices([]string{"web"}),
+		)
+		assert.NilError(t, err)
+		services := modelServices(t, model)
+		assert.Assert(t, is.Len(services, 1))
+		_, hasWeb := services["web"]
+		assert.Assert(t, hasWeb)
+	})
+
+	t.Run("transitive depends_on closure", func(t *testing.T) {
+		yaml := `
+name: test
+services:
+  web:
+    image: nginx
+    depends_on:
+      - api
+  api:
+    image: alpine
+    depends_on:
+      - db
+  db:
+    image: postgres
+  worker:
+    image: busybox
+`
+		model, err := LoadModelWithContext(context.Background(), buildConfigDetails(yaml, nil),
+			WithSelectedServices([]string{"web"}),
+		)
+		assert.NilError(t, err)
+		services := modelServices(t, model)
+		assert.Assert(t, is.Len(services, 3))
+		for _, name := range []string{"web", "api", "db"} {
+			_, ok := services[name]
+			assert.Assert(t, ok, "%s should be kept", name)
+		}
+		_, hasWorker := services["worker"]
+		assert.Assert(t, !hasWorker)
+	})
+
+	t.Run("implicit edge via links is followed", func(t *testing.T) {
+		yaml := `
+name: test
+services:
+  web:
+    image: nginx
+    links:
+      - other
+  other:
+    image: alpine
+  worker:
+    image: busybox
+`
+		model, err := LoadModelWithContext(context.Background(), buildConfigDetails(yaml, nil),
+			WithSelectedServices([]string{"web"}),
+		)
+		assert.NilError(t, err)
+		services := modelServices(t, model)
+		_, hasWeb := services["web"]
+		_, hasOther := services["other"]
+		_, hasWorker := services["worker"]
+		assert.Assert(t, hasWeb)
+		assert.Assert(t, hasOther, "links should be folded into depends_on by Normalize")
+		assert.Assert(t, !hasWorker)
+	})
+
+	t.Run("uninterpolated depends_on key is silently ignored", func(t *testing.T) {
+		yaml := `
+name: test
+services:
+  web:
+    image: nginx
+    depends_on:
+      - "${VAR}"
+  other:
+    image: alpine
+`
+		model, err := LoadModelWithContext(context.Background(), buildConfigDetails(yaml, nil),
+			func(o *Options) { o.SkipInterpolation = true },
+			WithSelectedServices([]string{"web"}),
+		)
+		assert.NilError(t, err)
+		services := modelServices(t, model)
+		_, hasWeb := services["web"]
+		assert.Assert(t, hasWeb)
+		_, hasVar := services["${VAR}"]
+		assert.Assert(t, !hasVar)
+	})
+
+	t.Run("SkipNormalization leaves links unfolded, so linked service is dropped", func(t *testing.T) {
+		yaml := `
+name: test
+services:
+  web:
+    image: nginx
+    links:
+      - other
+  other:
+    image: alpine
+`
+		model, err := LoadModelWithContext(context.Background(), buildConfigDetails(yaml, nil),
+			func(o *Options) { o.SkipNormalization = true },
+			WithSelectedServices([]string{"web"}),
+		)
+		assert.NilError(t, err)
+		services := modelServices(t, model)
+		_, hasWeb := services["web"]
+		_, hasOther := services["other"]
+		assert.Assert(t, hasWeb)
+		assert.Assert(t, !hasOther, "without normalization, links are not folded into depends_on")
+	})
+
+	t.Run("unknown root service errors", func(t *testing.T) {
+		yaml := `
+name: test
+services:
+  web:
+    image: nginx
+`
+		_, err := LoadModelWithContext(context.Background(), buildConfigDetails(yaml, nil),
+			WithSelectedServices([]string{"bogus"}),
+		)
+		assert.ErrorContains(t, err, "no such service:")
+	})
+
+	t.Run("no selection option leaves all services", func(t *testing.T) {
+		yaml := `
+name: test
+services:
+  web:
+    image: nginx
+  api:
+    image: alpine
+`
+		model, err := LoadModelWithContext(context.Background(), buildConfigDetails(yaml, nil))
+		assert.NilError(t, err)
+		services := modelServices(t, model)
+		assert.Assert(t, is.Len(services, 2))
 	})
 }
 

--- a/loader/selection.go
+++ b/loader/selection.go
@@ -1,0 +1,74 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package loader
+
+import "fmt"
+
+// SelectModelServices restricts dict["services"] in place to the given root
+// service names plus the transitive closure of their depends_on, and returns
+// the dict. An empty names slice is a no-op. A root name that doesn't match
+// any declared service is an error, reported before any mutation. depends_on
+// entries are expected in the canonical map form produced by the loader;
+// entries that are not, or whose key doesn't match any declared service (e.g.
+// an uninterpolated "${VAR}" under SkipInterpolation), are silently ignored.
+func SelectModelServices(dict map[string]any, names []string) (map[string]any, error) {
+	if len(names) == 0 {
+		return dict, nil
+	}
+
+	services, _ := dict["services"].(map[string]any)
+
+	for _, name := range names {
+		if _, ok := services[name]; !ok {
+			return nil, fmt.Errorf("no such service: %s", name)
+		}
+	}
+
+	selected := map[string]bool{}
+	queue := append([]string{}, names...)
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+
+		if selected[name] {
+			continue
+		}
+		selected[name] = true
+
+		service, ok := services[name].(map[string]any)
+		if !ok {
+			continue
+		}
+		dependsOn, ok := service["depends_on"].(map[string]any)
+		if !ok {
+			continue
+		}
+		for dep := range dependsOn {
+			if _, ok := services[dep]; ok && !selected[dep] {
+				queue = append(queue, dep)
+			}
+		}
+	}
+
+	for name := range services {
+		if !selected[name] {
+			delete(services, name)
+		}
+	}
+
+	return dict, nil
+}

--- a/loader/selection_test.go
+++ b/loader/selection_test.go
@@ -1,0 +1,273 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package loader
+
+import (
+	"testing"
+
+	"go.yaml.in/yaml/v4"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func unmarshalModel(t *testing.T, doc string) map[string]any {
+	t.Helper()
+	var model map[string]any
+	err := yaml.Unmarshal([]byte(doc), &model)
+	assert.NilError(t, err)
+	return model
+}
+
+func servicesOf(t *testing.T, dict map[string]any) map[string]any {
+	t.Helper()
+	services, ok := dict["services"].(map[string]any)
+	assert.Assert(t, ok, "dict[\"services\"] should be a map[string]any")
+	return services
+}
+
+func TestSelectModelServices(t *testing.T) {
+	t.Run("single service with no dependencies", func(t *testing.T) {
+		dict := unmarshalModel(t, `
+services:
+  a:
+    image: a
+  b:
+    image: b
+`)
+
+		result, err := SelectModelServices(dict, []string{"a"})
+		assert.NilError(t, err)
+
+		services := servicesOf(t, result)
+		assert.Assert(t, is.Len(services, 1))
+		_, ok := services["a"]
+		assert.Assert(t, ok, "a should remain")
+		assert.Assert(t, is.Len(servicesOf(t, dict), 1), "selection mutates the dict in place")
+	})
+
+	t.Run("transitive closure through canonical depends_on", func(t *testing.T) {
+		dict := unmarshalModel(t, `
+services:
+  a:
+    image: a
+    depends_on:
+      b:
+        condition: service_started
+        required: true
+  b:
+    image: b
+    depends_on:
+      c:
+        condition: service_healthy
+        required: true
+  c:
+    image: c
+  d:
+    image: d
+`)
+
+		_, err := SelectModelServices(dict, []string{"a"})
+		assert.NilError(t, err)
+
+		services := servicesOf(t, dict)
+		assert.Assert(t, is.Len(services, 3))
+		for _, name := range []string{"a", "b", "c"} {
+			_, ok := services[name]
+			assert.Assert(t, ok, "%s should be kept", name)
+		}
+		_, hasD := services["d"]
+		assert.Assert(t, !hasD, "unrelated service d should have been dropped")
+	})
+
+	t.Run("multiple disjoint roots are all kept", func(t *testing.T) {
+		dict := unmarshalModel(t, `
+services:
+  a:
+    image: a
+    depends_on:
+      b:
+        condition: service_started
+        required: true
+  b:
+    image: b
+  c:
+    image: c
+    depends_on:
+      d:
+        condition: service_started
+        required: true
+  d:
+    image: d
+  e:
+    image: e
+`)
+
+		_, err := SelectModelServices(dict, []string{"a", "c"})
+		assert.NilError(t, err)
+
+		services := servicesOf(t, dict)
+		assert.Assert(t, is.Len(services, 4))
+		for _, name := range []string{"a", "b", "c", "d"} {
+			_, ok := services[name]
+			assert.Assert(t, ok, "%s should be kept", name)
+		}
+		_, hasE := services["e"]
+		assert.Assert(t, !hasE, "e should have been dropped")
+	})
+
+	t.Run("unknown root name errors without mutating the dict", func(t *testing.T) {
+		dict := unmarshalModel(t, `
+services:
+  a:
+    image: a
+  b:
+    image: b
+`)
+
+		_, err := SelectModelServices(dict, []string{"bogus"})
+		assert.ErrorContains(t, err, "no such service: bogus")
+
+		services := servicesOf(t, dict)
+		assert.Assert(t, is.Len(services, 2), "dict must be unmodified on error")
+		_, hasA := services["a"]
+		_, hasB := services["b"]
+		assert.Assert(t, hasA && hasB, "all original services should still be present")
+	})
+
+	t.Run("depends_on key not matching any service is ignored", func(t *testing.T) {
+		dict := unmarshalModel(t, `
+services:
+  a:
+    image: a
+    depends_on:
+      "${VAR}":
+        condition: service_started
+        required: true
+  b:
+    image: b
+`)
+
+		_, err := SelectModelServices(dict, []string{"a"})
+		assert.NilError(t, err)
+
+		services := servicesOf(t, dict)
+		assert.Assert(t, is.Len(services, 1))
+		_, hasA := services["a"]
+		assert.Assert(t, hasA, "a should be kept")
+		_, hasVar := services["${VAR}"]
+		assert.Assert(t, !hasVar, "${VAR} must not be added as a service")
+	})
+
+	t.Run("empty names leaves dict unchanged", func(t *testing.T) {
+		dict := unmarshalModel(t, `
+services:
+  a:
+    image: a
+  b:
+    image: b
+`)
+
+		_, err := SelectModelServices(dict, nil)
+		assert.NilError(t, err)
+
+		services := servicesOf(t, dict)
+		assert.Assert(t, is.Len(services, 2))
+	})
+
+	t.Run("missing services key errors without panic", func(t *testing.T) {
+		dict := map[string]any{"name": "test"}
+
+		_, err := SelectModelServices(dict, []string{"a"})
+		assert.ErrorContains(t, err, "no such service: a")
+	})
+
+	t.Run("empty services map errors without panic", func(t *testing.T) {
+		dict := map[string]any{"services": map[string]any{}}
+
+		_, err := SelectModelServices(dict, []string{"a"})
+		assert.ErrorContains(t, err, "no such service: a")
+	})
+
+	t.Run("duplicate names in input are handled without panic", func(t *testing.T) {
+		dict := unmarshalModel(t, `
+services:
+  a:
+    image: a
+  b:
+    image: b
+`)
+
+		_, err := SelectModelServices(dict, []string{"a", "a", "a"})
+		assert.NilError(t, err)
+
+		services := servicesOf(t, dict)
+		assert.Assert(t, is.Len(services, 1))
+		_, hasA := services["a"]
+		assert.Assert(t, hasA)
+	})
+
+	t.Run("dependency cycle terminates and keeps all members", func(t *testing.T) {
+		dict := unmarshalModel(t, `
+services:
+  a:
+    image: a
+    depends_on:
+      b:
+        condition: service_started
+        required: true
+  b:
+    image: b
+    depends_on:
+      a:
+        condition: service_started
+        required: true
+  c:
+    image: c
+`)
+
+		_, err := SelectModelServices(dict, []string{"a"})
+		assert.NilError(t, err)
+
+		services := servicesOf(t, dict)
+		assert.Assert(t, is.Len(services, 2))
+		_, hasA := services["a"]
+		_, hasB := services["b"]
+		assert.Assert(t, hasA && hasB, "both members of the cycle should be kept")
+	})
+
+	t.Run("self-dependency terminates", func(t *testing.T) {
+		dict := unmarshalModel(t, `
+services:
+  a:
+    image: a
+    depends_on:
+      a:
+        condition: service_started
+        required: true
+  b:
+    image: b
+`)
+
+		_, err := SelectModelServices(dict, []string{"a"})
+		assert.NilError(t, err)
+
+		services := servicesOf(t, dict)
+		assert.Assert(t, is.Len(services, 1))
+		_, hasA := services["a"]
+		assert.Assert(t, hasA)
+	})
+}


### PR DESCRIPTION
LoadModelWithContext ignored Options.SelectedServices: selection only existed on the typed path (ModelToProject), so consumers loading the raw model — like docker compose config --no-interpolate <SERVICE> — always got every service back.

SelectModelServices restricts the dict to the selected services plus their transitive depends_on closure. Unresolved dependency keys, such as an uninterpolated ${VAR}, are skipped rather than failing the load, since the raw model may be only partially resolved. This completes for the model path the selection support #875 added to the typed path.

Addresses docker/compose#13614