### PR TITLE
fix(override): merge ulimits into the base value

### DIFF
--- a/override/merge.go
+++ b/override/merge.go
@@ -224,9 +224,9 @@ func convertIntoSequence(value any) []any {
 	return nil
 }
 
-func mergeUlimit(_ any, o any, p tree.Path) (any, error) {
+func mergeUlimit(c any, o any, p tree.Path) (any, error) {
 	over, ismapping := o.(map[string]any)
-	if base, ok := o.(map[string]any); ok && ismapping {
+	if base, ok := c.(map[string]any); ok && ismapping {
 		return mergeMappings(base, over, p)
 	}
 	return o, nil

--- a/override/merge_ulimits_test.go
+++ b/override/merge_ulimits_test.go
@@ -53,9 +53,10 @@ services:
       nofile: 
           soft: 10000
           hard: 40000
-      nproc: 
+      nproc:
           soft: 65535
       locks:
+          soft: 20000
           hard: 65535
 `)
 }


### PR DESCRIPTION
Set one ulimit key in the base file and a different one in the override, and the base key disappears:

```yaml
# base                # override
ulimits:              ulimits:
  locks:                locks:
    soft: 20000           hard: 65535
    hard: 40000

# got                 # want
locks:                locks:
  hard: 65535           soft: 20000
                        hard: 65535
```

`mergeUlimit` receives the base value and the override value, but it reads both mappings out of the override:

```go
func mergeUlimit(_ any, o any, p tree.Path) (any, error) {
	over, ismapping := o.(map[string]any)
	if base, ok := o.(map[string]any); ok && ismapping {
		return mergeMappings(base, over, p)
```

So it merges the override with itself. The base argument is named `_` and never read. Every other function in `mergeSpecials` takes its first argument as the base, this one is the exception.

`Test_mergeYamlUlimits` already covered the case, but its expectation encoded the old behaviour, so it is updated to expect the base `soft` to survive. Reverting `merge.go` alone makes it fail. Full suite is green
