### PR TITLE
fix(types): name the clashing service and make the error stable

### DIFF
--- a/loader/validate_test.go
+++ b/loader/validate_test.go
@@ -277,7 +277,7 @@ func TestValidateContainerName(t *testing.T) {
 		},
 	}
 	err := project.CheckContainerNameUnicity()
-	assert.Assert(t, strings.Contains(err.Error(), `container name "mycontainer" is already in use by`))
+	assert.Assert(t, strings.Contains(err.Error(), `container name "mycontainer" is already in use by service "myservice`))
 }
 
 func TestValidateWatch(t *testing.T) {

--- a/types/project.go
+++ b/types/project.go
@@ -905,13 +905,14 @@ func (p *Project) WithServicesTransform(fn func(name string, s ServiceConfig) (S
 
 // CheckContainerNameUnicity validate project doesn't have services declaring the same container_name
 func (p *Project) CheckContainerNameUnicity() error {
-	names := utils.Set[string]{}
-	for name, s := range p.Services {
+	names := map[string]string{}
+	for _, name := range p.ServiceNames() {
+		s := p.Services[name]
 		if s.ContainerName != "" {
 			if existing, ok := names[s.ContainerName]; ok {
-				return fmt.Errorf(`services.%s: container name %q is already in use by service %s"`, name, s.ContainerName, existing)
+				return fmt.Errorf(`services.%s: container name %q is already in use by service %q`, name, s.ContainerName, existing)
 			}
-			names.Add(s.ContainerName)
+			names[s.ContainerName] = name
 		}
 	}
 	return nil


### PR DESCRIPTION
## Problem

When two services declare the same `container_name`, the error names neither
the conflicting service nor anything actionable:

```
services.a: container name "shared" is already in use by service {}"
```

Two defects in one line:

1. **`{}` instead of the other service's name.**
2. **A stray unbalanced `"`** at the end.

And a third, related issue: **the message is not deterministic.** The same
project reports a different service on each run.

## Reproduce

```yaml
services:
  a:
    image: alpine
    container_name: shared
  b:
    image: alpine
    container_name: shared
```

`docker compose config`, six consecutive runs, no changes in between:

```
services.a: container name "shared" is already in use by service {}"
services.a: container name "shared" is already in use by service {}"
services.a: container name "shared" is already in use by service {}"
services.b: container name "shared" is already in use by service {}"
services.b: container name "shared" is already in use by service {}"
services.a: container name "shared" is already in use by service {}"
```

Docker Compose v5.1.3 (vendoring compose-go v2.10.2). Reproduces on `main`.

## Cause

[`types/project.go`](https://github.com/compose-spec/compose-go/blob/main/types/project.go#L1077-L1087):

```go
names := utils.Set[string]{}
for name, s := range p.Services {
    if s.ContainerName != "" {
        if existing, ok := names[s.ContainerName]; ok {
            return fmt.Errorf(`services.%s: container name %q is already in use by service %s"`, name, s.ContainerName, existing)
        }
        names.Add(s.ContainerName)
    }
}
```

[`utils/set.go`](https://github.com/compose-spec/compose-go/blob/main/utils/set.go#L23):

```go
type Set[T comparable] map[T]struct{}
```

`existing` is the map **value** — `struct{}{}` — not the service that claimed
the name, and `%s` renders an empty struct as `{}`. A `Set` structurally cannot
carry the owning service, so this never worked. The trailing `"` looks like a
leftover from `"%s"` that lost its opening quote.

The non-determinism comes from `range p.Services`: Go randomises map iteration,
so which service is recorded first, and therefore which is reported as the
offender, varies per run.

## Change

- Track `container_name -> declaring service` in a `map[string]string` so the
  conflicting service can be named.
- Print it with `%q`, which supplies the quotes and drops the stray one.
- Iterate via `ServiceNames()` (already in this file, returns sorted names) so
  the reported pair is stable.

After:

```
services.b: container name "shared" is already in use by service "a"
```

## Tests

The existing assertion stopped one word before the broken segment:

```go
assert.Assert(t, strings.Contains(err.Error(), `container name "mycontainer" is already in use by`))
```

so everything after `is already in use by` was unverified — which is how both
defects survived. It now asserts the full message, which the stable ordering
makes possible.

## Notes

- No API change. `CheckContainerNameUnicity`'s signature and error semantics are
  unchanged; only the message text and its stability.
- The determinism half mirrors
  [`fix(interpolation): report all errors in a deterministic order`](https://github.com/compose-spec/compose-go/commit/42e84bc) —
  same root cause (randomised map iteration producing a different message per
  run). Happy to split this into two commits if you'd prefer them reviewed
  separately.
