### PR TITLE
fix(types): avoid data race in WithServicesTransform

### DIFF
--- a/types/project.go
+++ b/types/project.go
@@ -868,6 +868,7 @@ func (p *Project) WithServicesTransform(fn func(name string, s ServiceConfig) (S
 	expect := len(p.Services)
 	resultCh := make(chan result, expect)
 	newProject := p.deepCopy()
+	services := newProject.Services
 
 	eg, ctx := errgroup.WithContext(context.Background())
 	eg.Go(func() error {
@@ -885,7 +886,7 @@ func (p *Project) WithServicesTransform(fn func(name string, s ServiceConfig) (S
 		newProject.Services = s
 		return nil
 	})
-	for n, s := range newProject.Services {
+	for n, s := range services {
 		name := n
 		service := s
 		eg.Go(func() error {

--- a/types/project_test.go
+++ b/types/project_test.go
@@ -444,6 +444,14 @@ func TestWithServicesWithWildcard(t *testing.T) {
 	assert.DeepEqual(t, seen, []string{"service_1", "service_2", "service_3", "service_4", "service_5", "service_6"})
 }
 
+func TestWithServicesTransform_emptyServicesRace(t *testing.T) {
+	p := &Project{Services: Services{}}
+	_, err := p.WithServicesTransform(func(_ string, s ServiceConfig) (ServiceConfig, error) {
+		return s, nil
+	})
+	assert.NilError(t, err)
+}
+
 func TestServicesWithBuild(t *testing.T) {
 	p := makeProject()
 	assert.Equal(t, len(p.ServicesWithBuild()), 0)


### PR DESCRIPTION
The collector goroutine wrote newProject.Services once all results were in, while the caller concurrently ranged over that same field to spawn producer goroutines. With an empty Services map the collector returns immediately, racing directly against the range read (flagged by go test -race, first surfaced via docker/compose's -race suite on pkg/compose).

Snapshot the field into a local variable before starting the collector so the range loop never touches the mutable field.