### PR TITLE
fix(loader): guard versionWarning global against data races

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -26,9 +26,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/compose-spec/compose-go/v2/consts"
 	"github.com/compose-spec/compose-go/v2/errdefs"
@@ -40,6 +40,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/transform"
 	"github.com/compose-spec/compose-go/v2/tree"
 	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/compose-spec/compose-go/v2/utils"
 	"github.com/compose-spec/compose-go/v2/validation"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/sirupsen/logrus"
@@ -101,13 +102,19 @@ type Options struct {
 	MaxNodeVisits int
 }
 
-var versionWarning []string
+var (
+	versionWarning   = utils.NewSet[string]()
+	versionWarningMu sync.Mutex
+)
 
+// warnObsoleteVersion warns once per file for the process lifetime (kept global so repeated LoadProject calls, e.g. compose watch, don't re-warn).
 func (o *Options) warnObsoleteVersion(file string) {
-	if !slices.Contains(versionWarning, file) {
+	versionWarningMu.Lock()
+	defer versionWarningMu.Unlock()
+	if !versionWarning.Has(file) {
 		logrus.Warning(fmt.Sprintf("%s: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion", file))
+		versionWarning.Add(file)
 	}
-	versionWarning = append(versionWarning, file)
 }
 
 type Listener = func(event string, metadata map[string]any)

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -3218,4 +3219,29 @@ volumes:
 	assert.Assert(t, hasFrontNet, "network referenced by web should remain")
 	assert.Assert(t, !hasOrphanNet, "unreferenced network should be pruned")
 	assert.Assert(t, !hasOrphanVol, "unreferenced volume should be pruned")
+}
+
+// TestWarnObsoleteVersionConcurrentLoad guards against a data race on the
+// process-global versionWarning set when files with an obsolete `version`
+// attribute are loaded concurrently (regression test for #918).
+func TestWarnObsoleteVersionConcurrentLoad(t *testing.T) {
+	const numGoroutines = 50
+	const yaml = `
+version: "3.8"
+name: race
+services:
+  test:
+    image: nginx
+`
+
+	var wg sync.WaitGroup
+	for range numGoroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := loadYAML(yaml)
+			assert.NilError(t, err)
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
warnObsoleteVersion mutated a package-level slice without synchronization, so calling LoadWithContext/LoadProject concurrently on different files raced (compose-spec/compose-go#918).

Guard access with a mutex and switch the backing store to the existing utils.Set helper. Kept process-global on purpose: it must survive repeated LoadProject calls (ie: a `compose watch` process) without re-emitting the warning.

Fix #918 