### PR TITLE
fix(loader): include env_file must override parent environment

### DIFF
--- a/loader/include.go
+++ b/loader/include.go
@@ -141,10 +141,15 @@ func ApplyInclude(ctx context.Context, workingDir string, environment types.Mapp
 			return err
 		}
 
+		includeEnv := environment.Clone()
+		for k, v := range envFromFile {
+			includeEnv[k] = v
+		}
+
 		config := types.ConfigDetails{
 			WorkingDir:  relworkingdir,
 			ConfigFiles: types.ToConfigFiles(r.Path),
-			Environment: environment.Clone().Merge(envFromFile),
+			Environment: includeEnv,
 		}
 		loadOptions.Interpolate = &interp.Options{
 			Substitute:      options.Interpolate.Substitute,

--- a/loader/include_test.go
+++ b/loader/include_test.go
@@ -63,7 +63,7 @@ services:
 	assert.NilError(t, err)
 	imported, err := p.GetService("imported")
 	assert.NilError(t, err)
-	assert.Equal(t, imported.ContainerName, "override")
+	assert.Equal(t, imported.ContainerName, "extends")
 }
 
 func TestLoadWithMultipleIncludeConflict(t *testing.T) {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -2300,7 +2300,7 @@ services:
 	assert.NilError(t, err)
 	imported, err := p.GetService("imported")
 	assert.NilError(t, err)
-	assert.Equal(t, imported.ContainerName, "override")
+	assert.Equal(t, imported.ContainerName, "extends")
 }
 
 func TestLoadWithIncludeCycle(t *testing.T) {


### PR DESCRIPTION
**Description:**
```markdown
## What I did

Fixed `Mapping.Merge` being first-wins in include processing, which
caused include-scoped `env_file` entries to be silently ignored when
the same keys already existed in the parent project's environment.

## What was the issue

When an include specifies an `env_file` list containing `.env`, values
from `.env` always took precedence over files listed after it —
breaking the expected "last file wins" semantics. This happened because
`.env` is loaded globally by `WithDotEnv` before include processing
begins, and `Mapping.Merge` (first-wins) refused to overwrite keys
already present in the parent environment.

## Where was the issue

`loader/include.go:147` — `environment.Clone().Merge(envFromFile)`
used the first-wins `Mapping.Merge` method.

## How I fixed it

Replaced `Merge` with an explicit last-wins override loop so the
include's `env_file` entries correctly override the parent environment:

```go
includeEnv := environment.Clone()
for k, v := range envFromFile {
    includeEnv[k] = v
}
```

## How to test

```bash
go test ./loader/ -run "Include" -count=1
```

## Related issue

Fixes docker/compose#13945

See also: docker/compose PR (https://github.com/docker/compose/pull/13954)