### PR TITLE
fix(types): reject unrecognized pull_policy values instead of defaulting

### DIFF
--- a/schema/compose-spec.json
+++ b/schema/compose-spec.json
@@ -713,7 +713,7 @@
         },
         "pull_policy": {
           "type": "string",
-          "pattern": "always|never|build|if_not_present|missing|refresh|daily|weekly|every_([0-9]+[wdhms])+",
+          "pattern": "^(always|never|build|if_not_present|missing|refresh|daily|weekly|every_([0-9]+[wdhms])+)$",
           "description": "Policy for pulling images. Options include: 'always', 'never', 'if_not_present', 'missing', 'build', or time-based refresh policies."
         },
         "pull_refresh_after": {

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -275,6 +275,28 @@ func TestValidateConcurrent(t *testing.T) {
 	wg.Wait()
 }
 
+func TestValidatePullPolicy(t *testing.T) {
+	newConfig := func(pullPolicy string) map[string]any {
+		return map[string]any{
+			"services": map[string]any{
+				"foo": map[string]any{
+					"image":       "busybox",
+					"pull_policy": pullPolicy,
+				},
+			},
+		}
+	}
+
+	for _, valid := range []string{"always", "never", "build", "if_not_present", "missing", "refresh", "daily", "weekly", "every_2d"} {
+		assert.NilError(t, Validate(newConfig(valid)), valid)
+	}
+
+	for _, invalid := range []string{"neverxxx", "xxdailyxx", "garbage-always-garbage", "hourly"} {
+		err := Validate(newConfig(invalid))
+		assert.ErrorContains(t, err, "pull_policy", invalid)
+	}
+}
+
 func TestSchema(t *testing.T) {
 	compiler := jsonschema.NewCompiler()
 	json, err := jsonschema.UnmarshalJSON(strings.NewReader(Schema))

--- a/types/types.go
+++ b/types/types.go
@@ -284,7 +284,9 @@ func (s ServiceConfig) GetDependents(p *Project) []string {
 
 func (s ServiceConfig) GetPullPolicy() (string, time.Duration, error) {
 	switch s.PullPolicy {
-	case PullPolicyAlways, PullPolicyNever, PullPolicyIfNotPresent, PullPolicyMissing, PullPolicyBuild:
+	case "":
+		return PullPolicyMissing, 0, nil
+	case PullPolicyAlways, PullPolicyNever, PullPolicyIfNotPresent, PullPolicyMissing, PullPolicyBuild, PullPolicyRefresh:
 		return s.PullPolicy, 0, nil
 	case "daily":
 		return PullPolicyRefresh, 24 * time.Hour, nil
@@ -299,7 +301,7 @@ func (s ServiceConfig) GetPullPolicy() (string, time.Duration, error) {
 			}
 			return PullPolicyRefresh, duration, nil
 		}
-		return PullPolicyMissing, 0, nil
+		return "", 0, fmt.Errorf("invalid pull_policy %q", s.PullPolicy)
 	}
 }
 

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -29,6 +29,26 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 )
 
+func TestGetPullPolicyRejectsInvalidValue(t *testing.T) {
+	s := ServiceConfig{PullPolicy: "neverxxx"}
+	_, _, err := s.GetPullPolicy()
+	assert.ErrorContains(t, err, `invalid pull_policy "neverxxx"`)
+}
+
+func TestGetPullPolicyDefaultsToMissingWhenUnset(t *testing.T) {
+	s := ServiceConfig{}
+	policy, _, err := s.GetPullPolicy()
+	assert.NilError(t, err)
+	assert.Equal(t, policy, PullPolicyMissing)
+}
+
+func TestGetPullPolicyAcceptsBareRefresh(t *testing.T) {
+	s := ServiceConfig{PullPolicy: PullPolicyRefresh}
+	policy, _, err := s.GetPullPolicy()
+	assert.NilError(t, err)
+	assert.Equal(t, policy, PullPolicyRefresh)
+}
+
 func TestParsePortConfig(t *testing.T) {
 	testCases := []struct {
 		value         string


### PR DESCRIPTION
An unanchored JSON Schema pattern let typo'd pull_policy values (e.g. "neverxxx") pass validation as substring matches, and GetPullPolicy() silently mapped any unrecognized value to PullPolicyMissing. A one-character typo could therefore silently invert "never" into a registry pull with no diagnostic.

Anchor the schema pattern with ^...$ and make GetPullPolicy() return an error for unrecognized values, while still defaulting silently when pull_policy is unset and accepting the bare "refresh" literal already allowed by the schema.

Fixes https://docker.atlassian.net/browse/DDB-665