### PR TITLE
introduce Project.WithoutUnresolvedOptionalDependencies

### DIFF
--- a/types/project.go
+++ b/types/project.go
@@ -551,6 +551,24 @@ func (p *Project) WithSelectedServices(names []string, options ...DependencyOpti
 	return newProject, nil
 }
 
+// WithoutUnresolvedOptionalDependencies removes from services any optional (required: false)
+// depends_on reference to a service absent from the model — typically disabled by an inactive
+// profile or dropped by service selection. Required references are deliberately kept, so
+// consumers can detect them and report a meaningful error.
+// It returns a new Project instance with the changes and keep the original Project unchanged
+func (p *Project) WithoutUnresolvedOptionalDependencies() *Project {
+	newProject := p.deepCopy()
+	for name, s := range newProject.Services {
+		for dep, cfg := range s.DependsOn {
+			if _, ok := newProject.Services[dep]; !ok && !cfg.Required {
+				delete(s.DependsOn, dep)
+			}
+		}
+		newProject.Services[name] = s
+	}
+	return newProject
+}
+
 // WithServicesDisabled removes from the project model the given services and their references in all dependencies
 // It returns a new Project instance with the changes and keep the original Project unchanged
 func (p *Project) WithServicesDisabled(names ...string) *Project {

--- a/types/project_test.go
+++ b/types/project_test.go
@@ -68,6 +68,39 @@ func Test_WithoutUnnecessaryResources(t *testing.T) {
 	}
 }
 
+func Test_WithoutUnresolvedOptionalDependencies(t *testing.T) {
+	p := &Project{
+		Services: Services{
+			"app": {
+				Name: "app",
+				DependsOn: DependsOnConfig{
+					"db":      {Required: true},
+					"debug":   {Required: false},
+					"missing": {Required: true},
+				},
+			},
+			"db": {Name: "db"},
+		},
+		DisabledServices: Services{
+			"debug": {Name: "debug", Profiles: []string{"debug"}},
+		},
+	}
+
+	derived := p.WithoutUnresolvedOptionalDependencies()
+
+	deps := derived.Services["app"].DependsOn
+	assert.Equal(t, len(deps), 2)
+	_, kept := deps["db"]
+	assert.Check(t, kept)
+	// a required reference to an absent service is kept so consumers can
+	// report a meaningful error
+	_, kept = deps["missing"]
+	assert.Check(t, kept)
+
+	// the original project is unchanged
+	assert.Equal(t, len(p.Services["app"].DependsOn), 3)
+}
+
 func Test_NoProfiles(t *testing.T) {
 	p := makeProject()
 	p, err := p.WithProfiles(nil)


### PR DESCRIPTION
Prunes optional (`required: false`) `depends_on` references to services absent from the model — disabled by an inactive profile or dropped by service selection. Required references are deliberately kept so consumers can detect them and report a meaningful error.

This cannot be folded into `WithProfiles`: `WithServicesEnabled` re-derives the enabled set by re-running `WithProfiles` over all services, and relies on dangling references surviving disablement so the dependency edge is restored when a profile is activated later. Hence an explicit final step, for consumers to apply once their selection is settled.

First consumer: docker/compose stops pruning these references as a `NewGraph` side effect that mutated the project (docker/compose#14081, Lot 0 step 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)