### PR TITLE
Memoize include and extends.file loads within a single Load call

### DIFF
--- a/loader/extends.go
+++ b/loader/extends.go
@@ -91,6 +91,12 @@ func applyServiceExtends(ctx context.Context, name string, services map[string]a
 			return nil, err
 		}
 		filename = refFilename
+		// extends declared in the referenced file are not part of the config
+		// files passed to the loader: don't report events for them
+		if len(opts.Listeners) > 0 {
+			opts = opts.clone()
+			opts.Listeners = nil
+		}
 	} else {
 		_, ok := services[ref]
 		if !ok {
@@ -133,6 +139,32 @@ func applyServiceExtends(ctx context.Context, name string, services map[string]a
 	return merged, nil
 }
 
+type extendsCacheKey struct{}
+
+// extendsRef identifies an extends.file base within an extends cache scope.
+type extendsRef struct {
+	path       string
+	workingDir string
+}
+
+type extendsBase struct {
+	services  map[string]any
+	processor PostProcessor
+}
+
+// withExtendsCache attaches a fresh extends.file cache to ctx. The cache is
+// scoped to a single loadYamlModel call: within that scope interpolation
+// options and environment are fixed, so the resolved path and working
+// directory fully identify the loaded file.
+func withExtendsCache(ctx context.Context) context.Context {
+	return context.WithValue(ctx, extendsCacheKey{}, map[extendsRef]extendsBase{})
+}
+
+func extendsCache(ctx context.Context) map[extendsRef]extendsBase {
+	cache, _ := ctx.Value(extendsCacheKey{}).(map[extendsRef]extendsBase)
+	return cache
+}
+
 func getExtendsBaseFromFile(
 	ctx context.Context,
 	name, ref string,
@@ -148,36 +180,29 @@ func getExtendsBaseFromFile(
 		if err != nil {
 			return nil, nil, err
 		}
-		localdir := filepath.Dir(local)
 		relworkingdir := loader.Dir(refPath)
 
-		extendsOpts := opts.clone()
-		// replace localResourceLoader with a new flavour, using extended file base path
-		extendsOpts.ResourceLoaders = append(opts.RemoteResourceLoaders(), localResourceLoader{
-			WorkingDir: localdir,
-		})
-		extendsOpts.ResolvePaths = false // we do relative path resolution after file has been loaded
-		extendsOpts.SkipNormalization = true
-		extendsOpts.SkipConsistencyCheck = true
-		extendsOpts.SkipInclude = true
-		extendsOpts.SkipExtends = true    // we manage extends recursively based on raw service definition
-		extendsOpts.SkipValidation = true // we validate the merge result
-		extendsOpts.SkipDefaultValues = true
-		source, processor, err := loadYamlFile(ctx, types.ConfigFile{Filename: local},
-			extendsOpts, relworkingdir, nil, ct, map[string]any{}, nil)
-		if err != nil {
-			return nil, nil, err
+		cache := extendsCache(ctx)
+		cacheKey := extendsRef{path: local, workingDir: relworkingdir}
+		base, hit := cache[cacheKey]
+		if hit {
+			// hand out a copy: resolving an extends chain writes merged
+			// services back into this map (see applyServiceExtends)
+			base.services = deepClone(base.services).(map[string]any)
+		} else {
+			base, err = loadExtendsBase(ctx, name, local, relworkingdir, opts, ct)
+			if err != nil {
+				return nil, nil, err
+			}
+			if cache != nil {
+				cache[cacheKey] = extendsBase{
+					services:  deepClone(base.services).(map[string]any),
+					processor: base.processor,
+				}
+			}
 		}
-		m, ok := source["services"]
-		if !ok {
-			return nil, nil, fmt.Errorf("cannot extend service %q in %s: no services section", name, local)
-		}
-		services, ok := m.(map[string]any)
-		if !ok {
-			return nil, nil, fmt.Errorf("cannot extend service %q in %s: services must be a mapping", name, local)
-		}
-		_, ok = services[ref]
-		if !ok {
+
+		if _, ok := base.services[ref]; !ok {
 			return nil, nil, fmt.Errorf(
 				"cannot extend service %q in %s: service %q not found in %s",
 				name,
@@ -186,19 +211,48 @@ func getExtendsBaseFromFile(
 				refPath,
 			)
 		}
-
-		var remotes []paths.RemoteResource
-		for _, loader := range opts.RemoteResourceLoaders() {
-			remotes = append(remotes, loader.Accept)
-		}
-		err = paths.ResolveRelativePaths(source, relworkingdir, remotes)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		return services, processor, nil
+		return base.services, base.processor, nil
 	}
 	return nil, nil, fmt.Errorf("cannot read %s", refPath)
+}
+
+func loadExtendsBase(ctx context.Context, name, local, relworkingdir string, opts *Options, ct *cycleTracker) (extendsBase, error) {
+	extendsOpts := opts.clone()
+	// replace localResourceLoader with a new flavour, using extended file base path
+	extendsOpts.ResourceLoaders = append(opts.RemoteResourceLoaders(), localResourceLoader{
+		WorkingDir: filepath.Dir(local),
+	})
+	extendsOpts.ResolvePaths = false // we do relative path resolution after file has been loaded
+	extendsOpts.SkipNormalization = true
+	extendsOpts.SkipConsistencyCheck = true
+	extendsOpts.SkipInclude = true
+	extendsOpts.SkipExtends = true    // we manage extends recursively based on raw service definition
+	extendsOpts.SkipValidation = true // we validate the merge result
+	extendsOpts.SkipDefaultValues = true
+	source, processor, err := loadYamlFile(ctx, types.ConfigFile{Filename: local},
+		extendsOpts, relworkingdir, nil, ct, map[string]any{}, nil)
+	if err != nil {
+		return extendsBase{}, err
+	}
+	m, ok := source["services"]
+	if !ok {
+		return extendsBase{}, fmt.Errorf("cannot extend service %q in %s: no services section", name, local)
+	}
+	services, ok := m.(map[string]any)
+	if !ok {
+		return extendsBase{}, fmt.Errorf("cannot extend service %q in %s: services must be a mapping", name, local)
+	}
+
+	var remotes []paths.RemoteResource
+	for _, loader := range opts.RemoteResourceLoaders() {
+		remotes = append(remotes, loader.Accept)
+	}
+	err = paths.ResolveRelativePaths(source, relworkingdir, remotes)
+	if err != nil {
+		return extendsBase{}, err
+	}
+
+	return extendsBase{services: services, processor: processor}, nil
 }
 
 func deepClone(value any) any {

--- a/loader/extends_test.go
+++ b/loader/extends_test.go
@@ -75,7 +75,9 @@ services:
 	assert.DeepEqual(t, p.Services["test1"].Hostname, "test1")
 	assert.Equal(t, p.Services["test2"].Hostname, "test2")
 	assert.Equal(t, p.Services["test3"].Hostname, "test3")
-	assert.Equal(t, extendsCount, 4)
+	// only the extends declared in the config file passed to the loader are
+	// reported, not the one of service "another" inside base.yaml
+	assert.Equal(t, extendsCount, 3)
 }
 
 func TestExtendsPort(t *testing.T) {
@@ -329,7 +331,9 @@ services:
 	assert.NilError(t, err)
 	assert.Equal(t, svcB.Build.Context, tmpdir)
 
-	assert.Equal(t, extendsCount, 3)
+	// only the two extends declared in the root file are reported, not the one
+	// of service "service" inside sub/compose.yaml
+	assert.Equal(t, extendsCount, 2)
 }
 
 func TestExtendsWithServiceRef(t *testing.T) {
@@ -515,7 +519,9 @@ services:
 		}
 	})
 	assert.NilError(t, err)
-	assert.Equal(t, extendsCount, 2)
+	// only the extends declared in the root file is reported, not the one of
+	// service "b" inside sub/compose.yaml
+	assert.Equal(t, extendsCount, 1)
 }
 
 func TestExtendsReset(t *testing.T) {

--- a/loader/include.go
+++ b/loader/include.go
@@ -18,9 +18,12 @@ package loader
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/dotenv"
@@ -29,6 +32,47 @@ import (
 	"github.com/compose-spec/compose-go/v2/tree"
 	"github.com/compose-spec/compose-go/v2/types"
 )
+
+type includeCacheKey struct{}
+
+// withIncludeCache attaches a fresh include cache to ctx. The cache is scoped
+// to a single load so a file reachable through several include paths (a
+// "diamond" include graph) is parsed and expanded only once per distinct
+// (paths, directories, environment) tuple.
+func withIncludeCache(ctx context.Context) context.Context {
+	return context.WithValue(ctx, includeCacheKey{}, map[string]map[string]any{})
+}
+
+func includeCache(ctx context.Context) map[string]map[string]any {
+	cache, _ := ctx.Value(includeCacheKey{}).(map[string]map[string]any)
+	return cache
+}
+
+// includeModelKey covers every input that determines the model loaded for an
+// include: resolved paths, working directory, project directory and effective
+// environment. Interpolate.Substitute and TypeCastMapping are intentionally
+// excluded: they are invariant across includes within a single load. If a
+// future option allows them to vary per include, they must be folded into the
+// key. Fields are length-prefixed and collections count-prefixed so the byte
+// stream is uniquely decodable.
+func includeModelKey(paths types.StringList, workingDir, projectDir string, env types.Mapping) string {
+	h := sha256.New()
+	write := func(s string) {
+		fmt.Fprintf(h, "%d:%s", len(s), s)
+	}
+	fmt.Fprintf(h, "%d;", len(paths))
+	for _, p := range paths {
+		write(p)
+	}
+	write(workingDir)
+	write(projectDir)
+	fmt.Fprintf(h, "%d;", len(env))
+	for _, k := range slices.Sorted(maps.Keys(env)) {
+		write(k)
+		write(env[k])
+	}
+	return string(h.Sum(nil))
+}
 
 // loadIncludeConfig parse the required config from raw yaml
 func loadIncludeConfig(source any) ([]types.IncludeConfig, error) {
@@ -106,6 +150,9 @@ func ApplyInclude(ctx context.Context, workingDir string, environment types.Mapp
 		loadOptions.ResolvePaths = true
 		loadOptions.SkipNormalization = true
 		loadOptions.SkipConsistencyCheck = true
+		// include and extends events are only reported for declarations in the
+		// config files passed to the loader, not for those in included files
+		loadOptions.Listeners = nil
 		loadOptions.ResourceLoaders = append(loadOptions.RemoteResourceLoaders(), localResourceLoader{
 			WorkingDir: r.ProjectDirectory,
 		})
@@ -151,9 +198,22 @@ func ApplyInclude(ctx context.Context, workingDir string, environment types.Mapp
 			LookupValue:     config.LookupEnv,
 			TypeCastMapping: options.Interpolate.TypeCastMapping,
 		}
-		imported, err := loadYamlModel(ctx, config, loadOptions, &cycleTracker{}, included)
-		if err != nil {
-			return err
+		cache := includeCache(ctx)
+		cacheKey := includeModelKey(r.Path, relworkingdir, r.ProjectDirectory, config.Environment)
+		imported, hit := cache[cacheKey]
+		if hit {
+			// hand out a copy, the cached model must stay pristine
+			imported = deepClone(imported).(map[string]any)
+		} else {
+			imported, err = loadYamlModel(ctx, config, loadOptions, &cycleTracker{}, included)
+			if err != nil {
+				return err
+			}
+			if cache != nil {
+				// store a pristine copy: the model returned to the caller is
+				// merged into the parent and mutated by later loading phases
+				cache[cacheKey] = deepClone(imported).(map[string]any)
+			}
 		}
 		err = importResources(imported, model, processor)
 		if err != nil {

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -407,6 +407,10 @@ func loadYamlModel(ctx context.Context, config types.ConfigDetails, opts *Option
 	)
 	workingDir, environment := config.WorkingDir, config.Environment
 
+	// interpolation options and environment are fixed within this call, so
+	// extends.file bases can be shared by every service loaded from it
+	ctx = withExtendsCache(ctx)
+
 	for _, file := range config.ConfigFiles {
 		dict, _, err = loadYamlFile(ctx, file, opts, workingDir, environment, ct, dict, included)
 		if err != nil {
@@ -569,7 +573,7 @@ func load(ctx context.Context, configDetails types.ConfigDetails, opts *Options,
 		}
 	}
 
-	dict, err := loadYamlModel(ctx, configDetails, opts, &cycleTracker{}, nil)
+	dict, err := loadYamlModel(withIncludeCache(ctx), configDetails, opts, &cycleTracker{}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/loader/memoize_test.go
+++ b/loader/memoize_test.go
@@ -1,0 +1,353 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package loader
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"gotest.tools/v3/assert"
+)
+
+// writeDiamondInclude writes a doubling include graph of the given depth in dir:
+// level<i>.yaml includes level<i+1>.yaml twice, the last level only defines a
+// service. Without include memoization the leaf is expanded 2^depth times.
+func writeDiamondInclude(t testing.TB, dir string, depth int) {
+	t.Helper()
+	for i := 0; i < depth; i++ {
+		content := fmt.Sprintf(`
+include:
+  - path: level%[1]d.yaml
+  - path: level%[1]d.yaml
+services:
+  svc%[2]d:
+    image: busybox
+`, i+1, i)
+		assert.NilError(t, os.WriteFile(filepath.Join(dir, fmt.Sprintf("level%d.yaml", i)), []byte(content), 0o600))
+	}
+	leaf := `
+services:
+  leaf:
+    image: busybox
+`
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, fmt.Sprintf("level%d.yaml", depth)), []byte(leaf), 0o600))
+}
+
+// TestIncludeDiamondDedup guards the include memoization: a depth-24 doubling
+// include graph would require 2^24 leaf expansions without it and cannot
+// complete within the timeout.
+func TestIncludeDiamondDedup(t *testing.T) {
+	dir := t.TempDir()
+	writeDiamondInclude(t, dir, 24)
+
+	type result struct {
+		p   *types.Project
+		err error
+	}
+	// The loader does not observe ctx.Done() today, so the timeout is consumed
+	// by the select below, not by LoadWithContext.
+	timer := time.NewTimer(20 * time.Second)
+	defer timer.Stop()
+
+	done := make(chan result, 1)
+	go func() {
+		p, err := LoadWithContext(context.Background(), types.ConfigDetails{
+			WorkingDir:  dir,
+			ConfigFiles: []types.ConfigFile{{Filename: filepath.Join(dir, "level0.yaml")}},
+		}, func(options *Options) {
+			options.SetProjectName("diamond", true)
+			options.SkipConsistencyCheck = true
+			// Compose always registers a listener; make sure memoization stays
+			// effective with one registered.
+			options.Listeners = []Listener{func(string, map[string]any) {}}
+		})
+		done <- result{p, err}
+	}()
+
+	select {
+	case r := <-done:
+		assert.NilError(t, r.err)
+		_, err := r.p.GetService("leaf")
+		assert.NilError(t, err)
+		_, err = r.p.GetService("svc23")
+		assert.NilError(t, err)
+	case <-timer.C:
+		t.Fatal("diamond include did not complete within 20s — include memoization likely not working")
+	}
+}
+
+// TestIncludeListenerTopLevelOnly pins the Listener contract: include/extends
+// events are only emitted for declarations in the config files passed to the
+// loader, not for ones inside included files.
+func TestIncludeListenerTopLevelOnly(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"compose.yaml": `
+name: top-level-listener
+include:
+  - path: child-a.yaml
+  - path: child-b.yaml
+services:
+  app:
+    image: app
+    extends: base
+  base:
+    image: busybox
+`,
+		"child-a.yaml": `
+include:
+  - path: shared.yaml
+services:
+  child-a-svc:
+    image: busybox
+    extends: child-a-base
+  child-a-base:
+    image: alpine
+`,
+		"child-b.yaml": `
+include:
+  - path: shared.yaml
+services:
+  child-b-svc:
+    image: busybox
+`,
+		"shared.yaml": `
+services:
+  shared:
+    image: shared
+`,
+	}
+	for name, content := range files {
+		assert.NilError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+	}
+
+	includeCount, extendsCount := 0, 0
+	p, err := LoadWithContext(context.Background(), types.ConfigDetails{
+		WorkingDir:  dir,
+		ConfigFiles: []types.ConfigFile{{Filename: filepath.Join(dir, "compose.yaml")}},
+	}, func(options *Options) {
+		options.SkipConsistencyCheck = true
+		options.Listeners = []Listener{
+			func(event string, _ map[string]any) {
+				switch event {
+				case "include":
+					includeCount++
+				case "extends":
+					extendsCount++
+				}
+			},
+		}
+	})
+	assert.NilError(t, err)
+
+	for _, name := range []string{"app", "base", "child-a-svc", "child-a-base", "child-b-svc", "shared"} {
+		_, err := p.GetService(name)
+		assert.NilError(t, err)
+	}
+	// only the two include declarations of compose.yaml, not the nested ones
+	assert.Equal(t, includeCount, 2)
+	// only app's extends, not child-a-svc's
+	assert.Equal(t, extendsCount, 1)
+}
+
+// TestIncludeSameFileDistinctEnv guards the include cache key: the same file
+// included twice with different env_file values must not share a memoized
+// model. Distinct label keys are derived from the environment so both
+// expansions stay observable after the conflict merge.
+func TestIncludeSameFileDistinctEnv(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"compose.yaml": `
+name: include-env-isolation
+include:
+  - path: shared.yaml
+    env_file: a.env
+  - path: shared.yaml
+    env_file: b.env
+`,
+		"shared.yaml": `
+services:
+  shared:
+    image: busybox
+    labels:
+      - tag-${TAG:-def}=1
+`,
+		"a.env": "TAG=a\n",
+		"b.env": "TAG=b\n",
+	}
+	for name, content := range files {
+		assert.NilError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+	}
+
+	p, err := LoadWithContext(context.Background(), types.ConfigDetails{
+		WorkingDir:  dir,
+		ConfigFiles: []types.ConfigFile{{Filename: filepath.Join(dir, "compose.yaml")}},
+	}, func(options *Options) {
+		options.SkipConsistencyCheck = true
+	})
+	assert.NilError(t, err)
+
+	shared, err := p.GetService("shared")
+	assert.NilError(t, err)
+	assert.Equal(t, shared.Labels["tag-a"], "1")
+	assert.Equal(t, shared.Labels["tag-b"], "1")
+}
+
+// TestExtendsFileNameCollision guards the extends.file cache against sharing a
+// mutable services map: resolving service web (same name as its base in
+// base.yaml) writes the merged result back into the base services map, which
+// must not leak into the other services extending the same base.
+func TestExtendsFileNameCollision(t *testing.T) {
+	dir := t.TempDir()
+	base := `
+services:
+  web:
+    image: base
+`
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "base.yaml"), []byte(base), 0o600))
+
+	root := `
+name: extends-collision
+services:
+  web:
+    extends:
+      file: base.yaml
+      service: web
+    environment:
+      - POLLUTED=1
+`
+	for i := 2; i <= 5; i++ {
+		root += fmt.Sprintf(`
+  web%d:
+    extends:
+      file: base.yaml
+      service: web
+`, i)
+	}
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "compose.yaml"), []byte(root), 0o600))
+
+	p, err := LoadWithContext(context.Background(), types.ConfigDetails{
+		WorkingDir:  dir,
+		ConfigFiles: []types.ConfigFile{{Filename: filepath.Join(dir, "compose.yaml")}},
+	}, func(options *Options) {
+		options.SkipConsistencyCheck = true
+	})
+	assert.NilError(t, err)
+
+	web, err := p.GetService("web")
+	assert.NilError(t, err)
+	assert.Check(t, web.Environment["POLLUTED"] != nil)
+	for i := 2; i <= 5; i++ {
+		svc, err := p.GetService(fmt.Sprintf("web%d", i))
+		assert.NilError(t, err)
+		assert.Equal(t, svc.Image, "base")
+		_, polluted := svc.Environment["POLLUTED"]
+		assert.Check(t, !polluted, "web%d inherited environment from the extending service web", i)
+	}
+}
+
+// TestExtendsCacheServesIsolatedCopies deterministically checks that a cache
+// hit returns a services map that is not aliased to the stored entry.
+func TestExtendsCacheServesIsolatedCopies(t *testing.T) {
+	dir := t.TempDir()
+	base := `
+services:
+  base:
+    image: busybox
+`
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "base.yaml"), []byte(base), 0o600))
+
+	ctx := withExtendsCache(context.Background())
+	opts := &Options{
+		SkipInterpolation: true,
+		ResourceLoaders:   []ResourceLoader{localResourceLoader{WorkingDir: dir}},
+	}
+	first, _, err := getExtendsBaseFromFile(ctx, "svc", "base", "compose.yaml", "base.yaml", opts, &cycleTracker{})
+	assert.NilError(t, err)
+	second, _, err := getExtendsBaseFromFile(ctx, "svc", "base", "compose.yaml", "base.yaml", opts, &cycleTracker{})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, first, second)
+
+	// simulate the write-back done by applyServiceExtends on the first copy
+	first["base"].(map[string]any)["image"] = "mutated"
+	assert.Equal(t, second["base"].(map[string]any)["image"], "busybox")
+
+	third, _, err := getExtendsBaseFromFile(ctx, "svc", "base", "compose.yaml", "base.yaml", opts, &cycleTracker{})
+	assert.NilError(t, err)
+	assert.Equal(t, third["base"].(map[string]any)["image"], "busybox")
+}
+
+func BenchmarkIncludeDiamond(b *testing.B) {
+	dir := b.TempDir()
+	writeDiamondInclude(b, dir, 16)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, err := LoadWithContext(context.Background(), types.ConfigDetails{
+			WorkingDir:  dir,
+			ConfigFiles: []types.ConfigFile{{Filename: filepath.Join(dir, "level0.yaml")}},
+		}, func(options *Options) {
+			options.SetProjectName("diamond", true)
+			options.SkipConsistencyCheck = true
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkExtendsFile(b *testing.B) {
+	dir := b.TempDir()
+	base := `
+services:
+  base:
+    image: busybox
+    environment:
+      - FOO=bar
+`
+	if err := os.WriteFile(filepath.Join(dir, "base.yaml"), []byte(base), 0o600); err != nil {
+		b.Fatal(err)
+	}
+	root := "name: extends-bench\nservices:"
+	for i := 0; i < 40; i++ {
+		root += fmt.Sprintf(`
+  svc%d:
+    extends:
+      file: base.yaml
+      service: base
+`, i)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "compose.yaml"), []byte(root), 0o600); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, err := LoadWithContext(context.Background(), types.ConfigDetails{
+			WorkingDir:  dir,
+			ConfigFiles: []types.ConfigFile{{Filename: filepath.Join(dir, "compose.yaml")}},
+		}, func(options *Options) {
+			options.SkipConsistencyCheck = true
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`ApplyInclude` re-parses and recursively re-expands an included file once per
include path that reaches it. When the same file is reachable through more
than one path (a "diamond" include graph), this is exponential: a depth-24
doubling graph loads the leaf 2²⁴ ≈ 16.7M times. Similarly, an `extends.file`
base is fully re-loaded (read, parse, interpolate, path-resolve) once per
extending service: 50 services extending `common.yaml` parse it 50 times.

This is the same problem as #886, which showed a real-world ~80-service
monorepo federation taking ~55s in `docker compose config`.

## Why not #886's approach

#886 memoizes includes while preserving the Listener contract "one event per
occurrence" by recording and replaying listener events on cache hits. As
noted in review, Docker Compose always registers a listener, so the replay
path is the production path — and event replay is itself exponential:
`3·(2^depth−1)` events on a doubling graph, measured at ~1.8GB peak heap at
depth 20 on that branch. The memoization would never be effective in practice.

## Fix

1. **Listener contract change**: `include`/`extends` events are only emitted
   for declarations in the config files passed to the loader, not for
   declarations inside included or extended files. This relaxation is backed
   by a product decision: for usage metrics, only the `include`/`extends`
   usage declared in the user's own config files needs to be accounted for —
   there is no requirement to track occurrences discovered recursively while
   expanding them. The only known consumer of these events is Docker
   Compose's telemetry counters, whose current per-occurrence counts are
   already inflated non-deterministically by diamond re-expansion. Resource
   metrics (services, networks, …) are computed from the final merged project
   and are unaffected.
2. **Include memoization**, per `Load` call, carried by the context. The key
   covers every input that determines the model: resolved paths, working
   directory, project directory and effective environment (length-prefixed
   SHA-256). A pristine deep copy is stored; every consumer gets its own copy.
3. **`extends.file` memoization**, scoped per `loadYamlModel` call (fixed
   interpolation/environment within that scope), keyed by resolved path +
   working directory. Services are deep-copied per consumer because resolving
   an extends chain writes merged services back into the base map.

Cycle detection is unaffected: both checks run before any cache lookup, and
only successfully-expanded (cycle-free) subtrees are ever cached.

## Benchmarks

CPU:

| scenario | before | after |
|---|---|---|
| diamond include, depth 10 | 235.5 ms | 3.8 ms |
| diamond include, depth 24 (+ listener) | timeout (2²⁴ loads) | 0.03 s |
| 40 services × `extends.file` same base | 9.2 ms | 5.5 ms |

Memory (total allocated during load):

| scenario | before | after |
|---|---|---|
| diamond include, depth 10 | 161.8 MB | 8.6 MB |
| worst case: 60 distinct includes × 8 services, zero cache hits | 174.5 MB | 174.9 MB (+0.2%) |

Both caches live only as context values on the load call stack: they are
released as soon as `Load` returns (post-GC retained heap measured identical
to main in all scenarios). Worst-case retention during a load is linear in
unique included content, bounded by the size of the final model — never
per-occurrence.

## Tests

- `TestIncludeDiamondDedup`: depth-24 diamond with a registered listener,
  guarded by a 20s timer — fails fast if memoization regresses.
- `TestIncludeListenerTopLevelOnly`, updated `extends_test.go` expectations:
  pin the new listener contract.
- `TestIncludeSameFileDistinctEnv`: same file included twice with different
  `env_file` must not share a cache entry.
- `TestExtendsFileNameCollision`, `TestExtendsCacheServesIsolatedCopies`:
  guard cache-entry isolation against the extends write-back.
- `BenchmarkIncludeDiamond`, `BenchmarkExtendsFile`.

Closes #886 — credit to @bonitao for the diagnosis and the diamond
regression-test approach, both reused here.
