### PR TITLE
cli: validate COMPOSE_FILE entries point to actual compose files

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -83,6 +84,12 @@ type ProjectOptions struct {
 	Listeners []loader.Listener
 	// ResourceLoaders manages support for remote resources
 	ResourceLoaders []loader.ResourceLoader
+
+	// configOrigin describes how ConfigPaths entries were selected when they
+	// don't result from an explicit user selection (COMPOSE_FILE environment
+	// variable, default file discovery), keyed by the value stored in
+	// ConfigPaths. Used to give context in configuration load errors.
+	configOrigin map[string]string
 }
 
 type ProjectOptionsFn func(*ProjectOptions) error
@@ -144,11 +151,62 @@ func WithConfigFileEnv(o *ProjectOptions) error {
 	}
 	f, ok := o.Environment[consts.ComposeFilePath]
 	if ok {
-		paths, err := absolutePaths(strings.Split(f, sep))
-		o.ConfigPaths = paths
-		return err
+		const origin = "set by COMPOSE_FILE environment variable"
+		for _, entry := range strings.Split(f, sep) {
+			path, err := o.acceptComposeFile(entry)
+			if err != nil {
+				return fmt.Errorf("compose file %q %s is invalid: %w", entry, origin, err)
+			}
+			o.ConfigPaths = append(o.ConfigPaths, path)
+			o.setConfigOrigin(path, origin)
+		}
 	}
 	return nil
+}
+
+// acceptComposeFile checks a compose file reference is usable: either stdin
+// ("-"), a remote resource supported by a registered ResourceLoader, or a
+// local path pointing to a regular file. Local paths are resolved to absolute.
+func (o *ProjectOptions) acceptComposeFile(path string) (string, error) {
+	if path == "-" {
+		return path, nil
+	}
+	for _, r := range o.ResourceLoaders {
+		if r.Accept(path) {
+			return path, nil
+		}
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	fi, err := os.Stat(abs)
+	if err != nil {
+		return "", err
+	}
+	if fi.IsDir() {
+		return "", fmt.Errorf("%s is a directory", abs)
+	}
+	if !fi.Mode().IsRegular() {
+		return "", fmt.Errorf("%s is not a regular file", abs)
+	}
+	return abs, nil
+}
+
+func (o *ProjectOptions) setConfigOrigin(path, origin string) {
+	if o.configOrigin == nil {
+		o.configOrigin = map[string]string{}
+	}
+	o.configOrigin[path] = origin
+}
+
+// configFileError decorates a compose file load error with the way the file
+// was selected, when this selection wasn't an explicit user choice.
+func (o *ProjectOptions) configFileError(filename string, err error) error {
+	if origin, ok := o.configOrigin[filename]; ok {
+		return fmt.Errorf("compose file %q %s is invalid: %w", filename, origin, err)
+	}
+	return fmt.Errorf("compose file %q is invalid: %w", filename, err)
 }
 
 // WithDefaultConfigPath searches for default config files from working directory
@@ -168,7 +226,9 @@ func WithDefaultConfigPath(o *ProjectOptions) error {
 				logrus.Warnf("Found multiple config files with supported names: %s", strings.Join(candidates, ", "))
 				logrus.Warnf("Using %s", winner)
 			}
+			const origin = "found by default file discovery"
 			o.ConfigPaths = append(o.ConfigPaths, winner)
+			o.setConfigOrigin(winner, origin)
 
 			overrides := findFiles(DefaultOverrideFileNames, pwd)
 			if len(overrides) > 0 {
@@ -177,6 +237,7 @@ func WithDefaultConfigPath(o *ProjectOptions) error {
 					logrus.Warnf("Using %s", overrides[0])
 				}
 				o.ConfigPaths = append(o.ConfigPaths, overrides[0])
+				o.setConfigOrigin(overrides[0], origin)
 			}
 			return nil
 		}
@@ -471,7 +532,12 @@ func (o *ProjectOptions) ReadConfigFiles(ctx context.Context, workingDir string,
 			}
 			b, err = os.ReadFile(f)
 			if err != nil {
-				return nil, err
+				// the raw read error on a directory is OS-specific and cryptic
+				// ("is a directory", "Incorrect function.", ...)
+				if fi, statErr := os.Stat(f); statErr == nil && fi.IsDir() {
+					err = fmt.Errorf("%s is a directory", f)
+				}
+				return nil, options.configFileError(c.Filename, err)
 			}
 		}
 		configs[i] = b
@@ -604,24 +670,4 @@ func findFiles(names []string, pwd string) []string {
 		}
 	}
 	return candidates
-}
-
-func absolutePaths(p []string) ([]string, error) {
-	var paths []string
-	for _, f := range p {
-		if f == "-" {
-			paths = append(paths, f)
-			continue
-		}
-		abs, err := filepath.Abs(f)
-		if err != nil {
-			return nil, err
-		}
-		f = abs
-		if _, err := os.Stat(f); err != nil {
-			return nil, err
-		}
-		paths = append(paths, f)
-	}
-	return paths, nil
 }

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/types"
@@ -427,4 +428,100 @@ func TestEnvFilesDefaultUnreadableWorkingDir(t *testing.T) {
 		WithWorkingDirectory(locked),
 		WithEnvFiles(filepath.Join(locked, ".env")), WithDotEnv)
 	assert.ErrorContains(t, err, "permission denied")
+}
+
+type stubRemoteLoader struct {
+	prefix string
+}
+
+func (l stubRemoteLoader) Accept(path string) bool {
+	return strings.HasPrefix(path, l.prefix)
+}
+
+func (l stubRemoteLoader) Load(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
+func (l stubRemoteLoader) Dir(_ string) string {
+	return ""
+}
+
+func TestWithConfigFileEnvValidation(t *testing.T) {
+	t.Run("empty entry resolves to working directory", func(t *testing.T) {
+		_, err := NewProjectOptions(nil,
+			WithEnv([]string{"COMPOSE_FILE="}),
+			WithConfigFileEnv)
+		assert.ErrorContains(t, err, `compose file "" set by COMPOSE_FILE environment variable is invalid`)
+		assert.ErrorContains(t, err, "is a directory")
+	})
+
+	t.Run("entry is a directory", func(t *testing.T) {
+		dir := t.TempDir()
+		_, err := NewProjectOptions(nil,
+			WithEnv([]string{"COMPOSE_FILE=" + dir}),
+			WithConfigFileEnv)
+		assert.ErrorContains(t, err, fmt.Sprintf("compose file %q set by COMPOSE_FILE environment variable is invalid", dir))
+		assert.ErrorContains(t, err, "is a directory")
+	})
+
+	t.Run("entry does not exist", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "missing.yaml")
+		_, err := NewProjectOptions(nil,
+			WithEnv([]string{"COMPOSE_FILE=" + missing}),
+			WithConfigFileEnv)
+		assert.ErrorContains(t, err, fmt.Sprintf("compose file %q set by COMPOSE_FILE environment variable is invalid", missing))
+	})
+
+	t.Run("empty entry within a list", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "compose.yaml")
+		assert.NilError(t, os.WriteFile(file, []byte("services: {}"), 0o600))
+		_, err := NewProjectOptions(nil,
+			WithEnv([]string{"COMPOSE_FILE=" + file + string(os.PathListSeparator)}),
+			WithConfigFileEnv)
+		assert.ErrorContains(t, err, `compose file "" set by COMPOSE_FILE environment variable is invalid`)
+	})
+
+	t.Run("valid entries", func(t *testing.T) {
+		dir := t.TempDir()
+		file := filepath.Join(dir, "compose.yaml")
+		override := filepath.Join(dir, "override.yaml")
+		assert.NilError(t, os.WriteFile(file, []byte("services: {}"), 0o600))
+		assert.NilError(t, os.WriteFile(override, []byte("services: {}"), 0o600))
+		opts, err := NewProjectOptions(nil,
+			WithEnv([]string{"COMPOSE_FILE=" + file + string(os.PathListSeparator) + override}),
+			WithConfigFileEnv)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, opts.ConfigPaths, []string{file, override})
+	})
+
+	t.Run("stdin entry", func(t *testing.T) {
+		opts, err := NewProjectOptions(nil,
+			WithEnv([]string{"COMPOSE_FILE=-"}),
+			WithConfigFileEnv)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, opts.ConfigPaths, []string{"-"})
+	})
+
+	t.Run("remote entry is not checked as a local file", func(t *testing.T) {
+		opts, err := NewProjectOptions(nil,
+			WithResourceLoader(stubRemoteLoader{prefix: "oci://"}),
+			// the default ":" separator conflicts with remote references, so
+			// using them in COMPOSE_FILE requires an explicit COMPOSE_PATH_SEPARATOR
+			WithEnv([]string{
+				"COMPOSE_PATH_SEPARATOR=;",
+				"COMPOSE_FILE=oci://example.org/compose:latest",
+			}),
+			WithConfigFileEnv)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, opts.ConfigPaths, []string{"oci://example.org/compose:latest"})
+	})
+}
+
+func TestConfigPathIsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	opts, err := NewProjectOptions([]string{dir})
+	assert.NilError(t, err)
+	_, err = ProjectFromOptions(context.TODO(), opts)
+	assert.ErrorContains(t, err, fmt.Sprintf("compose file %q is invalid", dir))
+	assert.ErrorContains(t, err, "is a directory")
 }


### PR DESCRIPTION
Entries set by the `COMPOSE_FILE` environment variable used to be resolved to absolute paths with a bare `os.Stat`, so an empty or directory entry made the loader fail later with a cryptic OS-level error such as `read <pwd>: is a directory` (an empty entry resolves to the working directory — see docker/compose#13649).

Each entry is now validated when selected: it must be stdin (`-`), a remote resource supported by a registered `ResourceLoader`, or a regular local file. Errors state how the file was selected:

```
compose file "" set by COMPOSE_FILE environment variable is invalid: /home/user is a directory
```

Implicitly selected config paths (`COMPOSE_FILE`, default file discovery) are tracked so read errors get the same context, while explicitly selected files (`-f`) keep a plain `compose file X is invalid` prefix.

Side effect: remote resource references in `COMPOSE_FILE` are no longer rejected by the local `os.Stat` check (they still require an explicit `COMPOSE_PATH_SEPARATOR`, as the default `:` conflicts with remote references).

---
*This contribution was prepared by an AI agent acting on the maintainer's behalf, then reviewed by them.*