### PR TITLE
Add SkipResolveLabels option to skip label_file resolution

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -383,6 +383,16 @@ func WithoutEnvironmentResolution(o *ProjectOptions) error {
 	return nil
 }
 
+// WithoutLabelsResolution disable resolution of `label_file` into service labels.
+// When set, service `labels` may be incomplete: `label_file` entries are left
+// unresolved, so callers must not treat `labels` as authoritative.
+func WithoutLabelsResolution(o *ProjectOptions) error {
+	o.loadOptions = append(o.loadOptions, func(options *loader.Options) {
+		options.SkipResolveLabels = true
+	})
+	return nil
+}
+
 // WithSelectedServices restricts the loaded project to the given services and their
 // dependencies. An empty list means "all services". When set, services not in the
 // list are dropped from the project before environment resolution, so their

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -306,6 +306,21 @@ func TestProjectWithDiscardEnvFile(t *testing.T) {
 	assert.Equal(t, service.Ports[0].Published, "8000")
 }
 
+// TestProjectWithoutLabelsResolution loads a compose file referencing a missing
+// `label_file`, which only succeeds because resolution is skipped.
+func TestProjectWithoutLabelsResolution(t *testing.T) {
+	opts, err := NewProjectOptions([]string{
+		"testdata/label-file/compose-with-missing-label-file.yaml",
+	}, WithoutLabelsResolution)
+
+	assert.NilError(t, err)
+	p, err := ProjectFromOptions(context.TODO(), opts)
+	assert.NilError(t, err)
+	service, err := p.GetService("simple")
+	assert.NilError(t, err)
+	assert.Assert(t, len(service.LabelFiles) == 1, "label_file entry should be preserved when resolution is skipped")
+}
+
 func TestProjectWithMultipleEnvFile(t *testing.T) {
 	opts, err := NewProjectOptions([]string{
 		"testdata/env-file/compose-with-env-files.yaml",

--- a/cli/testdata/label-file/compose-with-missing-label-file.yaml
+++ b/cli/testdata/label-file/compose-with-missing-label-file.yaml
@@ -1,0 +1,5 @@
+name: label-file
+services:
+  simple:
+    image: nginx
+    label_file: ./this-file-does-not-exist.labels

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -66,6 +66,10 @@ type Options struct {
 	SkipInclude bool
 	// SkipResolveEnvironment will ignore computing `environment` for services
 	SkipResolveEnvironment bool
+	// SkipResolveLabels will ignore resolving `label_file` into `labels` for services.
+	// When set, service `labels` may be incomplete: `label_file` entries are left unresolved,
+	// so callers must not treat `labels` as authoritative.
+	SkipResolveLabels bool
 	// SkipDefaultValues will ignore missing required attributes
 	SkipDefaultValues bool
 	// Interpolation options
@@ -654,9 +658,12 @@ func ModelToProject(dict map[string]interface{}, opts *Options, configDetails ty
 		}
 	}
 
-	project, err = project.WithServicesLabelsResolved(opts.discardEnvFiles)
-	if err != nil {
-		return nil, err
+	if !opts.SkipResolveLabels {
+		// discardEnvFiles only applies to `env_file`: `label_file` entries are never discarded
+		project, err = project.WithServicesLabelsResolved(false)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return project, nil

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -3007,6 +3007,78 @@ services:
 	})
 }
 
+// TestSkipResolveLabels ensures that a `label_file` referencing a missing file
+// fails the load by default, but not when label resolution is skipped with
+// Options.SkipResolveLabels.
+func TestSkipResolveLabels(t *testing.T) {
+	yaml := `
+name: test
+services:
+  other:
+    image: alpine
+    label_file: this-file-does-not-exist.labels
+`
+	t.Run("loading fails on missing label_file by default", func(t *testing.T) {
+		_, err := LoadWithContext(context.Background(), buildConfigDetails(yaml, nil))
+		assert.ErrorContains(t, err, "this-file-does-not-exist.labels")
+	})
+
+	t.Run("loading succeeds when label resolution is skipped", func(t *testing.T) {
+		p, err := LoadWithContext(context.Background(), buildConfigDetails(yaml, nil),
+			func(options *Options) {
+				options.SkipResolveLabels = true
+			},
+		)
+		assert.NilError(t, err)
+		other, err := p.GetService("other")
+		assert.NilError(t, err)
+		assert.Assert(t, len(other.LabelFiles) == 1, "label_file entry should be preserved when resolution is skipped")
+	})
+}
+
+// TestWithSelectedServicesOption_SkipsMissingLabelFile ensures that a
+// `label_file` referencing a missing file on a service that is NOT in the
+// selection does not cause the load to fail: the loader must apply service
+// selection before resolving labels.
+func TestWithSelectedServicesOption_SkipsMissingLabelFile(t *testing.T) {
+	yaml := `
+name: test
+services:
+  web:
+    image: nginx
+  other:
+    image: alpine
+    label_file: this-file-does-not-exist.labels
+`
+	p, err := LoadWithContext(context.Background(), buildConfigDetails(yaml, nil),
+		WithSelectedServices([]string{"web"}),
+	)
+	assert.NilError(t, err)
+	_, hasWeb := p.Services["web"]
+	_, hasOther := p.Services["other"]
+	assert.Assert(t, hasWeb)
+	assert.Assert(t, !hasOther)
+}
+
+// TestWithDiscardEnvFilesKeepsLabelFiles pins that the discard option only
+// applies to `env_file` entries: `label_file` references are kept in the
+// model after being resolved into labels.
+func TestWithDiscardEnvFilesKeepsLabelFiles(t *testing.T) {
+	yaml := `
+name: test
+services:
+  web:
+    image: nginx
+    label_file: ./example1.label
+`
+	p, err := LoadWithContext(context.Background(), buildConfigDetails(yaml, nil), WithDiscardEnvFiles)
+	assert.NilError(t, err)
+	web, err := p.GetService("web")
+	assert.NilError(t, err)
+	assert.Equal(t, web.Labels["FOO"], "foo_from_label_file")
+	assert.Assert(t, len(web.LabelFiles) == 1, "label_file entries should be kept: the discard option only applies to env_file")
+}
+
 func TestWithoutUnnecessaryResourcesOption(t *testing.T) {
 	yaml := `
 name: test


### PR DESCRIPTION
`docker/compose` loads the full project just to resolve the project name for runtime commands (exec, ps, logs, ...) and uses
`WithoutEnvironmentResolution` so a missing `env_file` on an unrelated service does not abort them. `label_file` resolution had no equivalent opt-out: `WithServicesLabelsResolved` ran unconditionally and failed on
any missing file (`label_file` variant of docker/compose#13601).

Gate it behind `loader.Options.SkipResolveLabels` and expose `cli.WithoutLabelsResolution`.