### PR TITLE
loader: skip re-merge of identical resources imported through diamond includes

### DIFF
--- a/loader/include.go
+++ b/loader/include.go
@@ -23,6 +23,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -260,6 +261,12 @@ func importResource(source map[string]any, target map[string]any, key string, pr
 			conflict, ok := to[name]
 			if !ok {
 				to[name] = a
+				continue
+			}
+			if reflect.DeepEqual(a, conflict) {
+				// Same resource reached through multiple include paths (a
+				// diamond); re-merging identical definitions would append
+				// duplicate entries to list-valued fields.
 				continue
 			}
 			err := processor.Apply(map[string]any{

--- a/loader/include_test.go
+++ b/loader/include_test.go
@@ -66,6 +66,32 @@ services:
 	assert.Equal(t, imported.ContainerName, "override")
 }
 
+func TestLoadWithDiamondInclude(t *testing.T) {
+	// the same file reached through multiple include paths must merge
+	// idempotently — re-merging identical definitions duplicated entries in
+	// list-valued extension fields
+	details := buildConfigDetails(`
+name: 'test-diamond-include'
+
+include:
+  - path: ./testdata/include-diamond-left.yaml
+  - path: ./testdata/include-diamond-right.yaml
+`, nil)
+
+	p, err := LoadWithContext(context.TODO(), details, func(options *Options) {
+		options.SkipNormalization = true
+		options.ResolvePaths = true
+	})
+	assert.NilError(t, err)
+	diamond, err := p.GetService("diamond")
+	assert.NilError(t, err)
+	xbake, ok := diamond.Build.Extensions["x-bake"].(map[string]any)
+	assert.Assert(t, ok)
+	cacheFrom, ok := xbake["cache-from"].([]any)
+	assert.Assert(t, ok)
+	assert.Equal(t, len(cacheFrom), 1)
+}
+
 func TestLoadWithMultipleIncludeConflict(t *testing.T) {
 	// include 2 different services with same name should trigger an error
 	details := buildConfigDetails(`

--- a/loader/testdata/include-diamond-base.yaml
+++ b/loader/testdata/include-diamond-base.yaml
@@ -1,0 +1,8 @@
+services:
+  diamond:
+    image: busybox
+    build:
+      context: .
+      x-bake:
+        cache-from:
+          - type=registry,ref=example/cache:a

--- a/loader/testdata/include-diamond-left.yaml
+++ b/loader/testdata/include-diamond-left.yaml
@@ -1,0 +1,2 @@
+include:
+  - ./include-diamond-base.yaml

--- a/loader/testdata/include-diamond-right.yaml
+++ b/loader/testdata/include-diamond-right.yaml
@@ -1,0 +1,2 @@
+include:
+  - ./include-diamond-base.yaml


### PR DESCRIPTION
### What I did

Restored the identical-resource fast path in `importResource` that #835 removed: when a resource re-imported through another include path is deeply equal to the already-imported definition, skip the merge. Genuinely different definitions keep the #835 override-merge behavior. Added a regression test with a diamond include fixture.

### Why

Since #835, a file reached through multiple `include:` paths (a diamond) is re-merged once per path, and list-valued extension fields get their entries appended per re-merge — a service included through N paths ends with N copies of every `x-*` list entry:

```yaml
# base.yaml
services:
  shared:
    image: busybox
    build:
      context: .
      x-bake:
        cache-from:
          - type=registry,ref=example/cache:a
# left.yaml / right.yaml:   include: [./base.yaml]
# compose.yaml:             include: [./left.yaml, ./right.yaml]
```

`docker compose config | grep -c 'example/cache:a'` → **1** on CLI v2.40.3 (compose-go v2.9.1), **2** on v5.0.0+/v2.10.0+; each additional include path adds another copy. Bisected to 3d3411d9 (#835). Spec-schema fields are unaffected (normalized downstream), which is why this went unnoticed.

Real-world impact: a monorepo integration-test tree with ~60 include paths to shared services saw its resolved `config` output grow from 2,043 to 127,725 cache entries (1.1 MB → 21 MB), and resolved output became dependent on which Docker Desktop version a developer runs.

### Testing

- New `TestLoadWithDiamondInclude` fails on master (`2 != 1`) and passes with the fix.
- `go test ./loader/ ./override/` pass.
