### PR TITLE
fix(transform): honor ignoreParseError in ssh and ulimits parsers

### DIFF
--- a/transform/ssh.go
+++ b/transform/ssh.go
@@ -23,7 +23,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/tree"
 )
 
-func transformSSH(data any, p tree.Path, _ bool) (any, error) {
+func transformSSH(data any, p tree.Path, ignoreParseError bool) (any, error) {
 	switch v := data.(type) {
 	case map[string]any:
 		return v, nil
@@ -37,6 +37,9 @@ func transformSSH(data any, p tree.Path, _ bool) (any, error) {
 			id, path, ok := strings.Cut(s, "=")
 			if !ok {
 				if id != "default" {
+					if ignoreParseError {
+						return data, nil
+					}
 					return nil, fmt.Errorf("invalid ssh key %q", s)
 				}
 				result[id] = nil

--- a/transform/ulimits.go
+++ b/transform/ulimits.go
@@ -22,13 +22,18 @@ import (
 	"github.com/compose-spec/compose-go/v2/tree"
 )
 
-func transformUlimits(data any, p tree.Path, _ bool) (any, error) {
+func transformUlimits(data any, p tree.Path, ignoreParseError bool) (any, error) {
 	switch v := data.(type) {
 	case map[string]any:
 		return v, nil
 	case int:
 		return v, nil
+	case string:
+		if ignoreParseError {
+			return v, nil
+		}
+		return data, fmt.Errorf("%s: invalid type %T for ulimits", p, v)
 	default:
-		return data, fmt.Errorf("%s: invalid type %T for external", p, v)
+		return data, fmt.Errorf("%s: invalid type %T for ulimits", p, v)
 	}
 }

--- a/transform/ulimits_test.go
+++ b/transform/ulimits_test.go
@@ -24,19 +24,7 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestSSHConfig(t *testing.T) {
-	ssh, err := transformSSH([]any{
-		"default",
-		"foo=bar",
-	}, tree.NewPath("test"), false)
-	assert.NilError(t, err)
-	assert.DeepEqual(t, ssh, map[string]any{
-		"default": nil,
-		"foo":     "bar",
-	})
-}
-
-func Test_transformSSH_ignoreParseError(t *testing.T) {
+func Test_transformUlimits(t *testing.T) {
 	tests := []struct {
 		name             string
 		yaml             any
@@ -45,33 +33,43 @@ func Test_transformSSH_ignoreParseError(t *testing.T) {
 		wantErr          string
 	}{
 		{
-			name: "unresolved variable, error",
-			yaml: []any{
-				"${SSH_AUTH_SOCK}",
-			},
-			wantErr: `invalid ssh key "${SSH_AUTH_SOCK}"`,
+			name: "int",
+			yaml: 65535,
+			want: 65535,
 		},
 		{
-			name: "unresolved variable, ignored",
-			yaml: []any{
-				"${SSH_AUTH_SOCK}",
+			name: "long syntax",
+			yaml: map[string]any{
+				"soft": 20000,
+				"hard": 40000,
 			},
+			want: map[string]any{
+				"soft": 20000,
+				"hard": 40000,
+			},
+		},
+		{
+			name:    "unresolved variable, error",
+			yaml:    "${NOFILE}",
+			wantErr: `test: invalid type string for ulimits`,
+		},
+		{
+			name:             "unresolved variable, ignored",
+			yaml:             "${NOFILE}",
 			ignoreParseError: true,
-			want: []any{
-				"${SSH_AUTH_SOCK}",
-			},
+			want:             "${NOFILE}",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := transformSSH(tt.yaml, tree.NewPath("test"), tt.ignoreParseError)
+			got, err := transformUlimits(tt.yaml, tree.NewPath("test"), tt.ignoreParseError)
 			if tt.wantErr != "" {
 				assert.Error(t, err, tt.wantErr)
 				return
 			}
 			assert.NilError(t, err)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("transformSSH() got = %v, want %v", got, tt.want)
+				t.Errorf("transformUlimits() got = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
ignoreParseError was threaded into every transform.Canonical parser's signature to satisfy the shared transformFunc type, but only ports and volume mounts actually used it; ssh and ulimits kept a no-op `_ bool`.

A short-form value left unresolved on purpose (SkipInterpolation, e.g. docker compose publish's raw secret-scanning pass) crashed the loader outright instead of degrading gracefully like its siblings.

Also fixes a copy-pasted "for external" error message in ulimits.

Fixes a loader crash in `docker compose publish`'s raw secret-scanning pass (unresolved `${VAR}` in short-form `ssh`/`ulimits`), helping unblock docker/compose#13672