### PR TITLE
fix: merge attributes of repeated variable occurrences in ExtractVariables

### DIFF
--- a/template/variables.go
+++ b/template/variables.go
@@ -44,27 +44,50 @@ func recurseExtract(value interface{}, pattern *regexp.Regexp) map[string]Variab
 	case string:
 		if values, is := extractVariable(value, pattern); is {
 			for _, v := range values {
-				m[v.Name] = v
+				combineVariable(m, v)
 			}
 		}
 	case map[string]interface{}:
 		for _, elem := range value {
 			submap := recurseExtract(elem, pattern)
-			for key, value := range submap {
-				m[key] = value
+			for _, value := range submap {
+				combineVariable(m, value)
 			}
 		}
 
 	case []interface{}:
 		for _, elem := range value {
 			submap := recurseExtract(elem, pattern)
-			for key, value := range submap {
-				m[key] = value
+			for _, value := range submap {
+				combineVariable(m, value)
 			}
 		}
 	}
 
 	return m
+}
+
+// combineVariable merges a new occurrence of a variable into m: a variable
+// used several times in the configuration is required as soon as one of its
+// occurrences is (interpolation of that occurrence fails when the variable is
+// unset, whatever the other occurrences declare), and keeps the default and
+// presence values of the first occurrence defining one, so a plain `${VAR}`
+// occurrence doesn't erase the attributes of a `${VAR:?}` or `${VAR:-value}`
+// one.
+func combineVariable(m map[string]Variable, v Variable) {
+	existing, ok := m[v.Name]
+	if !ok {
+		m[v.Name] = v
+		return
+	}
+	existing.Required = existing.Required || v.Required
+	if existing.DefaultValue == "" {
+		existing.DefaultValue = v.DefaultValue
+	}
+	if existing.PresenceValue == "" {
+		existing.PresenceValue = v.PresenceValue
+	}
+	m[v.Name] = existing
 }
 
 func extractVariable(value interface{}, pattern *regexp.Regexp) ([]Variable, bool) {

--- a/template/variables_test.go
+++ b/template/variables_test.go
@@ -182,6 +182,31 @@ func TestExtractVariables(t *testing.T) {
 			},
 		},
 		{
+			// a plain occurrence must not erase the required flag of another
+			// occurrence, whatever the (map) iteration order
+			// https://github.com/docker/compose/issues/13718
+			name: "required-and-plain-occurrences",
+			dict: map[string]interface{}{
+				"labels": []interface{}{
+					"rule=Host(`${PIHOLE_DOMAIN:?}`)",
+					"regex=^(https://${PIHOLE_DOMAIN})/",
+				},
+			},
+			expected: map[string]Variable{
+				"PIHOLE_DOMAIN": {Name: "PIHOLE_DOMAIN", Required: true},
+			},
+		},
+		{
+			name: "default-and-plain-occurrences",
+			dict: map[string]interface{}{
+				"a": "${SOME_VAR:-value}",
+				"b": "prefix-${SOME_VAR}",
+			},
+			expected: map[string]Variable{
+				"SOME_VAR": {Name: "SOME_VAR", DefaultValue: "value"},
+			},
+		},
+		{
 			name: "nested",
 			dict: map[string]interface{}{
 				"domainname": "${SUBDOMAIN:-$ROOTDOMAIN}",


### PR DESCRIPTION
`ExtractVariables` merged repeated occurrences of the same variable by plain overwrite: whichever occurrence happened to be processed last won, and map iteration made the outcome non-deterministic. A plain `${VAR}` occurrence could erase the `Required` flag extracted from a `${VAR:?}` one, so `docker compose config --variables` reported `Required: false` for a variable that interpolation actually requires (docker/compose#13718).

Merge occurrences instead:
- a variable is required as soon as one of its occurrences is — interpolation of that occurrence fails when the variable is unset, whatever the other occurrences declare;
- the first non-empty default/presence value is kept, so a plain occurrence doesn't erase them.

Verified end-to-end against docker/compose: `config --quiet` fails with "required variable PIHOLE_DOMAIN is missing a value" while `config --variables` used to report `Required: false`; with this change it reports `Required: true`.

Fixes docker/compose#13718
