### PR TITLE
fix(interpolation): report all errors in a deterministic order

### DIFF
--- a/interpolation/interpolation.go
+++ b/interpolation/interpolation.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
+	"strings"
 
 	"github.com/compose-spec/compose-go/v2/template"
 	"github.com/compose-spec/compose-go/v2/tree"
@@ -44,7 +46,12 @@ type LookupValue func(key string) (string, bool)
 // Cast a value to a new type, or return an error if the value can't be cast
 type Cast func(value string) (interface{}, error)
 
-// Interpolate replaces variables in a string with the values from a mapping
+// Interpolate replaces variables in a string with the values from a mapping.
+// Every failure is collected into a single joined error, reported in a stable
+// order, rather than returning the first one. There is one error per failing
+// config value: if a value holds several failing variable references, only
+// the first one is reported. The walk continues past failures, so
+// LookupValue, Substitute and Cast may run on values dropped from the result.
 func Interpolate(config map[string]interface{}, opts Options) (map[string]interface{}, error) {
 	if opts.LookupValue == nil {
 		opts.LookupValue = os.LookupEnv
@@ -57,16 +64,17 @@ func Interpolate(config map[string]interface{}, opts Options) (map[string]interf
 	}
 
 	out := map[string]interface{}{}
-
+	var errs []error
 	for key, value := range config {
 		interpolatedValue, err := recursiveInterpolate(value, tree.NewPath(key), opts)
 		if err != nil {
-			return out, err
+			errs = append(errs, err)
+			continue
 		}
 		out[key] = interpolatedValue
 	}
 
-	return out, nil
+	return out, joinErrors(errs)
 }
 
 func recursiveInterpolate(value interface{}, path tree.Path, opts Options) (interface{}, error) {
@@ -88,29 +96,49 @@ func recursiveInterpolate(value interface{}, path tree.Path, opts Options) (inte
 
 	case map[string]interface{}:
 		out := map[string]interface{}{}
+		var errs []error
 		for key, elem := range value {
 			interpolatedElem, err := recursiveInterpolate(elem, path.Next(key), opts)
 			if err != nil {
-				return nil, err
+				errs = append(errs, err)
+				continue
 			}
 			out[key] = interpolatedElem
 		}
-		return out, nil
+		return out, joinErrors(errs)
 
 	case []interface{}:
 		out := make([]interface{}, len(value))
+		var errs []error
 		for i, elem := range value {
 			interpolatedElem, err := recursiveInterpolate(elem, path.Next(tree.PathMatchList), opts)
 			if err != nil {
-				return nil, err
+				errs = append(errs, err)
+				continue
 			}
 			out[i] = interpolatedElem
 		}
-		return out, nil
+		// Index order is already deterministic, no need to sort.
+		return out, errors.Join(errs...)
 
 	default:
 		return value, nil
 	}
+}
+
+// joinErrors joins errors collected while ranging over a map in a stable
+// order, so that the random map iteration order does not leak into the
+// reported error. Errors are sorted by their formatted message, so different
+// error kinds are grouped rather than interleaved by config path. Only called
+// on the error path: successful interpolation pays no sorting cost.
+func joinErrors(errs []error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	slices.SortStableFunc(errs, func(a, b error) int {
+		return strings.Compare(a.Error(), b.Error())
+	})
+	return errors.Join(errs...)
 }
 
 func newPathError(path tree.Path, err error) error {

--- a/interpolation/interpolation.go
+++ b/interpolation/interpolation.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"slices"
-	"strings"
 
 	"github.com/compose-spec/compose-go/v2/template"
 	"github.com/compose-spec/compose-go/v2/tree"
@@ -47,8 +46,8 @@ type LookupValue func(key string) (string, bool)
 type Cast func(value string) (interface{}, error)
 
 // Interpolate replaces variables in a string with the values from a mapping.
-// Every failure is collected into a single joined error, reported in a stable
-// order, rather than returning the first one. There is one error per failing
+// Every failure is collected into a single joined error, sorted by config
+// path, rather than returning the first one. There is one error per failing
 // config value: if a value holds several failing variable references, only
 // the first one is reported. The walk continues past failures, so
 // LookupValue, Substitute and Cast may run on values dropped from the result.
@@ -126,20 +125,45 @@ func recursiveInterpolate(value interface{}, path tree.Path, opts Options) (inte
 	}
 }
 
-// joinErrors joins errors collected while ranging over a map in a stable
-// order, so that the random map iteration order does not leak into the
-// reported error. Errors are sorted by their formatted message, so different
-// error kinds are grouped rather than interleaved by config path. Only called
-// on the error path: successful interpolation pays no sorting cost.
+// joinErrors joins errors collected while ranging over a map, sorted by the
+// config path they carry, so that the random map iteration order does not
+// leak into the reported error. Only called on the error path: successful
+// interpolation pays no sorting cost.
 func joinErrors(errs []error) error {
 	if len(errs) == 0 {
 		return nil
 	}
 	slices.SortStableFunc(errs, func(a, b error) int {
-		return strings.Compare(a.Error(), b.Error())
+		return slices.Compare(errorPath(a), errorPath(b))
 	})
 	return errors.Join(errs...)
 }
+
+// errorPath returns the config path an error is sorted by, as path segments
+// so that keys compare whole (a raw string compare would order "service-1"
+// before "service"). For an already-joined subtree, errors.As finds whichever
+// pathError comes first; any of them does, as they all share the subtree
+// prefix that orders it among its siblings. An error carrying no path falls
+// back to its message, so the order stays deterministic whatever is
+// collected.
+func errorPath(err error) []string {
+	var pe pathError
+	if errors.As(err, &pe) {
+		return pe.path.Parts()
+	}
+	return []string{err.Error()}
+}
+
+// pathError is an interpolation error carrying the config path where it
+// occurred, so collected errors can be sorted by path.
+type pathError struct {
+	path tree.Path
+	err  error
+	msg  string
+}
+
+func (e pathError) Error() string { return e.msg }
+func (e pathError) Unwrap() error { return e.err }
 
 func newPathError(path tree.Path, err error) error {
 	var ite *template.InvalidTemplateError
@@ -147,11 +171,19 @@ func newPathError(path tree.Path, err error) error {
 	case err == nil:
 		return nil
 	case errors.As(err, &ite):
-		return fmt.Errorf(
-			"invalid interpolation format for %s.\nYou may need to escape any $ with another $.\n%s",
-			path, ite.Template)
+		return pathError{
+			path: path,
+			err:  err,
+			msg: fmt.Sprintf(
+				"invalid interpolation format for %s.\nYou may need to escape any $ with another $.\n%s",
+				path, ite.Template),
+		}
 	default:
-		return fmt.Errorf("error while interpolating %s: %w", path, err)
+		return pathError{
+			path: path,
+			err:  err,
+			msg:  fmt.Sprintf("error while interpolating %s: %s", path, err),
+		}
 	}
 }
 

--- a/interpolation/interpolation_test.go
+++ b/interpolation/interpolation_test.go
@@ -263,6 +263,29 @@ func TestInterpolateErrorsRemainUnwrappable(t *testing.T) {
 	assert.Check(t, is.Equal("MISSINGA", missing.Variable))
 }
 
+func TestInterpolateErrorsSortedByPath(t *testing.T) {
+	// Mixed error kinds: an invalid template at an early path and a missing
+	// required variable at a later one. Sorting by config path must report
+	// them in path order, not grouped by message kind, on every run whatever
+	// the map iteration order.
+	config := map[string]interface{}{
+		"service": map[string]interface{}{
+			"aaa": "${",
+			"zzz": "${MISSING:?required}",
+		},
+	}
+	expected := "invalid interpolation format for service.aaa.\nYou may need to escape any $ with another $.\n${\n" +
+		"error while interpolating service.zzz: required variable MISSING is missing a value: required"
+	for range 100 {
+		_, err := Interpolate(config, Options{LookupValue: defaultMapping})
+		assert.Error(t, err, expected)
+	}
+	// The pathError wrapper also makes the invalid-template error reachable.
+	_, err := Interpolate(config, Options{LookupValue: defaultMapping})
+	var ite *template.InvalidTemplateError
+	assert.Check(t, errors.As(err, &ite))
+}
+
 func TestPathMatches(t *testing.T) {
 	testcases := []struct {
 		doc      string

--- a/interpolation/interpolation_test.go
+++ b/interpolation/interpolation_test.go
@@ -17,10 +17,12 @@
 package interpolation
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"testing"
 
+	"github.com/compose-spec/compose-go/v2/template"
 	"github.com/compose-spec/compose-go/v2/tree"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -221,6 +223,44 @@ func TestInterpolateWithCast(t *testing.T) {
 		},
 	}
 	assert.Check(t, is.DeepEqual(expected, result))
+}
+
+func TestInterpolateReportsAllErrors(t *testing.T) {
+	config := map[string]interface{}{
+		"service": map[string]interface{}{
+			"environment": map[string]interface{}{
+				"TIMEZONE": "${TIMEZONE:?}",
+			},
+			"volumes": []interface{}{
+				map[string]interface{}{
+					"source": "${ACME_PATH:?}",
+				},
+			},
+		},
+	}
+	expected := "error while interpolating service.environment.TIMEZONE: required variable TIMEZONE is missing a value\n" +
+		"error while interpolating service.volumes.[].source: required variable ACME_PATH is missing a value"
+	// Go map iteration order is random, hence the repeats: sorting the
+	// collected errors must report them in the same order on every run.
+	for range 100 {
+		_, err := Interpolate(config, Options{LookupValue: defaultMapping})
+		assert.Error(t, err, expected)
+	}
+}
+
+func TestInterpolateErrorsRemainUnwrappable(t *testing.T) {
+	config := map[string]interface{}{
+		"service": map[string]interface{}{
+			"aaa": "${MISSINGA:?}",
+			"zzz": "${MISSINGZ:?}",
+		},
+	}
+	_, err := Interpolate(config, Options{LookupValue: defaultMapping})
+	// errors.As reports the first error of the joined list, which sorting
+	// pins to the one on the "aaa" key.
+	var missing *template.MissingRequiredError
+	assert.Assert(t, errors.As(err, &missing))
+	assert.Check(t, is.Equal("MISSINGA", missing.Variable))
 }
 
 func TestPathMatches(t *testing.T) {


### PR DESCRIPTION
Interpolation used to stop at the first error, and Go's random map iteration made a different missing required variable surface on each run. 
Collect every interpolation error while walking the whole config instead, and sort the collected errors by message before joining them, so both the reported set and its order are stable across runs and users can fix all missing variables at once. 
Sorting only happens on the error path, which keeps the successful-interpolation hot path allocation-identical to the previous behavior.

Fixes docker/compose#13712